### PR TITLE
Clip pressures in validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,11 @@ running the MPC controller.  The validation script executes a 24‑hour
 simulation with EPANET feedback applied every hour (``--feedback-interval`` is
 ``1`` by default) which keeps predictions from the surrogate model from
 diverging over long horizons.  It now also reports mean absolute error (MAE)
-and the maximum absolute error for pressure and chlorine.  Predictions and
-ground truth are denormalized and chlorine values are exponentiated so the
-resulting errors are reported in physical units.  All metrics are written to
+ and the maximum absolute error for pressure and chlorine.  Predictions and
+ ground truth are denormalized and chlorine values are exponentiated so the
+ resulting errors are reported in physical units.  Pressures below 5 m are
+ clipped to this lower bound during validation so metrics match the training
+ distribution.  All metrics are written to
 ``logs/surrogate_metrics.json`` for reproducibility.
 
 ## Running MPC control

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -246,7 +246,7 @@ def validate_surrogate(
             if isinstance(res, tuple):
                 res = res[0]
 
-            pressures_df = res.node["pressure"]
+            pressures_df = res.node["pressure"].clip(lower=5.0)
             chlorine_df = res.node["quality"]
             demand_df = res.node.get("demand")
             pump_df = res.link["setting"][wn.pump_name_list]

--- a/tests/test_validate_surrogate.py
+++ b/tests/test_validate_surrogate.py
@@ -47,3 +47,31 @@ def test_validate_surrogate_accepts_tuple():
     )
     assert "pressure_rmse" in metrics
     assert arr.shape[1] == len(wn.node_name_list)
+
+
+def test_validate_surrogate_clips_low_pressure():
+    device = torch.device('cpu')
+    wn, node_to_index, pump_names, edge_index, node_types, edge_types = load_network('CTown.inp')
+    wn.options.time.duration = 2 * 3600
+    wn.options.time.hydraulic_timestep = 3600
+    wn.options.time.quality_timestep = 3600
+    wn.options.time.report_timestep = 3600
+    sim = wntr.sim.EpanetSimulator(wn)
+    res = sim.run_sim(str(TEMP_DIR / "temp_clip"))
+    # create an unrealistic negative pressure for the next timestep
+    res.node["pressure"].iloc[1] = -1.0
+    model = DummyModel().to(device)
+    metrics, arr, times = validate_surrogate(
+        model,
+        edge_index,
+        None,
+        wn,
+        [res],
+        device,
+        "test_clip",
+        torch.tensor(node_types, dtype=torch.long),
+        torch.tensor(edge_types, dtype=torch.long),
+    )
+    # clipped to 5 m -> prediction (0) minus 5 yields -5
+    assert arr.shape[0] >= 1
+    assert abs(arr[0, 0] + 5.0) < 1e-6


### PR DESCRIPTION
## Summary
- clip pressures to 5 m during surrogate validation to match training
- document this behavior in the README
- add regression test for the new clipping logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e9d6f60483249ca359e90baadd2a