### PR TITLE
Add centralized plotting and visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ supported:
 2. **Matrix format** – ``X`` is an array of node feature matrices and a shared
    ``edge_index`` array is stored separately.
 
+All plots generated during training, validation and MPC experiments are
+saved under the top-level ``plots/`` directory.  The scripts automatically
+create this folder if it does not yet exist.
+
 The script automatically detects which format is provided and loads the data
 accordingly. When using the matrix format, supply the path to the shared
 ``edge_index`` file via ``--edge-index-path`` (defaults to ``data/edge_index.npy``).

--- a/tests/test_validate_surrogate.py
+++ b/tests/test_validate_surrogate.py
@@ -34,4 +34,4 @@ def test_validate_surrogate_accepts_tuple():
     sim = wntr.sim.EpanetSimulator(wn)
     res = sim.run_sim(str(TEMP_DIR / "temp"))
     model = DummyModel().to(device)
-    validate_surrogate(model, edge_index, None, wn, [(res, {})], device)
+    validate_surrogate(model, edge_index, None, wn, [(res, {})], device, "test")


### PR DESCRIPTION
## Summary
- centralize visual output under new `plots/` directory
- add scatter and loss curve plots to `train_gnn.py`
- generate error histograms and MPC performance comparisons in `experiments_validation.py`
- log pump controls and output per-run plots in `mpc_control.py`
- adjust tests for new interfaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a26ee527c8324ac8853f6c4c9c6e7