### PR TITLE
Add headloss consistency loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy 
 Use the ``--physics_loss`` flag to enable a physics-informed penalty that
 encourages mass conservation of predicted flows.  This adds a lightweight loss
 term based on Kirchhoff's law as described by Ashraf et al. (AAAI 2024).
+An additional ``--pressure_loss`` option enforces pressure-headloss
+consistency using the Hazen--Williams equation.  The weights of both physics
+terms can be tuned via ``--w_mass`` and ``--w_head``.
 
 The trained model now supports validation loss tracking and early stopping.
 Normalization is applied automatically so the ``--normalize`` flag is optional.

--- a/models/loss_utils.py
+++ b/models/loss_utils.py
@@ -31,3 +31,62 @@ def compute_mass_balance_loss(pred_flows: torch.Tensor, edge_index: torch.Tensor
         node_balance[v] += f
 
     return torch.mean(node_balance ** 2)
+
+
+def pressure_headloss_consistency_loss(
+    pred_pressures: torch.Tensor,
+    pred_flows: torch.Tensor,
+    edge_index: torch.Tensor,
+    edge_attr: torch.Tensor,
+    edge_attr_mean: torch.Tensor | None = None,
+    edge_attr_std: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Return MSE between predicted and Hazen-Williams head losses.
+
+    Parameters
+    ----------
+    pred_pressures : torch.Tensor
+        Predicted pressures per node with shape ``[..., N]`` where ``N`` is the
+        number of nodes. The tensor is flattened across all leading dimensions.
+    pred_flows : torch.Tensor
+        Predicted flow rates per edge with shape ``[..., E]``.
+    edge_index : torch.Tensor
+        Edge index tensor of shape ``[2, E]`` defining flow directions.
+    edge_attr : torch.Tensor
+        Edge attribute matrix ``[E, 3]`` providing pipe length ``[m]``, diameter
+        ``[m]`` and Hazen--Williams roughness coefficient ``C``. Values may be
+        normalized; ``edge_attr_mean`` and ``edge_attr_std`` will be used to
+        restore physical units when provided.
+    edge_attr_mean : torch.Tensor, optional
+        Mean used during normalization of ``edge_attr``.
+    edge_attr_std : torch.Tensor, optional
+        Standard deviation used during normalization of ``edge_attr``.
+    """
+
+    # Un-normalise edge attributes if statistics are available
+    if edge_attr_mean is not None and edge_attr_std is not None:
+        attr = edge_attr * edge_attr_std + edge_attr_mean
+    else:
+        attr = edge_attr
+
+    length = attr[:, 0]
+    diam = attr[:, 1]
+    rough = attr[:, 2].clamp(min=1e-6)
+
+    # Flatten prediction tensors so the first dimension represents the batch
+    p = pred_pressures.reshape(-1, pred_pressures.shape[-1])
+    q = pred_flows.reshape(-1, pred_flows.shape[-1])
+
+    src = edge_index[0]
+    tgt = edge_index[1]
+    p_src = p[:, src]
+    p_tgt = p[:, tgt]
+    pred_hl = (p_src - p_tgt).abs()
+
+    # Hazen--Williams head loss formula (SI units)
+    const = 10.67
+    hw_hl = const * length * q.abs().pow(1.852) / (
+        rough.pow(1.852) * diam.pow(4.87)
+    )
+
+    return torch.mean((pred_hl - hw_hl) ** 2)

--- a/tests/test_headloss_loss.py
+++ b/tests/test_headloss_loss.py
@@ -1,0 +1,15 @@
+import torch
+from models.loss_utils import pressure_headloss_consistency_loss
+
+def test_headloss_consistency_zero():
+    edge_index = torch.tensor([[0], [1]], dtype=torch.long)
+    edge_attr = torch.tensor([[1000.0, 0.5, 100.0]], dtype=torch.float32)
+    flow = torch.tensor([0.1], dtype=torch.float32)
+    const = 10.67
+    hl = const * edge_attr[0,0] * flow.abs().pow(1.852) / (
+        edge_attr[0,2].pow(1.852) * edge_attr[0,1].pow(4.87)
+    )
+    pressures = torch.tensor([50.0 + hl.item(), 50.0], dtype=torch.float32)
+    loss = pressure_headloss_consistency_loss(pressures, flow, edge_index, edge_attr)
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)
+


### PR DESCRIPTION
## Summary
- implement physics-based pressure-headloss loss using the Hazen–Williams equation
- integrate new loss into the training loop with CLI flags `--pressure_loss`, `--w_mass`, `--w_head`
- document new options in README
- test the new loss computation

## Testing
- `PYTHONPATH=. pytest -q`
- `python scripts/data_generation.py --num-scenarios 2 --output-dir data/test_run2 --seed 123`
- `python scripts/train_gnn.py --x-path data/test_run2/X_train.npy --y-path data/test_run2/Y_train.npy --edge-index-path data/test_run2/edge_index.npy --epochs 1 --batch-size 1 --inp-path CTown.inp --physics_loss --pressure_loss --w_mass 0.5 --w_head 0.1 --x-val-path '' --y-val-path ''`

------
https://chatgpt.com/codex/tasks/task_e_684ecaf423488324ab9c6444d898042f