### PR TITLE
Enhance data generation with extreme events

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,17 @@ looks like:
 python scripts/data_generation.py --num-scenarios 2000 --output-dir data/ --seed 42
 ```
 
+Set ``--extreme-event-prob`` to inject rare scenarios such as fire flows,
+pump failures or source quality changes.  Scenario labels are stored alongside
+the sequence arrays when ``--sequence-length`` is greater than one.
+
 To create sequence datasets for the recurrent surrogate specify ``--sequence-length``:
 
 ```bash
 python scripts/data_generation.py --num-scenarios 200 --sequence-length 24 --output-dir data/
 ```
+This will also generate ``scenario_train.npy`` etc. recording the type of each
+scenario.
 
 The training script automatically detects such sequence files and will use the recurrent
 model. Adjust the recurrent hidden size via ``--rnn-hidden-dim`` if desired.

--- a/tests/test_extreme_events.py
+++ b/tests/test_extreme_events.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.data_generation import _run_single_scenario
+
+
+def test_extreme_event_label():
+    inp = Path(__file__).resolve().parents[1] / 'CTown.inp'
+    res, _, _ = _run_single_scenario((0, str(inp), 123), extreme_event_prob=1.0)
+    assert hasattr(res, 'scenario_type')
+    assert res.scenario_type in {'fire_flow', 'pump_failure', 'quality_variation'}


### PR DESCRIPTION
## Summary
- expand `data_generation.py` with fire flow, pump failure and quality variation events
- inject extreme events with `--extreme-event-prob` option and log scenario labels
- clip demands and chlorine to realistic ranges
- save scenario labels for sequence datasets
- document new option in README
- test extreme scenario labeling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b5dcff308324bd2889ee6bda6e0c