### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -245,7 +245,7 @@ def run_scenarios(
     num_scenarios: int,
     seed: Optional[int] = None,
     extreme_event_prob: float = 0.0,
-    num_workers: int | None = None,
+    num_workers: Optional[int] = None,
 ) -> List[
     Tuple[wntr.sim.results.SimulationResults, Dict[str, np.ndarray], Dict[str, List[float]]]
 ]:

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -12,7 +12,7 @@ import os
 import json
 import pickle
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -93,7 +93,7 @@ def _prepare_features(
 def validate_surrogate(
     model: torch.nn.Module,
     edge_index: torch.Tensor,
-    edge_attr: torch.Tensor | None,
+    edge_attr: Optional[torch.Tensor],
     wn: wntr.network.WaterNetworkModel,
     test_results: List,
     device: torch.device,

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -411,8 +411,8 @@ def apply_sequence_normalization(
     x_std: torch.Tensor,
     y_mean,
     y_std,
-    edge_attr_mean: torch.Tensor | None = None,
-    edge_attr_std: torch.Tensor | None = None,
+    edge_attr_mean: Optional[torch.Tensor] = None,
+    edge_attr_std: Optional[torch.Tensor] = None,
 ) -> None:
     dataset.X = (dataset.X - x_mean) / x_std
     if dataset.multi:


### PR DESCRIPTION
## Summary
- support Python 3.9 by replacing `| None` type hints with `Optional[...]`

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/ --seed 0`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --x-val-path data/X_val.npy --y-val-path data/Y_val.npy --epochs 2 --batch-size 8 --hidden-dim 32 --num-layers 2 --inp-path CTown.inp`
- `python scripts/experiments_validation.py --model models/gnn_surrogate_20250611_053656.pth --inp CTown.inp`

------
https://chatgpt.com/codex/tasks/task_e_6849143960e08324a9986e3b19eaee55