### PR TITLE
Fix min-pressure/cl2 calculations and add chlorine source

### DIFF
--- a/CTown.inp
+++ b/CTown.inp
@@ -1167,9 +1167,11 @@ LINK          PU11 CLOSED IF              NODE          T7            ABOVE     
 
 [QUALITY]
 ;Node            	InitQual
+R1 1.0
 
 [SOURCES]
 ;Node            	Type        	Quality     	Pattern
+R1 SETPOINT 1.0
 
 [REACTIONS]
 ;Type     	Pipe/Tank       	Coefficient

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -281,8 +281,12 @@ def simulate_closed_loop(
         flows = results.link["flowrate"].iloc[-1]
         headloss = results.link["headloss"].iloc[-1]
         energy = float(sum(9.81 * abs(headloss[p]) * flows[p] for p in pump_names))
-        min_p = min(pressures.values())
-        min_c = min(chlorine.values())
+        min_p = min(
+            pressures[n] for n in wn.junction_name_list + wn.tank_name_list
+        )
+        min_c = min(
+            chlorine[n] for n in wn.junction_name_list + wn.tank_name_list
+        )
         log.append(
             {
                 "time": hour,


### PR DESCRIPTION
## Summary
- compute min pressure and chlorine values ignoring reservoir nodes
- add initial chlorine concentration and source at R1 in the EPANET input
- regenerate data, retrain the GNN, and run a short MPC demo

## Testing
- `python scripts/data_generation.py > /tmp/data_generation.log`
- `python scripts/train_gnn.py --epochs 1 > /tmp/train.log`
- `python scripts/mpc_control.py --horizon 6 --iterations 5 --Pmin 20 --Cmin 0.2 > /tmp/mpc.log && tail -n 5 /tmp/mpc.log`

------
https://chatgpt.com/codex/tasks/task_e_6844c1356e9c8324a4fe62abcf2ce6f7