### PR TITLE
Fix surrogate loader to use most recent model

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Once the surrogate model is trained you can run gradient-based MPC using
 python scripts/mpc_control.py --horizon 6 --iterations 50 --feedback-interval 24
 ```
 
+By default the controller loads the most recent ``.pth`` file found in the
+``models`` directory so retraining will automatically use the newest weights.
+
 This executes a 24‑hour closed loop simulation where pump actions are optimized
 at each hour.  EPANET is only called every 24 hours (controlled by
 ``--feedback-interval``) and all intermediate updates rely on the GNN surrogate

--- a/tests/test_load_surrogate.py
+++ b/tests/test_load_surrogate.py
@@ -1,5 +1,6 @@
 import torch
 import pytest
+import os
 from pathlib import Path
 import sys
 
@@ -32,3 +33,32 @@ def test_load_surrogate_detects_nan(tmp_path):
     torch.save(state, path)
     with pytest.raises(ValueError):
         load_surrogate_model(torch.device('cpu'), path=str(path))
+
+
+def test_load_surrogate_selects_latest(tmp_path, monkeypatch):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+
+    older = {
+        'conv1.lin.weight': torch.zeros(1, 1),
+        'conv1.bias': torch.zeros(1),
+        'conv2.lin.weight': torch.zeros(1, 1),
+        'conv2.bias': torch.zeros(1)
+    }
+    newer = {
+        'conv1.lin.weight': torch.zeros(2, 2),
+        'conv1.bias': torch.zeros(2),
+        'conv2.lin.weight': torch.zeros(1, 2),
+        'conv2.bias': torch.zeros(1)
+    }
+    old_path = models_dir / 'old.pth'
+    new_path = models_dir / 'new.pth'
+    torch.save(older, old_path)
+    torch.save(newer, new_path)
+    os.utime(old_path, (os.path.getmtime(old_path) - 10, os.path.getmtime(old_path) - 10))
+
+    # Ensure function searches within our temporary repository
+    monkeypatch.setattr('scripts.mpc_control.REPO_ROOT', tmp_path)
+
+    model = load_surrogate_model(torch.device('cpu'))
+    assert model.conv1.out_channels == 2


### PR DESCRIPTION
## Summary
- improve `load_surrogate_model` to automatically find the newest checkpoint
- test the new behaviour
- document that `mpc_control.py` loads the latest model by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68463861f84c8324beedabfbf44362bf