### PR TITLE
Add recurrent sequence modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ looks like:
 python scripts/data_generation.py --num-scenarios 2000 --output-dir data/ --seed 42
 ```
 
+To create sequence datasets for the recurrent surrogate specify ``--sequence-length``:
+
+```bash
+python scripts/data_generation.py --num-scenarios 200 --sequence-length 24 --output-dir data/
+```
+
+The training script automatically detects such sequence files and will use the recurrent
+model. Adjust the recurrent hidden size via ``--rnn-hidden-dim`` if desired.
+
 Validate the resulting model with `scripts/experiments_validation.py` before
 running the MPC controller.  The validation script executes a 24‑hour
 simulation with EPANET feedback applied every hour (``--feedback-interval`` is

--- a/tests/test_recurrent_forward.py
+++ b/tests/test_recurrent_forward.py
@@ -1,0 +1,21 @@
+import torch
+from scripts.train_gnn import RecurrentGNNSurrogate
+
+def test_recurrent_gnn_forward_shape():
+    edge_index = torch.tensor([[0,1],[1,0]], dtype=torch.long)
+    edge_attr = torch.ones(2,3)
+    model = RecurrentGNNSurrogate(
+        in_channels=2,
+        hidden_channels=4,
+        edge_dim=3,
+        output_dim=1,
+        num_layers=2,
+        use_attention=False,
+        gat_heads=1,
+        dropout=0.0,
+        residual=False,
+        rnn_hidden_dim=5,
+    )
+    X_seq = torch.ones(1, 3, 2, 2)
+    out = model(X_seq, edge_index, edge_attr)
+    assert out.shape == (1, 3, 2, 1)


### PR DESCRIPTION
## Summary
- allow data generation of multi-step sequences
- integrate LSTM-based RecurrentGNNSurrogate
- update training loop to handle sequence data
- document new workflow in README
- add unit test for the new recurrent model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a94115a083248ebd166b06e0d3f2