### PR TITLE
Add heterogeneous graph modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ consumption. ``train_gnn.py`` automatically detects such multi-task arrays and
 switches to a ``MultiTaskGNNSurrogate`` model which optimizes a weighted loss
 over all targets.
 
+The GNN architecture has been refactored to support **heterogeneous graphs**.
+Node embeddings are now conditioned on the component type (junction, tank,
+pump or valve) while edges differentiate pipes, pumps and valves.  The helper
+scripts automatically compute these type indices from the EPANET network and
+store them in ``edge_type.npy``.  Training and MPC control handle these
+additional attributes transparently.
+
 Example usage:
 
 ```bash

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -452,7 +452,7 @@ def main() -> None:
     args = parser.parse_args()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    wn, node_to_index, pump_names, edge_index, edge_attr = load_network(
+    wn, node_to_index, pump_names, edge_index, edge_attr, node_types, edge_types = load_network(
         args.inp, return_edge_attr=True
     )
     edge_index = edge_index.to(device)

--- a/tests/test_hydroconv.py
+++ b/tests/test_hydroconv.py
@@ -4,12 +4,12 @@ from scripts.train_gnn import HydroConv
 def test_mass_conservation():
     edge_index = torch.tensor([[0,1],[1,0]], dtype=torch.long)
     edge_attr = torch.ones(2,3)
-    conv = HydroConv(1,1,edge_dim=3)
+    conv = HydroConv(1,1,edge_dim=3, num_node_types=1, num_edge_types=1)
     with torch.no_grad():
-        conv.lin.weight.fill_(1.0)
-        conv.lin.bias.zero_()
-        conv.edge_mlp[0].weight.fill_(1.0)
-        conv.edge_mlp[0].bias.zero_()
+        conv.lin[0].weight.fill_(1.0)
+        conv.lin[0].bias.zero_()
+        conv.edge_mlps[0][0].weight.fill_(1.0)
+        conv.edge_mlps[0][0].bias.zero_()
     x = torch.tensor([[1.0],[2.0]])
     out = conv(x, edge_index, edge_attr)
     assert torch.allclose(out.sum(), torch.tensor(0.0), atol=1e-6)

--- a/tests/test_mpc_input_check.py
+++ b/tests/test_mpc_input_check.py
@@ -23,7 +23,7 @@ class DummyModel(torch.nn.Module):
 
 def test_simulate_closed_loop_requires_pump_inputs():
     device = torch.device("cpu")
-    wn, node_to_index, pump_names, edge_index, edge_attr = load_network("CTown.inp", return_edge_attr=True)
+    wn, node_to_index, pump_names, edge_index, edge_attr, node_types, edge_types = load_network("CTown.inp", return_edge_attr=True)
     model = DummyModel().to(device)
     with pytest.raises(ValueError):
         simulate_closed_loop(

--- a/tests/test_validate_surrogate.py
+++ b/tests/test_validate_surrogate.py
@@ -26,7 +26,7 @@ class DummyModel(torch.nn.Module):
 
 def test_validate_surrogate_accepts_tuple():
     device = torch.device('cpu')
-    wn, node_to_index, pump_names, edge_index = load_network('CTown.inp')
+    wn, node_to_index, pump_names, edge_index, node_types, edge_types = load_network('CTown.inp')
     wn.options.time.duration = 2 * 3600
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600


### PR DESCRIPTION
## Summary
- extend HydroConv and training utilities for node/edge types
- generate and save edge types
- update MPC controller and experiments for heterogeneous graphs
- adapt unit tests for new APIs
- document heterogeneous modeling in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec4085c1883249588877aba8d5712