### PR TITLE
Fix Python 3.9 compatibility for data_generation

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -3,7 +3,7 @@ import pickle
 import os
 import argparse
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Tuple, Optional
 
 import numpy as np
 import wntr
@@ -12,7 +12,7 @@ from wntr.metrics.economic import pump_energy
 
 
 def run_scenarios(
-    inp_file: str, num_scenarios: int, seed: int | None = None
+    inp_file: str, num_scenarios: int, seed: Optional[int] = None
 ) -> List[Tuple[wntr.sim.results.SimulationResults, Dict[str, float]]]:
     """Run a collection of randomized scenarios and return each result along
     with the demand scaling applied to every junction."""


### PR DESCRIPTION
## Summary
- remove Python 3.10 style union typing in `data_generation.py`
- tests run successfully with `pytest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e2d7cb9c83249cedef2a30ace931