### PR TITLE
Fix data path in scripts

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -1,6 +1,7 @@
 import random
 import pickle
 import os
+from pathlib import Path
 from typing import List, Tuple
 
 import numpy as np
@@ -128,7 +129,11 @@ def build_edge_index(wn: wntr.network.WaterNetworkModel) -> np.ndarray:
     return edge_index
 
 
-DATA_DIR = "data"
+# Use a fixed data directory inside the repository so generated files are
+# written in a predictable location regardless of where the script is launched
+# from.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = REPO_ROOT / "data"
 
 
 def main() -> None:

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import os
 import pickle
+from pathlib import Path
 from typing import Dict, List
 
 import matplotlib.pyplot as plt
@@ -17,7 +18,11 @@ import pandas as pd
 import torch
 import wntr
 
-DATA_DIR = "data"
+# Compute absolute path to the repository's data directory so that results are
+# always written inside the project regardless of the current working
+# directory.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = REPO_ROOT / "data"
 
 from mpc_control import (
     load_network,

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -2,6 +2,7 @@ import argparse
 import time
 from typing import Dict, List
 import os
+from pathlib import Path
 
 
 import numpy as np
@@ -11,7 +12,11 @@ from torch_geometric.nn import GCNConv
 import wntr
 
 
-DATA_DIR = "data"
+# Resolve the repository root so files are written relative to the project
+# instead of the current working directory.  This avoids permission errors
+# when the script is executed from another location.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = REPO_ROOT / "data"
 
 
 class GNNSurrogate(torch.nn.Module):

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -79,8 +80,11 @@ def train(model, loader, optimizer, device):
         total_loss += loss.item() * batch.num_graphs
     return total_loss / len(loader.dataset)
 
-DATA_DIR = "data"
-MODELS_DIR = "models"
+# Resolve important directories relative to the repository root so that training
+# can be launched from any location.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = REPO_ROOT / "data"
+MODELS_DIR = REPO_ROOT / "models"
 
 
 def main(args: argparse.Namespace):


### PR DESCRIPTION
## Summary
- handle data directory using absolute path in all scripts

## Testing
- `python -m py_compile scripts/*.py`
- `python scripts/experiments_validation.py --horizon 1 --iterations 1` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684362c9f21483248410898eb7da850a