### PR TITLE
Add reporting utilities for key performance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,28 @@ have no effect on the predictions.
 `simulate_closed_loop` now performs the same check and raises a `ValueError`
 when the loaded model does not include pump controls so that experiment scripts
 fail fast instead of silently optimising with zero gradients.
+
+## Reporting Key Performance Metrics
+
+The module `scripts/metrics.py` provides helper functions to compute the most
+common evaluation metrics for surrogate accuracy, MPC control behaviour and
+runtime performance.  Each function returns a formatted ``pandas.DataFrame`` for
+easy printing or saving.
+
+Example usage:
+
+```python
+from metrics import accuracy_metrics, control_metrics, computational_metrics, export_table
+
+# arrays of ground truth and predictions
+acc_df = accuracy_metrics(true_p, pred_p, true_c, pred_c)
+control_df = control_metrics(min_p, min_c, energy, p_min=20.0, c_min=0.2)
+comp_df = computational_metrics(inference_times, optimisation_times)
+
+# export to CSV
+export_table(acc_df, "logs/accuracy.csv")
+```
+
+Tables use clear labels and units so results can be understood at a glance.  The
+same metrics can also be exported to Excel or JSON by passing a path ending in
+``.xlsx`` or ``.json``.

--- a/scripts/metrics.py
+++ b/scripts/metrics.py
@@ -1,0 +1,138 @@
+"""Utility functions for reporting surrogate and MPC performance metrics."""
+
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+
+def _to_numpy(seq: Sequence[float]) -> np.ndarray:
+    """Convert a sequence to a NumPy array of floats."""
+    return np.asarray(seq, dtype=float)
+
+
+def accuracy_metrics(
+    true_pressure: Sequence[float],
+    pred_pressure: Sequence[float],
+    true_chlorine: Sequence[float],
+    pred_chlorine: Sequence[float],
+) -> pd.DataFrame:
+    """Return accuracy metrics for pressure and chlorine predictions.
+
+    Parameters
+    ----------
+    true_pressure, pred_pressure : sequence of floats
+        Ground truth and predicted pressures in meters.
+    true_chlorine, pred_chlorine : sequence of floats
+        Ground truth and predicted chlorine levels in mg/L.
+
+    Returns
+    -------
+    pd.DataFrame
+        Table with MAE, RMSE, MAPE and maximum error for pressure and chlorine.
+    """
+    tp = _to_numpy(true_pressure)
+    pp = _to_numpy(pred_pressure)
+    tc = _to_numpy(true_chlorine)
+    pc = _to_numpy(pred_chlorine)
+
+    abs_p = np.abs(tp - pp)
+    abs_c = np.abs(tc - pc)
+
+    mae_p = abs_p.mean()
+    mae_c = abs_c.mean()
+
+    rmse_p = np.sqrt(((tp - pp) ** 2).mean())
+    rmse_c = np.sqrt(((tc - pc) ** 2).mean())
+
+    # avoid divide-by-zero by adding a tiny epsilon
+    mape_p = (abs_p / np.maximum(np.abs(tp), 1e-8)).mean() * 100.0
+    mape_c = (abs_c / np.maximum(np.abs(tc), 1e-8)).mean() * 100.0
+
+    max_err_p = abs_p.max()
+    max_err_c = abs_c.max()
+
+    data = {
+        "Pressure (m)": [mae_p, rmse_p, mape_p, max_err_p],
+        "Chlorine (mg/L)": [mae_c, rmse_c, mape_c, max_err_c],
+    }
+    index = [
+        "Mean Absolute Error (MAE)",
+        "Root Mean Squared Error (RMSE)",
+        "Mean Absolute Percentage Error",
+        "Maximum Error",
+    ]
+    return pd.DataFrame(data, index=index)
+
+
+def control_metrics(
+    min_pressures: Sequence[float],
+    min_chlorine: Sequence[float],
+    energy_kwh: Sequence[float],
+    p_min: float,
+    c_min: float,
+) -> pd.DataFrame:
+    """Compute constraint violations and total pump energy.
+
+    Parameters
+    ----------
+    min_pressures : sequence of floats
+        Minimum pressure recorded for each simulation step in meters.
+    min_chlorine : sequence of floats
+        Minimum chlorine concentration for each step in mg/L.
+    energy_kwh : sequence of floats
+        Pump energy usage per step in kWh.
+    p_min, c_min : float
+        Operational lower bounds for pressure and chlorine.
+    """
+    p = _to_numpy(min_pressures)
+    c = _to_numpy(min_chlorine)
+    e = _to_numpy(energy_kwh)
+
+    pressure_violations = int(np.sum(p < p_min))
+    chlorine_violations = int(np.sum(c < c_min))
+    total_energy = float(e.sum())
+
+    data = {
+        "Value": [pressure_violations, chlorine_violations, total_energy]
+    }
+    index = [
+        "Pressure Constraint Violations (hrs)",
+        "Chlorine Constraint Violations (hrs)",
+        "Total Pump Energy (kWh)",
+    ]
+    return pd.DataFrame(data, index=index)
+
+
+def computational_metrics(
+    inference_times: Sequence[float],
+    optimisation_times: Sequence[float],
+) -> pd.DataFrame:
+    """Return average inference and optimisation runtimes in milliseconds."""
+    inf = _to_numpy(inference_times) * 1000.0
+    opt = _to_numpy(optimisation_times) * 1000.0
+
+    data = {
+        "Average Time (ms)": [inf.mean(), opt.mean()]
+    }
+    index = [
+        "Inference Time per Simulation Step",
+        "Optimization Time per Control Step",
+    ]
+    return pd.DataFrame(data, index=index)
+
+
+def export_table(df: pd.DataFrame, path: str) -> None:
+    """Export a metric table to CSV, Excel or JSON based on file suffix."""
+    p = Path(path)
+    if p.suffix == ".csv":
+        df.to_csv(p)
+    elif p.suffix in {".xls", ".xlsx"}:
+        df.to_excel(p)
+    elif p.suffix == ".json":
+        df.to_json(p, orient="records", indent=2)
+    else:
+        raise ValueError(f"Unsupported export format: {p.suffix}")
+
+

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(REPO_ROOT / "scripts"))
+
+from metrics import accuracy_metrics, control_metrics, computational_metrics
+
+
+def test_accuracy_metrics_basic():
+    true_p = [10.0, 20.0]
+    pred_p = [9.0, 21.0]
+    true_c = [0.5, 0.4]
+    pred_c = [0.45, 0.6]
+    df = accuracy_metrics(true_p, pred_p, true_c, pred_c)
+    assert np.isclose(df.loc["Mean Absolute Error (MAE)", "Pressure (m)"], 1.0)
+    assert np.isclose(df.loc["Mean Absolute Error (MAE)", "Chlorine (mg/L)"], 0.125)
+    assert np.isclose(df.loc["Maximum Error", "Pressure (m)"], 1.0)
+    assert np.isclose(df.loc["Maximum Error", "Chlorine (mg/L)"], 0.2)
+
+
+def test_control_metrics_basic():
+    min_p = [30.0, 10.0, 25.0]
+    min_c = [0.3, 0.1, 0.4]
+    energy = [1.0, 2.0, 3.0]
+    df = control_metrics(min_p, min_c, energy, p_min=20.0, c_min=0.2)
+    assert df.loc["Pressure Constraint Violations (hrs)", "Value"] == 1
+    assert df.loc["Chlorine Constraint Violations (hrs)", "Value"] == 1
+    assert np.isclose(df.loc["Total Pump Energy (kWh)", "Value"], 6.0)
+
+
+def test_computational_metrics_basic():
+    inf = [0.01, 0.02]
+    opt = [0.1, 0.12]
+    df = computational_metrics(inf, opt)
+    assert np.isclose(df.loc["Inference Time per Simulation Step", "Average Time (ms)"], 15.0)
+    assert np.isclose(df.loc["Optimization Time per Control Step", "Average Time (ms)"], 110.0)


### PR DESCRIPTION
## Summary
- add `metrics.py` module with helper functions for computing accuracy, control and computational metrics
- provide `export_table` helper for writing tables to CSV/Excel/JSON
- include tests for the new metrics
- document metric reporting utilities in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850455fcc64832496bd34c4d0a7c8d7