### PR TITLE
Ensure pumps active every hour during data generation

### DIFF
--- a/tests/test_pump_controls.py
+++ b/tests/test_pump_controls.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.data_generation import _run_single_scenario
+
+
+def test_at_least_one_pump_active_per_hour():
+    inp = Path(__file__).resolve().parents[1] / 'CTown.inp'
+    res, scale, controls = _run_single_scenario((0, str(inp), 42))
+    hours = len(next(iter(controls.values())))
+    for h in range(hours):
+        assert any(controls[p][h] > 0 for p in controls)
+


### PR DESCRIPTION
## Summary
- keep at least one pump active per hour when generating scenarios
- add regression test verifying pump schedules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847788e974483249554464fbfb4b94a