### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -243,7 +243,7 @@ def run_scenarios(
     num_scenarios: int,
     seed: Optional[int] = None,
     extreme_event_prob: float = 0.0,
-    num_workers: int | None = None,
+    num_workers: Optional[int] = None,
 ) -> List[
     Tuple[wntr.sim.results.SimulationResults, Dict[str, np.ndarray], Dict[str, List[float]]]
 ]:


### PR DESCRIPTION
## Summary
- fix union type hint that required Python 3.10
- run tests

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 1 --output-dir data/ --seed 42 --num-workers 1 --sequence-length 1`

------
https://chatgpt.com/codex/tasks/task_e_68498ccf6dc883249db8633c5fc13605