### PR TITLE
Fix energy computation and add tests

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -18,6 +18,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import torch
 import wntr
+from wntr.metrics.economic import pump_energy
 
 # Compute absolute path to the repository's data directory so that results are
 # always written inside the project regardless of the current working
@@ -142,12 +143,15 @@ def run_all_pumps_on(
         results = sim.run_sim()
         pressures = results.node["pressure"].iloc[-1].to_dict()
         chlorine = results.node["quality"].iloc[-1].to_dict()
-        energy = results.link["energy"][pump_names].iloc[-1].sum()
+        energy_df = pump_energy(
+            results.link["flowrate"][pump_names], results.node["head"], wn
+        )
+        energy = energy_df[pump_names].iloc[-1].sum()
         log.append(
             {
                 "time": hour,
-                "min_pressure": min(pressures.values()),
-                "min_chlorine": min(chlorine.values()),
+                "min_pressure": max(min(pressures.values()), 0.0),
+                "min_chlorine": max(min(chlorine.values()), 0.0),
                 "energy": float(energy),
             }
         )
@@ -190,12 +194,15 @@ def run_heuristic_baseline(
         results = sim.run_sim()
         pressures = results.node["pressure"].iloc[-1].to_dict()
         chlorine = results.node["quality"].iloc[-1].to_dict()
-        energy = results.link["energy"][pump_names].iloc[-1].sum()
+        energy_df = pump_energy(
+            results.link["flowrate"][pump_names], results.node["head"], wn
+        )
+        energy = energy_df[pump_names].iloc[-1].sum()
         log.append(
             {
                 "time": hour,
-                "min_pressure": min(pressures.values()),
-                "min_chlorine": min(chlorine.values()),
+                "min_pressure": max(min(pressures.values()), 0.0),
+                "min_chlorine": max(min(chlorine.values()), 0.0),
                 "energy": float(energy),
             }
         )

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,0 +1,7 @@
+def test_min_clip():
+    pressures = {'A': -1e-6, 'B': 10.0}
+    chlorine = {'A': -0.5, 'B': 0.3}
+    min_p = max(min(pressures.values()), 0.0)
+    min_c = max(min(chlorine.values()), 0.0)
+    assert min_p >= 0
+    assert min_c >= 0

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,0 +1,13 @@
+import wntr
+from wntr.metrics.economic import pump_energy
+
+
+def test_pump_energy_not_nan():
+    wn = wntr.network.WaterNetworkModel('CTown.inp')
+    wn.options.time.hydraulic_timestep = 3600
+    wn.options.time.duration = 3600
+    wn.options.time.report_timestep = 3600
+    sim = wntr.sim.EpanetSimulator(wn)
+    results = sim.run_sim()
+    energy_df = pump_energy(results.link['flowrate'][wn.pump_name_list], results.node['head'], wn)
+    assert not energy_df[wn.pump_name_list].isna().any().any(), 'energy contains NaN'


### PR DESCRIPTION
## Summary
- compute pump energy using `wntr.metrics.economic.pump_energy`
- clip negative pressure and chlorine values to zero
- apply same energy computation in experiment baselines
- add minimal unit tests for energy computation and clipping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b2c860608324aedabc598ae21bac