### PR TITLE
Fix module path for experiments_validation

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -13,6 +13,7 @@ import json
 import pickle
 from pathlib import Path
 from typing import Dict, List, Optional
+import sys
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -20,12 +21,17 @@ import pandas as pd
 import torch
 import wntr
 from wntr.metrics.economic import pump_energy
+
+# Ensure the repository root is importable when running this script directly
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from models.loss_utils import compute_mass_balance_loss
 
 # Compute absolute path to the repository's data directory so that results are
 # always written inside the project regardless of the current working
 # directory.
-REPO_ROOT = Path(__file__).resolve().parents[1]
 DATA_DIR = REPO_ROOT / "data"
 TEMP_DIR = DATA_DIR / "temp"
 os.makedirs(TEMP_DIR, exist_ok=True)


### PR DESCRIPTION
## Summary
- fix import path for loss_utils in experiments_validation
- ensure repository root is available on `sys.path`

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/ --seed 0 --num-workers 1`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --x-val-path data/X_val.npy --y-val-path data/Y_val.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 2 --batch-size 4 --hidden-dim 16 --num-layers 2 --output-dim 2 --early-stop-patience 2`
- `python scripts/experiments_validation.py --model models/gnn_surrogate_20250611_171431.pth --inp CTown.inp`


------
https://chatgpt.com/codex/tasks/task_e_6849b81b69548324a3d9773919d847c4