### PR TITLE
Fix scatter plot saving bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ supported:
 
 All plots generated during training, validation and MPC experiments are
 saved under the top-level ``plots/`` directory.  The scripts automatically
-create this folder if it does not yet exist.
+create this folder if it does not yet exist. After each training run
+``train_gnn.py`` saves two scatter plots comparing model predictions to
+EPANET results: ``pred_vs_actual_pressure_<run>.png`` and
+``pred_vs_actual_chlorine_<run>.png``.
 
 The script automatically detects which format is provided and loads the data
 accordingly. When using the matrix format, supply the path to the shared

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -1,0 +1,16 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import save_scatter_plots
+
+
+def test_save_scatter_plots(tmp_path):
+    p_true = np.array([1.0, 2.0, 3.0])
+    p_pred = np.array([1.1, 2.1, 2.9])
+    c_true = np.array([0.1, 0.2, 0.3])
+    c_pred = np.array([0.1, 0.19, 0.31])
+    save_scatter_plots(p_true, p_pred, c_true, c_pred, "unit", plots_dir=tmp_path)
+    assert (tmp_path / "pred_vs_actual_pressure_unit.png").exists()
+    assert (tmp_path / "pred_vs_actual_chlorine_unit.png").exists()


### PR DESCRIPTION
## Summary
- fix evaluation call to use tensor edge data
- plot pressure and chlorine predictions separately
- add helper `save_scatter_plots` and unit test
- document new scatter plot outputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684acec58ac48324b15cd47a4ab51a9b