### PR TITLE
Fix import of models in training script

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2,6 +2,7 @@ import argparse
 import os
 from pathlib import Path
 from datetime import datetime
+import sys
 
 import numpy as np
 import torch
@@ -15,6 +16,11 @@ import wntr
 import matplotlib.pyplot as plt
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from typing import Optional
+
+# Ensure the repository root is importable when running this file directly
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from models.loss_utils import compute_mass_balance_loss
 


### PR DESCRIPTION
## Summary
- ensure `scripts/train_gnn.py` can be executed directly by
  adding the repository root to `sys.path`

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 30 --output-dir data/ --seed 1`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --x-val-path data/X_val.npy --y-val-path data/Y_val.npy --epochs 1 --batch-size 16 --hidden-dim 32 --num-layers 3 --normalize --early-stop-patience 5 --edge-index-path data/edge_index.npy --inp-path CTown.inp`


------
https://chatgpt.com/codex/tasks/task_e_6849abfbf7e08324946d23cdb43024ab