### PR TITLE
Fix surrogate normalization loading

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -131,7 +131,15 @@ def validate_surrogate(
                 c = chlorine_df.iloc[i].to_dict()
                 controls = pump_array[i]
                 x = _prepare_features(wn, p, c, controls, model).to(device)
-                pred = model(x, edge_index, edge_attr)
+                if hasattr(model, "rnn"):
+                    seq_in = x.unsqueeze(0).unsqueeze(0)
+                    pred = model(seq_in, edge_index, edge_attr)
+                    if isinstance(pred, dict):
+                        pred = pred.get("node_outputs")[0, 0]
+                else:
+                    pred = model(x, edge_index, edge_attr)
+                    if isinstance(pred, dict):
+                        pred = pred.get("node_outputs")
                 if hasattr(model, "y_mean") and model.y_mean is not None:
                     pred = pred * model.y_std + model.y_mean
                 y_true_p = pressures_df.iloc[i + 1].to_numpy()


### PR DESCRIPTION
## Summary
- extend `GNNSurrogate` to support optional `fc_out`
- load multitask normalization stats and handle various checkpoint formats
- support sequence models in validation and MPC
- update tests for surrogate loading

## Testing
- `pytest -q`
- `python scripts/experiments_validation.py --model models/gnn_surrogate_test.pth --inp CTown.inp --test-pkl data/test_results_list.pkl --horizon 1 --iterations 1`

------
https://chatgpt.com/codex/tasks/task_e_6848f17e83448324945bce24901a7167