### PR TITLE
Add graceful Ctrl+C handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Normalization is applied automatically so the ``--normalize`` flag is optional.
 Each run is stored with a unique timestamp to avoid overwriting previous
 checkpoints.  Normalization statistics are saved alongside the weights and
 automatically applied by the inference scripts.
+You may cancel training early with ``Ctrl+C``.  The loop exits gracefully,
+keeping the best model on disk and producing the usual plots.
 
 To achieve good predictive accuracy the surrogate should be trained on a large
 collection of EPANET simulations.  The data generation script accepts a

--- a/tests/test_interrupt_handler.py
+++ b/tests/test_interrupt_handler.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import handle_keyboard_interrupt
+
+
+def test_handle_keyboard_interrupt(capsys):
+    handle_keyboard_interrupt("foo/bar.pth")
+    captured = capsys.readouterr()
+    assert "Training interrupted" in captured.out
+    assert "foo/bar.pth" in captured.out


### PR DESCRIPTION
## Summary
- catch SIGINT during training and stop after the current epoch
- print a message indicating the best checkpoint is kept
- document early Ctrl+C handling
- test the interrupt message helper

## Testing
- `pytest tests/test_interrupt_handler.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_68523be50a4483248ccddcc7ecc1cbb3