### PR TITLE
Add sparse graph training options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy 
     --inp-path CTown.inp
 ```
 
+For large graphs you can reduce memory usage by training on subgraphs.
+Passing ``--cluster-batch-size <N>`` partitions the network into clusters of
+approximately ``N`` nodes and iterates over those clusters instead of loading
+the full graph each time.  Use ``--neighbor-sampling`` to sample ``N`` target
+nodes and their neighbors on-the-fly instead of deterministic clusters.
+During inference on very large networks the same clusters can be evaluated
+sequentially to keep memory usage low.
+
 Use the ``--physics_loss`` flag to enable a physics-informed penalty that
 encourages mass conservation of predicted flows.  This adds a lightweight loss
 term based on Kirchhoff's law as described by Ashraf et al. (AAAI 2024).


### PR DESCRIPTION
## Summary
- implement greedy clustering and neighbor sampling in `train_gnn.py`
- add `--cluster-batch-size` and `--neighbor-sampling` CLI options
- document new scaling options in README

## Testing
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --x-val-path '' --y-val-path '' --epochs 1 --batch-size 2 --cluster-batch-size 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee5a6ae3c8324850fc997aa8fc806