### PR TITLE
Fix NaN prediction from corrupted surrogate

### DIFF
--- a/tests/test_load_surrogate.py
+++ b/tests/test_load_surrogate.py
@@ -1,0 +1,34 @@
+import torch
+import pytest
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.mpc_control import load_surrogate_model
+
+
+def test_load_surrogate_renames_old_keys(tmp_path):
+    state = {
+        'conv1.bias': torch.zeros(4),
+        'conv1.lin.weight': torch.zeros(4, 2),
+        'conv2.bias': torch.zeros(2),
+        'conv2.lin.weight': torch.zeros(2, 4)
+    }
+    path = tmp_path / 'model_old.pth'
+    torch.save(state, path)
+    model = load_surrogate_model(torch.device('cpu'), path=str(path))
+    assert model.conv1.out_channels == 4
+    assert model.conv2.out_channels == 2
+
+
+def test_load_surrogate_detects_nan(tmp_path):
+    state = {
+        'layers.0.weight': torch.full((3, 2), float('nan')),
+        'layers.0.bias': torch.zeros(3),
+        'layers.1.weight': torch.zeros(1, 3),
+        'layers.1.bias': torch.zeros(1)
+    }
+    path = tmp_path / 'model_nan.pth'
+    torch.save(state, path)
+    with pytest.raises(ValueError):
+        load_surrogate_model(torch.device('cpu'), path=str(path))


### PR DESCRIPTION
## Summary
- make `load_surrogate_model` robust against old checkpoints with `conv1/conv2` keys
- reject checkpoints that contain NaN parameters
- add regression tests for surrogate loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460324a4b88324a89f8d7f712a60ff