### PR TITLE
Refactor GNN encoder and allow weight sharing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
 - `CTown.inp` – EPANET input file for the C‑Town network.
 - `scripts/`
   - `data_generation.py` – create randomized simulation scenarios and produce training datasets.
-  - `train_gnn.py` – train a two-layer GCN (`SimpleGCN`) on generated data.
+  - `train_gnn.py` – train a graph neural network surrogate on generated data.
   - `mpc_control.py` – run gradient-based MPC using the trained surrogate.
   - `experiments_validation.py` – validate the surrogate, compare baselines and aggregate results.
 - `models/` – storage location for trained weights (`gnn_surrogate.pth`).
@@ -37,7 +37,7 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
 ## Architecture Overview
 
 1. **Data Generation** – `scripts/data_generation.py` executes multiple EPANET simulations with randomized pump states and scaled base demands. It writes node feature matrices, labels for the next hour pressure and chlorine, and the graph `edge_index` to the `data/` directory.
-2. **Surrogate Training** – `scripts/train_gnn.py` loads the generated data, builds `torch_geometric.data.Data` objects and trains a simple two-layer GCN. NaNs in the features are replaced with zero to avoid invalid losses. Gradients are clipped to keep the training stable. Scatter plots comparing predictions to EPANET are saved under `plots/`.
+2. **Surrogate Training** – `scripts/train_gnn.py` loads the generated data and trains a configurable GNN encoder. The model supports heterogeneous node and edge types, optional attention and residual connections. NaNs in the features are replaced with zero to avoid invalid losses. Gradients are clipped to keep the training stable. Scatter plots comparing predictions to EPANET are saved under `plots/`.
 3. **MPC Controller** – `scripts/mpc_control.py` loads the trained surrogate (`GNNSurrogate`) and repeatedly optimizes pump speeds via gradient descent. The controller can either propagate the network state entirely through the surrogate or periodically synchronize with EPANET for ground truth. Simulation history is written to `data/mpc_history.csv` and a summary JSON file to `logs/`.
 4. **Experiment Validation** – `scripts/experiments_validation.py` evaluates the surrogate on prerecorded EPANET scenarios and compares the MPC controller against two baselines. Results are aggregated into CSV files under `data/` and plots under `plots/`. Validation metrics are stored in `logs/surrogate_metrics.json`.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ scripts automatically compute these type indices from the EPANET network and
 store them in ``edge_type.npy``.  Training and MPC control handle these
 additional attributes transparently.
 
+Optionally, the same convolution layer can be reused for all message passing
+steps by passing ``--share-weights`` to ``train_gnn.py``. This reduces the
+number of parameters and can speed up optimisation.
+
 Example usage:
 
 ```bash

--- a/tests/test_load_surrogate.py
+++ b/tests/test_load_surrogate.py
@@ -19,8 +19,8 @@ def test_load_surrogate_renames_old_keys(tmp_path):
     path = tmp_path / 'model_old.pth'
     torch.save(state, path)
     model = load_surrogate_model(torch.device('cpu'), path=str(path))
-    assert model.conv1.out_channels == 4
-    assert model.conv2.out_channels == 2
+    assert model.layers[0].out_channels == 4
+    assert model.layers[-1].out_channels == 2
 
 
 def test_load_surrogate_detects_nan(tmp_path):
@@ -62,7 +62,7 @@ def test_load_surrogate_selects_latest(tmp_path, monkeypatch):
     monkeypatch.setattr('scripts.mpc_control.REPO_ROOT', tmp_path)
 
     model = load_surrogate_model(torch.device('cpu'))
-    assert model.conv1.out_channels == 2
+    assert model.layers[0].out_channels == 2
 
 
 def test_load_surrogate_handles_multitask_norm(tmp_path):

--- a/tests/test_mpc_input_check.py
+++ b/tests/test_mpc_input_check.py
@@ -16,7 +16,7 @@ class DummyConv(torch.nn.Module):
 class DummyModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.conv1 = DummyConv(4)  # only basic features
+        self.layers = torch.nn.ModuleList([DummyConv(4)])  # only basic features
     def forward(self, x, edge_index, edge_attr=None):
         return torch.zeros(x.size(0), 2)
 


### PR DESCRIPTION
## Summary
- simplify `EnhancedGNNEncoder` construction
- add optional parameter sharing across GNN layers
- drop legacy `conv1`/`conv2` attributes and update MPC utilities
- adjust tests for new model structure
- document `--share-weights` flag

## Testing
- `python pytorchcheck.py` *(fails: no NVIDIA driver)*
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 1 --batch-size 2 --share-weights`

------
https://chatgpt.com/codex/tasks/task_e_684ee01553988324a04a6acf2624b20e