### PR TITLE
Add pump controls as node features for MPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ A GNN, MPC-gradient based, optimizer for EPANET water systems
 
 The repository provides a simple training script `scripts/train_gnn.py` which
 expects feature and label data saved in the `data/` directory as NumPy arrays.
-Two dataset formats are
+Each node feature vector has the layout
+``[base_demand, pressure, chlorine, elevation, pump_1, ..., pump_N]`` where the
+additional elements represent the speeds of all pumps in the network.  The
+helper script `scripts/data_generation.py` generates these arrays as well as the
+graph ``edge_index``.  Two dataset formats are
 supported:
 
 1. **Dictionary format** – each entry of ``X`` is a dictionary containing the
@@ -30,5 +34,17 @@ python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy 
 ```
 
 The trained model weights are saved to `models/gnn_surrogate.pth` by default.
+
+## Running MPC control
+
+Once the surrogate model is trained you can run gradient-based MPC using
+`scripts/mpc_control.py`:
+
+```bash
+python scripts/mpc_control.py --horizon 6 --iterations 50
+```
+
+This executes a 24‑hour closed loop simulation where pump actions are
+optimized at each hour.  Results are written to `data/mpc_history.csv`.
 
 I'll complete the README Later

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -78,8 +78,11 @@ def build_dataset(
         quality_array = quality.values
         times = pressures.index
 
+        pump_status = sim_results.link["status"][wn_template.pump_name_list].values
+
         for i in range(len(times) - 1):
             feat_nodes = []
+            controls = pump_status[i]
             for node in wn_template.node_name_list:
                 idx = pressures.columns.get_loc(node)
                 p_t = pressure_array[i, idx]
@@ -97,7 +100,9 @@ def build_dataset(
                 else:
                     elev = wn_template.get_node(node).head
 
-                feat_nodes.append([base_d, p_t, c_t, elev])
+                feat = [base_d, p_t, c_t, elev]
+                feat.extend(controls.tolist())
+                feat_nodes.append(feat)
             X_sample = np.array(feat_nodes, dtype=np.float64)
             X_list.append(X_sample)
 


### PR DESCRIPTION
## Summary
- augment dataset generation to include pump status per pump in every node feature
- propagate feature dimension through MPC and evaluation utilities
- load GNN input dimension from saved state
- document the new feature layout and MPC usage

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68436fba3f7883249ca6ea45a8bd0438