### PR TITLE
Add temporal attention and tank dynamics

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Optionally, the same convolution layer can be reused for all message passing
 steps by passing ``--share-weights`` to ``train_gnn.py``. This reduces the
 number of parameters and can speed up optimisation.
 
+The surrogate now applies temporal self-attention after the LSTM to re-weight
+each node's history and updates tank pressures explicitly from predicted
+flows. Tank levels are reset automatically at the start of each MPC run.
+
 Example usage:
 
 ```bash

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -900,6 +900,9 @@ def propagate_with_surrogate(
         b_node_type = node_types.repeat(batch_size) if node_types is not None else None
         b_edge_type = edge_types.repeat(batch_size) if edge_types is not None else None
 
+    if hasattr(model, "reset_tank_levels"):
+        model.reset_tank_levels(batch_size, device)
+
     with torch.no_grad():
         for t, u in enumerate(control_seq):
             if u.dim() == 1:
@@ -996,6 +999,9 @@ def simulate_closed_loop(
         .pin_memory() if torch.cuda.is_available() else torch.from_numpy(c_arr)
     )
     cur_c = cur_c.to(device, non_blocking=True)
+
+    if hasattr(model, "reset_tank_levels"):
+        model.reset_tank_levels(1, device)
 
     base_demands = {
         j: wn.get_node(j).demand_timeseries_list[0].base_value

--- a/tests/test_recurrent_forward.py
+++ b/tests/test_recurrent_forward.py
@@ -36,7 +36,7 @@ def test_multitask_gnn_forward_shapes():
         gat_heads=1,
         dropout=0.0,
         residual=False,
-        rnn_hidden_dim=5,
+        rnn_hidden_dim=8,
     )
     X_seq = torch.ones(1, 3, 2, 2)
     out = model(X_seq, edge_index, edge_attr)

--- a/tests/test_tank_dynamics.py
+++ b/tests/test_tank_dynamics.py
@@ -1,0 +1,32 @@
+import torch
+from scripts.train_gnn import MultiTaskGNNSurrogate
+
+def test_tank_pressure_update():
+    edge_index = torch.tensor([[0],[1]], dtype=torch.long)
+    edge_attr = torch.ones(1,3)
+    model = MultiTaskGNNSurrogate(
+        in_channels=2,
+        hidden_channels=4,
+        edge_dim=3,
+        node_output_dim=2,
+        edge_output_dim=1,
+        energy_output_dim=1,
+        num_layers=1,
+        use_attention=False,
+        gat_heads=1,
+        dropout=0.0,
+        residual=False,
+        rnn_hidden_dim=4,
+    )
+    # constant decoders so flows=1 and base pressure=0
+    model.node_decoder.weight.data.zero_()
+    model.node_decoder.bias.data.zero_()
+    model.edge_decoder.weight.data.zero_()
+    model.edge_decoder.bias.data.fill_(1.0)
+    model.tank_indices = torch.tensor([0])
+    model.tank_areas = torch.tensor([1.0])
+    model.tank_edges = [torch.tensor([0])]
+    model.tank_signs = [torch.tensor([1.0])]
+    X = torch.zeros(1,1,2,2)
+    out = model(X, edge_index, edge_attr)
+    assert torch.isclose(out['node_outputs'][0,0,0,0], torch.tensor(3600.0))


### PR DESCRIPTION
## Summary
- enhance `MultiTaskGNNSurrogate` with temporal attention
- track tank levels and update tank node pressures from predicted flows
- reset tank levels in training and MPC routines
- store tank geometry on model creation
- document new features in `README`
- update recurrent forward tests and add a tank dynamics test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685320e1814c8324a81c1bb6e4bb6cf4