### PR TITLE
Improve inference with TorchScript and batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ python scripts/mpc_control.py --horizon 6 --iterations 50 --feedback-interval 24
 
 Pass ``--profile`` to print the runtime of each MPC optimisation step. The
 controller now builds node features on the GPU to minimise Python overhead.
+The surrogate model is compiled with TorchScript during loading for faster
+inference.  Use ``--no-jit`` to disable this.  ``propagate_with_surrogate`` can
+also accept lists of pressure/chlorine dictionaries to evaluate multiple
+scenarios in parallel.
 ```
 
 By default the controller loads the most recent ``.pth`` file found in the

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -76,18 +76,18 @@ class HydroConv(MessagePassing):
 
         aggr = self.propagate(edge_index, x=x, edge_attr=edge_attr, edge_type=edge_type)
         out = torch.zeros((x.size(0), self.out_channels), device=x.device, dtype=aggr.dtype)
-        for t in range(self.num_node_types):
+        for t, lin in enumerate(self.lin):
             idx = node_type == t
-            if idx.any():
-                out[idx] = self.lin[t](aggr[idx])
+            if torch.any(idx):
+                out[idx] = lin(aggr[idx])
         return out
 
     def message(self, x_i: torch.Tensor, x_j: torch.Tensor, edge_attr: torch.Tensor, edge_type: torch.Tensor) -> torch.Tensor:
         weight = torch.zeros(edge_attr.size(0), 1, device=edge_attr.device)
-        for t in range(self.num_edge_types):
+        for t, mlp in enumerate(self.edge_mlps):
             idx = edge_type == t
-            if idx.any():
-                weight[idx] = self.edge_mlps[t](edge_attr[idx])
+            if torch.any(idx):
+                weight[idx] = mlp(edge_attr[idx])
         return weight * (x_j - x_i)
 
 

--- a/tests/test_load_surrogate.py
+++ b/tests/test_load_surrogate.py
@@ -18,7 +18,7 @@ def test_load_surrogate_renames_old_keys(tmp_path):
     }
     path = tmp_path / 'model_old.pth'
     torch.save(state, path)
-    model = load_surrogate_model(torch.device('cpu'), path=str(path))
+    model = load_surrogate_model(torch.device('cpu'), path=str(path), use_jit=False)
     assert model.layers[0].out_channels == 4
     assert model.layers[-1].out_channels == 2
 
@@ -33,7 +33,7 @@ def test_load_surrogate_detects_nan(tmp_path):
     path = tmp_path / 'model_nan.pth'
     torch.save(state, path)
     with pytest.raises(ValueError):
-        load_surrogate_model(torch.device('cpu'), path=str(path))
+        load_surrogate_model(torch.device('cpu'), path=str(path), use_jit=False)
 
 
 def test_load_surrogate_selects_latest(tmp_path, monkeypatch):
@@ -61,7 +61,7 @@ def test_load_surrogate_selects_latest(tmp_path, monkeypatch):
     # Ensure function searches within our temporary repository
     monkeypatch.setattr('scripts.mpc_control.REPO_ROOT', tmp_path)
 
-    model = load_surrogate_model(torch.device('cpu'))
+    model = load_surrogate_model(torch.device('cpu'), use_jit=False)
     assert model.layers[0].out_channels == 2
 
 
@@ -85,5 +85,5 @@ def test_load_surrogate_handles_multitask_norm(tmp_path):
         y_mean_energy=np.zeros(1),
         y_std_energy=np.ones(1),
     )
-    model = load_surrogate_model(torch.device('cpu'), path=str(path))
+    model = load_surrogate_model(torch.device('cpu'), path=str(path), use_jit=False)
     assert model.y_mean is not None


### PR DESCRIPTION
## Summary
- compile surrogate models with TorchScript in `load_surrogate_model`
- add `--no-jit` option to disable scripting
- support batching in `prepare_node_features` and `propagate_with_surrogate`
- update experiment runner for new API
- adjust tests for new `use_jit` flag
- document JIT compilation and batched inference

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 2 --output-dir data/test --seed 0`
- `python scripts/train_gnn.py --x-path data/test/X_train.npy --y-path data/test/Y_train.npy --edge-index-path data/test/edge_index.npy --epochs 1 --batch-size 2 --inp-path CTown.inp --output models/test_model.pth --normalize --run-name test --x-val-path '' --y-val-path ''`
- `python scripts/experiments_validation.py --model models/test_model_test.pth --inp CTown.inp --horizon 1 --iterations 1 --Pmin 20 --Cmin 0.2 --feedback-interval 1 --run-name test --no-jit --test-pkl data/test/test_results_list.pkl` *(fails: mat1 and mat2 shapes cannot be multiplied)*
- `python scripts/mpc_control.py --horizon 1 --iterations 1 --Pmin 20 --Cmin 0.2 --feedback-interval 24 --no-jit` *(fails: mat1 and mat2 shapes cannot be multiplied)*


------
https://chatgpt.com/codex/tasks/task_e_684efb9c097883249e1db24cf0506464