### PR TITLE
Fix metrics import path

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,9 +4,15 @@ from pathlib import Path
 import numpy as np
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.append(str(REPO_ROOT / "scripts"))
+# Add the repository root so the `scripts` package can be imported when
+# running the tests directly or through CI.
+sys.path.append(str(REPO_ROOT))
 
-from metrics import accuracy_metrics, control_metrics, computational_metrics
+from scripts.metrics import (
+    accuracy_metrics,
+    control_metrics,
+    computational_metrics,
+)
 
 
 def test_accuracy_metrics_basic():


### PR DESCRIPTION
## Summary
- update `tests/test_metrics.py` to import metrics via the `scripts` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ce0acedc8324aa2c78e3ddf57eac