### PR TITLE
Fix import paths and validation

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -22,6 +22,8 @@ class HydroConv(MessagePassing):
 
     def __init__(self, in_channels: int, out_channels: int, edge_dim: int):
         super().__init__(aggr="add")
+        self.in_channels = in_channels
+        self.out_channels = out_channels
         self.lin = nn.Linear(in_channels, out_channels)
         self.edge_mlp = nn.Sequential(
             nn.Linear(edge_dim, 1),

--- a/tests/test_validate_surrogate.py
+++ b/tests/test_validate_surrogate.py
@@ -21,7 +21,7 @@ class DummyModel(torch.nn.Module):
         self.y_mean = None
         self.y_std = torch.ones(1)
 
-    def forward(self, x, edge_index):
+    def forward(self, x, edge_index, edge_attr=None):
         return torch.zeros(x.size(0), self.out_dim, device=x.device)
 
 def test_validate_surrogate_accepts_tuple():
@@ -34,4 +34,4 @@ def test_validate_surrogate_accepts_tuple():
     sim = wntr.sim.EpanetSimulator(wn)
     res = sim.run_sim(str(TEMP_DIR / "temp"))
     model = DummyModel().to(device)
-    validate_surrogate(model, edge_index, wn, [(res, {})], device)
+    validate_surrogate(model, edge_index, None, wn, [(res, {})], device)


### PR DESCRIPTION
## Summary
- support running modules both as scripts and packages
- add edge attribute support in experiments validation
- handle EnhancedGNNEncoder checkpoints when loading models
- expose in/out channels for `HydroConv`
- adjust unit test for new validate_surrogate API

## Testing
- `pytest -q`
- `python scripts/experiments_validation.py --model models/gnn_surrogate_20250611_015549.pth --inp CTown.inp`

------
https://chatgpt.com/codex/tasks/task_e_6848dfdffcc0832497d052da01459770