### PR TITLE
Fix MPC run with models lacking pump inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,6 @@ control inputs (the additional features appended by `scripts/data_generation.py`
 If a model trained with only four features (demand, pressure, chlorine and
 elevation) is loaded, `mpc_control.py` will exit early because pump actions would
 have no effect on the predictions.
+`simulate_closed_loop` now performs the same check and raises a `ValueError`
+when the loaded model does not include pump controls so that experiment scripts
+fail fast instead of silently optimising with zero gradients.

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -696,6 +696,13 @@ def simulate_closed_loop(
     pressures and chlorine levels using the GNN surrogate which allows the loop
     to run nearly instantly.
     """
+    expected_in_dim = 4 + len(pump_names)
+    in_dim = getattr(getattr(model, "conv1", None), "in_channels", None)
+    if in_dim is None or in_dim < expected_in_dim:
+        raise ValueError(
+            "Loaded model was trained without pump controls - rerun train_gnn.py"
+        )
+
     log = []
     pressure_violations = 0
     chlorine_violations = 0

--- a/tests/test_mpc_input_check.py
+++ b/tests/test_mpc_input_check.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+import torch
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.mpc_control import simulate_closed_loop, load_network, GNNSurrogate
+
+class DummyConv(torch.nn.Module):
+    def __init__(self, in_channels):
+        super().__init__()
+        self.in_channels = in_channels
+    def forward(self, x, edge_index, edge_attr=None):
+        return x
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = DummyConv(4)  # only basic features
+    def forward(self, x, edge_index, edge_attr=None):
+        return torch.zeros(x.size(0), 2)
+
+
+def test_simulate_closed_loop_requires_pump_inputs():
+    device = torch.device("cpu")
+    wn, node_to_index, pump_names, edge_index, edge_attr = load_network("CTown.inp", return_edge_attr=True)
+    model = DummyModel().to(device)
+    with pytest.raises(ValueError):
+        simulate_closed_loop(
+            wn,
+            model,
+            edge_index.to(device),
+            edge_attr.to(device),
+            horizon=2,
+            iterations=1,
+            node_to_index=node_to_index,
+            pump_names=pump_names,
+            device=device,
+            Pmin=20.0,
+            Cmin=0.2,
+            feedback_interval=0,
+        )


### PR DESCRIPTION
## Summary
- detect missing pump control features in `simulate_closed_loop`
- document failure mode in README
- add regression test ensuring MPC fails fast when a surrogate without pump inputs is loaded

## Testing
- `pytest -q`
- `pytest tests/test_mpc_input_check.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684ad9bddcf083249b6bc1e1bf912964