### PR TITLE
Improve experiments_validation and energy computation

### DIFF
--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -324,8 +324,8 @@ def simulate_closed_loop(
             results = sim.run_sim()
             pressures = results.node["pressure"].iloc[-1].to_dict()
             chlorine = results.node["quality"].iloc[-1].to_dict()
+            energy = results.link["energy"][pump_names].iloc[-1].sum()
             end = time.time()
-            energy = float('nan')
         else:
             # Fast surrogate-based propagation
             pressures, chlorine = propagate_with_surrogate(


### PR DESCRIPTION
## Summary
- fix time handling and energy tracking in baseline simulations
- compute energy when MPC synchronizes with EPANET
- store surrogate validation metrics to CSV

## Testing
- `python -m py_compile scripts/experiments_validation.py scripts/mpc_control.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a4a58af08324afbd856d1eb9236b