### PR TITLE
Optimize MPC feature assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Once the surrogate model is trained you can run gradient-based MPC using
 python scripts/mpc_control.py --horizon 6 --iterations 50 --feedback-interval 24
 ```
 
+Pass ``--profile`` to print the runtime of each MPC optimisation step. The
+controller now builds node features on the GPU to minimise Python overhead.
+```
+
 By default the controller loads the most recent ``.pth`` file found in the
 ``models`` directory so retraining will automatically use the newest weights.
 

--- a/tests/test_mpc_input_check.py
+++ b/tests/test_mpc_input_check.py
@@ -23,7 +23,16 @@ class DummyModel(torch.nn.Module):
 
 def test_simulate_closed_loop_requires_pump_inputs():
     device = torch.device("cpu")
-    wn, node_to_index, pump_names, edge_index, edge_attr, node_types, edge_types = load_network("CTown.inp", return_edge_attr=True)
+    (
+        wn,
+        node_to_index,
+        pump_names,
+        edge_index,
+        edge_attr,
+        node_types,
+        edge_types,
+        template,
+    ) = load_network("CTown.inp", return_edge_attr=True, return_features=True)
     model = DummyModel().to(device)
     with pytest.raises(ValueError):
         simulate_closed_loop(
@@ -31,6 +40,9 @@ def test_simulate_closed_loop_requires_pump_inputs():
             model,
             edge_index.to(device),
             edge_attr.to(device),
+            template.to(device),
+            torch.tensor(node_types, dtype=torch.long, device=device),
+            torch.tensor(edge_types, dtype=torch.long, device=device),
             horizon=2,
             iterations=1,
             node_to_index=node_to_index,


### PR DESCRIPTION
## Summary
- add GPU feature assembly for MPC cost computation
- allow profiling with a new flag
- update test helper for new simulate_closed_loop signature

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 2 --output-dir data/tmp_test`
- `python scripts/train_gnn.py --x-path data/tmp_test/X_train.npy --y-path data/tmp_test/Y_train.npy --edge-index-path data/tmp_test/edge_index.npy --inp-path CTown.inp --epochs 1 --batch-size 2`

------
https://chatgpt.com/codex/tasks/task_e_684ef06c61108324a42a5f780a6af211