### PR TITLE
Handle tank nodes separately

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1014,7 +1014,9 @@ def main(args: argparse.Namespace):
     edge_attr_raw = torch.tensor(edge_attr, dtype=torch.float32)
     edge_types = build_edge_type(wn, edge_index_np)
     node_types = build_node_type(wn)
-    num_node_types = int(np.max(node_types)) + 1
+    # Always allocate a distinct node type for tanks even if they are absent
+    # from the network to ensure ``HydroConv`` learns a dedicated transform.
+    num_node_types = max(int(np.max(node_types)) + 1, 2)
     num_edge_types = int(np.max(edge_types)) + 1
     edge_mean, edge_std = compute_edge_attr_stats(edge_attr)
     X_raw = np.load(args.x_path, allow_pickle=True)


### PR DESCRIPTION
## Summary
- ensure at least two node types when setting up GNN training

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 2 --output-dir data/`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 10 --x-val-path dummy --y-val-path dummy`
- `python scripts/experiments_validation.py --model models/gnn_surrogate_20250617_213808.pth --inp CTown.inp --test-pkl data/test_results_list.pkl`
- `python scripts/mpc_control.py --horizon 3 --iterations 2 --no-jit`

------
https://chatgpt.com/codex/tasks/task_e_6851da634054832496b06a5c572d6891