### PR TITLE
Implement multi-task GNN surrogate

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ loading the EPANET network (``--inp-path``).  If the dimension does not match
 ``4 + num_pumps`` an error is raised. Use ``--output-dim`` to specify how many
 continuous targets are predicted per node.
 
+When datasets were generated with ``scripts/data_generation.py`` after this
+update, each time step also stores pipe flow rates and pump energy
+consumption. ``train_gnn.py`` automatically detects such multi-task arrays and
+switches to a ``MultiTaskGNNSurrogate`` model which optimizes a weighted loss
+over all targets.
+
 Example usage:
 
 ```bash

--- a/tests/test_recurrent_forward.py
+++ b/tests/test_recurrent_forward.py
@@ -1,5 +1,5 @@
 import torch
-from scripts.train_gnn import RecurrentGNNSurrogate
+from scripts.train_gnn import RecurrentGNNSurrogate, MultiTaskGNNSurrogate
 
 def test_recurrent_gnn_forward_shape():
     edge_index = torch.tensor([[0,1],[1,0]], dtype=torch.long)
@@ -19,3 +19,27 @@ def test_recurrent_gnn_forward_shape():
     X_seq = torch.ones(1, 3, 2, 2)
     out = model(X_seq, edge_index, edge_attr)
     assert out.shape == (1, 3, 2, 1)
+
+
+def test_multitask_gnn_forward_shapes():
+    edge_index = torch.tensor([[0,1],[1,0]], dtype=torch.long)
+    edge_attr = torch.ones(2,3)
+    model = MultiTaskGNNSurrogate(
+        in_channels=2,
+        hidden_channels=4,
+        edge_dim=3,
+        node_output_dim=2,
+        edge_output_dim=1,
+        energy_output_dim=1,
+        num_layers=2,
+        use_attention=False,
+        gat_heads=1,
+        dropout=0.0,
+        residual=False,
+        rnn_hidden_dim=5,
+    )
+    X_seq = torch.ones(1, 3, 2, 2)
+    out = model(X_seq, edge_index, edge_attr)
+    assert out['node_outputs'].shape == (1, 3, 2, 2)
+    assert out['edge_outputs'].shape == (1, 3, 2, 1)
+    assert out['pump_energy'].shape == (1, 3, 1)


### PR DESCRIPTION
## Summary
- expand `data_generation.py` to record pipe flows and pump energy
- introduce `MultiTaskGNNSurrogate` with separate decoders for node, edge and energy predictions
- support multi-task datasets and normalization in `train_gnn.py`
- update README with multi-task description
- test forward shapes for the new surrogate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ba42c05883249c1b0942953119f1