### PR TITLE
Fix baseline pump control and improve validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ python scripts/data_generation.py --num-scenarios 2000 --output-dir data/
 ```
 
 Validate the resulting model with `scripts/experiments_validation.py` before
-running the MPC controller.
+running the MPC controller.  The validation script executes a 24‑hour
+simulation with EPANET feedback applied every hour (``--feedback-interval`` is
+``1`` by default) which keeps predictions from the surrogate model from
+diverging over long horizons.
 
 ## Running MPC control
 

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -133,8 +133,8 @@ def run_all_pumps_on(
     for hour in range(24):
         for pn in pump_names:
             link = wn.get_link(pn)
-            link.status = 1
-            link.speed = 1.0
+            link.initial_status = wntr.network.base.LinkStatus.Open
+            link.base_speed = 1.0
         sim = wntr.sim.EpanetSimulator(wn)
         wn.options.time.duration = 3600
         wn.options.time.report_timestep = 3600
@@ -173,13 +173,13 @@ def run_heuristic_baseline(
 
     for hour in range(24):
         if min(pressures.values()) < threshold_p or min(chlorine.values()) < threshold_c:
-            status = 1
+            status = wntr.network.base.LinkStatus.Open
         else:
-            status = 0
+            status = wntr.network.base.LinkStatus.Closed
         for pn in pump_names:
             link = wn.get_link(pn)
-            link.status = status
-            link.speed = 1.0
+            link.initial_status = status
+            link.base_speed = 1.0
         sim = wntr.sim.EpanetSimulator(wn)
         wn.options.time.duration = 3600
         wn.options.time.report_timestep = 3600
@@ -248,7 +248,7 @@ def main() -> None:
     parser.add_argument(
         "--feedback-interval",
         type=int,
-        default=24,
+        default=1,
         help="Hours between EPANET synchronizations",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- ensure heuristic baseline sets pump initial status correctly
- use Open/Closed enum for all-on pump baseline
- default experiments_validation to hourly EPANET feedback to avoid divergence
- document the new behaviour in README

## Testing
- `python scripts/experiments_validation.py --help` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*
- `python pytorchcheck.py` *(fails: ModuleNotFoundError: No module named 'torch_geometric')*


------
https://chatgpt.com/codex/tasks/task_e_684509d93398832492e108a7ae4e347c