### PR TITLE
Ensure scatter plots use un-normalized targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ create this folder if it does not yet exist. After each training run
 EPANET results: ``pred_vs_actual_pressure_<run>.png`` and
 ``pred_vs_actual_chlorine_<run>.png``.
 When normalization is enabled (the default) the test data is scaled using the
-training statistics and the predictions are transformed back to physical units
-before plotting.
+training statistics. During evaluation both predictions **and** the
+corresponding ground truth labels are transformed back to physical units before
+plotting.
 
 The script automatically detects which format is provided and loads the data
 accordingly. When using the matrix format, supply the path to the shared

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1328,6 +1328,7 @@ def main(args: argparse.Namespace):
                         y_std = model.y_std.to(node_pred.device)
                         y_mean = model.y_mean.to(node_pred.device)
                         node_pred = node_pred * y_std + y_mean
+                        Y_node = Y_node * y_std + y_mean
                     preds_p.extend(node_pred[..., 0].cpu().numpy().ravel())
                     preds_c.extend(node_pred[..., 1].cpu().numpy().ravel())
                     true_p.extend(Y_node[..., 0].cpu().numpy().ravel())
@@ -1340,10 +1341,13 @@ def main(args: argparse.Namespace):
                         y_std = model.y_std.to(out.device)
                         y_mean = model.y_mean.to(out.device)
                         out = out * y_std + y_mean
+                        batch_y = batch.y * y_std + y_mean
+                    else:
+                        batch_y = batch.y
                     preds_p.extend(out[:, 0].cpu().numpy())
                     preds_c.extend(out[:, 1].cpu().numpy())
-                    true_p.extend(batch.y[:, 0].cpu().numpy())
-                    true_c.extend(batch.y[:, 1].cpu().numpy())
+                    true_p.extend(batch_y[:, 0].cpu().numpy())
+                    true_c.extend(batch_y[:, 1].cpu().numpy())
         if preds_p:
             preds_p = np.array(preds_p)
             preds_c = np.array(preds_c)


### PR DESCRIPTION
## Summary
- inverse-transform ground truth values during test evaluation
- clarify normalization behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685075a9c72c83248c9eeead6bfae147