### PR TITLE
Enable physics losses by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy 
     --early-stop-patience 5 --edge-index-path data/edge_index.npy \
     --inp-path CTown.inp
 ```
+To disable the physics penalties pass ``--no-physics-loss``.
 
 For large graphs you can reduce memory usage by training on subgraphs.
 Passing ``--cluster-batch-size <N>`` partitions the network into clusters of
@@ -74,12 +75,12 @@ nodes and their neighbors on-the-fly instead of deterministic clusters.
 During inference on very large networks the same clusters can be evaluated
 sequentially to keep memory usage low.
 
-Use the ``--physics_loss`` flag to enable a physics-informed penalty that
-encourages mass conservation of predicted flows.  This adds a lightweight loss
-term based on Kirchhoff's law as described by Ashraf et al. (AAAI 2024).
-An additional ``--pressure_loss`` option enforces pressure-headloss
-consistency using the Hazen--Williams equation.  The weights of both physics
-terms can be tuned via ``--w_mass`` and ``--w_head``.
+A physics-informed mass balance penalty is applied by default to encourage
+conservation of predicted flows.  Disable it with ``--no-physics-loss`` if
+necessary.  An additional ``--pressure_loss`` option enforces
+pressure–headloss consistency using the Hazen--Williams equation.  The
+relative importance of both penalties can be tuned via ``--w_mass`` and
+``--w_head``.
 
 The trained model now supports validation loss tracking and early stopping.
 Normalization is applied automatically so the ``--normalize`` flag is optional.

--- a/models/loss_utils.py
+++ b/models/loss_utils.py
@@ -71,7 +71,7 @@ def pressure_headloss_consistency_loss(
         attr = edge_attr
 
     length = attr[:, 0]
-    diam = attr[:, 1]
+    diam = attr[:, 1].clamp(min=1e-6)
     rough = attr[:, 2].clamp(min=1e-6)
 
     # Flatten prediction tensors so the first dimension represents the batch

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1547,9 +1547,17 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--physics_loss",
+        dest="physics_loss",
         action="store_true",
-        help="Add mass conservation loss to training",
+        help="Enable mass conservation loss (default)",
     )
+    parser.add_argument(
+        "--no-physics-loss",
+        dest="physics_loss",
+        action="store_false",
+        help="Disable mass conservation loss",
+    )
+    parser.set_defaults(physics_loss=True)
     parser.add_argument(
         "--pressure_loss",
         action="store_true",

--- a/tests/test_physics_training.py
+++ b/tests/test_physics_training.py
@@ -1,0 +1,66 @@
+import numpy as np
+import torch
+from torch.utils.data import DataLoader as TorchLoader
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import (
+    SequenceDataset,
+    MultiTaskGNNSurrogate,
+    train_sequence,
+)
+
+
+def test_train_sequence_with_physics_losses():
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    edge_attr = torch.tensor(
+        [[1.0, 0.5, 100.0], [1.0, 0.5, 100.0]], dtype=torch.float32
+    )
+    T = 2
+    N = 2
+    E = 2
+    X = np.ones((1, T, N, 4), dtype=np.float32)
+    Y = np.array(
+        [
+            {
+                "node_outputs": np.zeros((T, N, 2), dtype=np.float32),
+                "edge_outputs": np.zeros((T, E), dtype=np.float32),
+                "pump_energy": np.zeros((T, 1), dtype=np.float32),
+            }
+        ],
+        dtype=object,
+    )
+    ds = SequenceDataset(X, Y, edge_index.numpy(), edge_attr.numpy())
+    loader = TorchLoader(ds, batch_size=1)
+    model = MultiTaskGNNSurrogate(
+        in_channels=4,
+        hidden_channels=8,
+        edge_dim=3,
+        node_output_dim=2,
+        edge_output_dim=1,
+        energy_output_dim=1,
+        num_layers=2,
+        use_attention=False,
+        gat_heads=1,
+        dropout=0.0,
+        residual=False,
+        rnn_hidden_dim=4,
+    )
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_tuple = train_sequence(
+        model,
+        loader,
+        ds.edge_index,
+        ds.edge_attr,
+        edge_attr,
+        None,
+        None,
+        opt,
+        torch.device("cpu"),
+        physics_loss=True,
+        pressure_loss=True,
+    )
+    # mass and head losses should be finite numbers
+    assert torch.isfinite(torch.tensor(loss_tuple[4]))
+    assert torch.isfinite(torch.tensor(loss_tuple[5]))


### PR DESCRIPTION
## Summary
- enable physics informed loss by default and add `--no-physics-loss`
- avoid zero diameter in headloss penalty
- document new behaviour in README
- add regression test covering mass balance and headloss penalties

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/ --seed 123`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --x-val-path data/X_val.npy --y-val-path data/Y_val.npy --epochs 15 --batch-size 16 --inp-path CTown.inp --output models/gnn_surrogate_long.pth`
- `python scripts/experiments_validation.py --model models/gnn_surrogate_long_20250617_191515.pth --inp CTown.inp`
- `python scripts/mpc_control.py --horizon 6 --iterations 5 --feedback-interval 24`


------
https://chatgpt.com/codex/tasks/task_e_6851bbd740708324be29fa3ddbffafae