### PR TITLE
Fix multiprocessing file collisions in data generation

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -57,7 +57,13 @@ def _run_single_scenario(args) -> Tuple[wntr.sim.results.SimulationResults, Dict
         pump_controls[pn] = 0.0
 
     sim = wntr.sim.EpanetSimulator(wn)
-    sim_results = sim.run_sim()
+    prefix = TEMP_DIR / f"temp_{os.getpid()}_{idx}"
+    sim_results = sim.run_sim(file_prefix=str(prefix))
+
+    for ext in [".inp", ".rpt", ".bin", ".hyd", ".msx", ".msx-rpt", ".msx-bin", ".check.msx"]:
+        f = f"{prefix}{ext}"
+        if os.path.exists(f):
+            os.remove(f)
 
     flows = sim_results.link["flowrate"]
     heads = sim_results.node["head"]


### PR DESCRIPTION
## Summary
- avoid EPANET temp file conflicts when data generation runs in parallel
- clean up temporary files after each scenario

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 2 --output-dir data/ --seed 0 --n-jobs 2`

------
https://chatgpt.com/codex/tasks/task_e_68470576ac388324877d78324aba7e21