### PR TITLE
Fix MPC NaNs from reservoir nodes

### DIFF
--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -181,8 +181,16 @@ def prepare_node_features(
             demand = 0.0
         if name in wn.junction_name_list or name in wn.tank_name_list:
             elev = node.elevation
+        elif name in wn.reservoir_name_list:
+            # ``Reservoir`` objects expose ``head`` as ``None`` and store the
+            # hydraulic head in ``base_head``. Using ``head`` directly would
+            # produce ``NaN`` feature values which later lead to ``NaN``
+            # predictions during MPC optimisation.
+            elev = node.base_head
         else:
             elev = node.head
+        if elev is None:
+            elev = 0.0
         base = [demand, pressures.get(name, 0.0), chlorine.get(name, 0.0), elev]
         base.extend(pump_controls.tolist())
         feats[idx] = np.array(base, dtype=np.float32)


### PR DESCRIPTION
## Summary
- handle `Reservoir` nodes in `prepare_node_features`
- avoid NaNs in MPC inputs by using `base_head`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462d9fb8348324a85e5846858e3372