### PR TITLE
Fix HydroConv edge type handling

### DIFF
--- a/tests/test_validate_surrogate.py
+++ b/tests/test_validate_surrogate.py
@@ -21,7 +21,7 @@ class DummyModel(torch.nn.Module):
         self.y_mean = None
         self.y_std = torch.ones(1)
 
-    def forward(self, x, edge_index, edge_attr=None):
+    def forward(self, x, edge_index, edge_attr=None, node_types=None, edge_types=None):
         return torch.zeros(x.size(0), self.out_dim, device=x.device)
 
 def test_validate_surrogate_accepts_tuple():
@@ -35,7 +35,15 @@ def test_validate_surrogate_accepts_tuple():
     res = sim.run_sim(str(TEMP_DIR / "temp"))
     model = DummyModel().to(device)
     metrics, arr, times = validate_surrogate(
-        model, edge_index, None, wn, [(res, {})], device, "test"
+        model,
+        edge_index,
+        None,
+        wn,
+        [(res, {})],
+        device,
+        "test",
+        torch.tensor(node_types, dtype=torch.long),
+        torch.tensor(edge_types, dtype=torch.long),
     )
     assert "pressure_rmse" in metrics
     assert arr.shape[1] == len(wn.node_name_list)


### PR DESCRIPTION
## Summary
- configure EnhancedGNNEncoder with node/edge type counts
- support typed weights when loading checkpoints in MPC
- pass type tensors during validation
- update unit test for new signature

## Testing
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/ --seed 0`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 1 --batch-size 4 --x-val-path data/X_val.npy --y-val-path data/Y_val.npy --normalize --run-name test_run`
- `python scripts/experiments_validation.py --model models/gnn_surrogate_test_run.pth --inp CTown.inp --test-pkl data/test_results_list.pkl --iterations 1 --horizon 1 --feedback-interval 1 --run-name testrun`
- `python scripts/mpc_control.py --horizon 1 --iterations 1 --feedback-interval 1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d3fdb5008324913e1c0ce55c07b5