### PR TITLE
Fix dataset loading in training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ supported:
    ``edge_index`` array is stored separately.
 
 The script automatically detects which format is provided and loads the data
-accordingly.
+accordingly. When using the matrix format, supply the path to the shared
+``edge_index`` file via ``--edge-index-path`` (defaults to ``edge_index.npy``).
 
 Example usage:
 
 ```bash
 python scripts/train_gnn.py --x-path X_train.npy --y-path y_train.npy \
-    --epochs 100 --batch-size 16 --hidden-dim 32 --num-classes 2
+    --epochs 100 --batch-size 16 --hidden-dim 32 --num-classes 2 \
+    --edge-index-path edge_index.npy
 ```
 
 The trained model weights are saved to `model.pt` by default.


### PR DESCRIPTION
## Summary
- support matrix-format datasets by accepting an edge index path
- detect whether samples are dicts or matrices before loading
- document edge index usage in the README

## Testing
- `python -m py_compile scripts/train_gnn.py`
- ⚠️ `pip install torch==2.3.0 -q` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6842206edbf883249f015ccd197ed817