### PR TITLE
Fix test data normalization for scatter plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ create this folder if it does not yet exist. After each training run
 ``train_gnn.py`` saves two scatter plots comparing model predictions to
 EPANET results: ``pred_vs_actual_pressure_<run>.png`` and
 ``pred_vs_actual_chlorine_<run>.png``.
+When normalization is enabled (the default) the test data is scaled using the
+training statistics and the predictions are transformed back to physical units
+before plotting.
 
 The script automatically detects which format is provided and loads the data
 accordingly. When using the matrix format, supply the path to the shared


### PR DESCRIPTION
## Summary
- expose normalization statistics on the model during training
- normalize test datasets before plotting predictions
- update README to document normalisation when creating scatter plots

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684c546ece1c83249ae1fd85d26156ae