### PR TITLE
Fix pump control property usage

### DIFF
--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -199,10 +199,14 @@ def simulate_closed_loop(
         for i, pump in enumerate(pump_names):
             link = wn.get_link(pump)
             if controls[i].item() < 0.5:
-                link.status = 0
+                # ``link.status`` is read-only in wntr.  The user must update
+                # ``initial_status`` before each simulation step instead.
+                link.initial_status = wntr.network.base.LinkStatus.Closed
             else:
-                link.status = 1
-                link.speed = float(controls[i].item())
+                link.initial_status = wntr.network.base.LinkStatus.Open
+                # update pump speed via ``base_speed`` which controls the
+                # speed timeseries base multiplier
+                link.base_speed = float(controls[i].item())
         sim = wntr.sim.EpanetSimulator(wn)
         wn.options.time.duration = 3600
         wn.options.time.report_timestep = 3600


### PR DESCRIPTION
## Summary
- fix closed-loop simulation by setting `initial_status` instead of read-only `status`
- adjust pump speed via `base_speed`

## Testing
- `python -m py_compile scripts/mpc_control.py`
- `pip install torch_geometric -i https://data.pyg.org/whl/torch-2.7.1+cpu.html`
- `python scripts/mpc_control.py --horizon 1 --iterations 1` *(fails: models/gnn_surrogate.pth not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843305eb6648324a941a876b2927f16