### PR TITLE
Fix reservoir feature creation

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -54,11 +54,23 @@ def _prepare_features(
             demand = node.demand_timeseries_list[0].base_value
         else:
             demand = 0.0
+
         if name in wn.junction_name_list or name in wn.tank_name_list:
             elev = node.elevation
+        elif name in wn.reservoir_name_list:
+            # ``Reservoir`` objects store their hydraulic head in ``base_head``
+            # and expose ``head`` as ``None`` which previously caused a
+            # ``TypeError`` when converting features to a tensor.
+            elev = node.base_head
         else:
             elev = node.head
-        feats.append([demand, pressures.get(name, 0.0), chlorine.get(name, 0.0), elev])
+
+        if elev is None:
+            elev = 0.0
+
+        feats.append(
+            [demand, pressures.get(name, 0.0), chlorine.get(name, 0.0), elev]
+        )
     return torch.tensor(feats, dtype=torch.float32)
 
 


### PR DESCRIPTION
## Summary
- prevent `None` elevation values when preparing features

## Testing
- `python3 - <<'EOF'
import sys,os
sys.path.append('scripts')
from experiments_validation import _prepare_features
import wntr
wn=wntr.network.WaterNetworkModel('CTown.inp')
res=wntr.sim.EpanetSimulator(wn).run_sim()
press=res.node['pressure'].iloc[0].to_dict()
chlor=res.node['quality'].iloc[0].to_dict()
x=_prepare_features(wn, press, chlor)
print('done', x.shape, x.dtype, x[0])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684342b59758832492b43eba9c858b0f