### PR TITLE
Improve MPC speed with GNN surrogate

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -1,6 +1,7 @@
 import random
 import pickle
 import os
+import argparse
 from pathlib import Path
 from typing import List, Tuple
 
@@ -142,8 +143,17 @@ DATA_DIR = REPO_ROOT / "data"
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-scenarios", type=int, default=10, help="Number of random scenarios to simulate")
+    parser.add_argument(
+        "--output-dir",
+        default=DATA_DIR,
+        help="Directory to store generated datasets",
+    )
+    args = parser.parse_args()
+
     inp_file = "CTown.inp"
-    N = 10
+    N = args.num_scenarios
 
     results = run_scenarios(inp_file, N)
     train_res, val_res, test_res = split_results(results)
@@ -155,21 +165,22 @@ def main() -> None:
 
     edge_index = build_edge_index(wn_template)
 
-    os.makedirs(DATA_DIR, exist_ok=True)
+    out_dir = Path(args.output_dir)
+    os.makedirs(out_dir, exist_ok=True)
 
-    np.save(os.path.join(DATA_DIR, "X_train.npy"), X_train)
-    np.save(os.path.join(DATA_DIR, "Y_train.npy"), Y_train)
-    np.save(os.path.join(DATA_DIR, "X_val.npy"), X_val)
-    np.save(os.path.join(DATA_DIR, "Y_val.npy"), Y_val)
-    np.save(os.path.join(DATA_DIR, "X_test.npy"), X_test)
-    np.save(os.path.join(DATA_DIR, "Y_test.npy"), Y_test)
-    np.save(os.path.join(DATA_DIR, "edge_index.npy"), edge_index)
+    np.save(os.path.join(out_dir, "X_train.npy"), X_train)
+    np.save(os.path.join(out_dir, "Y_train.npy"), Y_train)
+    np.save(os.path.join(out_dir, "X_val.npy"), X_val)
+    np.save(os.path.join(out_dir, "Y_val.npy"), Y_val)
+    np.save(os.path.join(out_dir, "X_test.npy"), X_test)
+    np.save(os.path.join(out_dir, "Y_test.npy"), Y_test)
+    np.save(os.path.join(out_dir, "edge_index.npy"), edge_index)
 
-    with open(os.path.join(DATA_DIR, "train_results_list.pkl"), "wb") as f:
+    with open(os.path.join(out_dir, "train_results_list.pkl"), "wb") as f:
         pickle.dump(train_res, f)
-    with open(os.path.join(DATA_DIR, "val_results_list.pkl"), "wb") as f:
+    with open(os.path.join(out_dir, "val_results_list.pkl"), "wb") as f:
         pickle.dump(val_res, f)
-    with open(os.path.join(DATA_DIR, "test_results_list.pkl"), "wb") as f:
+    with open(os.path.join(out_dir, "test_results_list.pkl"), "wb") as f:
         pickle.dump(test_res, f)
 
 

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -242,6 +242,14 @@ def main() -> None:
     )
     parser.add_argument("--horizon", type=int, default=6, help="MPC horizon")
     parser.add_argument("--iterations", type=int, default=50, help="GD iterations")
+    parser.add_argument("--Pmin", type=float, default=20.0, help="Pressure threshold")
+    parser.add_argument("--Cmin", type=float, default=0.2, help="Chlorine threshold")
+    parser.add_argument(
+        "--feedback-interval",
+        type=int,
+        default=24,
+        help="Hours between EPANET synchronizations",
+    )
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -269,6 +277,9 @@ def main() -> None:
         node_to_index,
         pump_names,
         device,
+        args.Pmin,
+        args.Cmin,
+        args.feedback_interval,
     )
 
     heur_df = run_heuristic_baseline(


### PR DESCRIPTION
## Summary
- generate larger training sets with CLI arguments
- remove heavy EPANET loop from MPC
- allow periodic EPANET synchronization
- run MPC on CUDA device
- document high-volume training and new MPC options

## Testing
- `python -m py_compile scripts/mpc_control.py scripts/data_generation.py scripts/experiments_validation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c5d4845883249dfcfacdb8725a6f