### PR TITLE
Fix pump status handling for latest WNTR

### DIFF
--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -240,9 +240,9 @@ def simulate_closed_loop(
         for i, pump in enumerate(pump_names):
             link = wn.get_link(pump)
             if controls[i].item() < 0.5:
-                link.status = wntr.network.base.LinkStatus.Closed
+                link.initial_status = wntr.network.base.LinkStatus.Closed
             else:
-                link.status = wntr.network.base.LinkStatus.Open
+                link.initial_status = wntr.network.base.LinkStatus.Open
                 link.base_speed = float(controls[i].item())
 
         # update demands based on patterns and random variation


### PR DESCRIPTION
## Summary
- update pump setting to use `initial_status`

## Testing
- `python -m py_compile scripts/mpc_control.py`
- `python scripts/mpc_control.py --horizon 1 --iterations 1` *(fails: `gnn_surrogate.pth not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68438f7310f8832498dddde5c92ce2a5