### PR TITLE
Fix NaN predictions from reservoir nodes in MPC

### DIFF
--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -181,8 +181,16 @@ def prepare_node_features(
             demand = 0.0
         if name in wn.junction_name_list or name in wn.tank_name_list:
             elev = node.elevation
+        elif name in wn.reservoir_name_list:
+            # ``Reservoir`` objects store their head in ``base_head`` and expose
+            # ``head`` as ``None``.  Using ``head`` directly would introduce
+            # ``NaN`` values into the feature tensor which in turn leads to
+            # NaN predictions during MPC optimisation.
+            elev = node.base_head
         else:
             elev = node.head
+        if elev is None:
+            elev = 0.0
         base = [demand, pressures.get(name, 0.0), chlorine.get(name, 0.0), elev]
         base.extend(pump_controls.tolist())
         feats[idx] = np.array(base, dtype=np.float32)


### PR DESCRIPTION
## Summary
- avoid NaN elevations for reservoirs when building MPC features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461f728648832499ee05300830995a