### PR TITLE
Fix chlorine scatter scaling

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -507,6 +507,11 @@ def predicted_vs_actual_scatter(
     tc = _to_numpy(true_chlorine)
     pc = _to_numpy(pred_chlorine)
 
+    # chlorine values are stored in log space (log1p). Convert back to mg/L
+    # before plotting so the axes reflect physical units.
+    tc = np.expm1(tc)
+    pc = np.expm1(pc)
+
     fig, axes = plt.subplots(1, 2, figsize=(10, 4))
 
     axes[0].scatter(tp, pp, label="Pressure", color="tab:blue", alpha=0.7)


### PR DESCRIPTION
## Summary
- display chlorine scatter axes in mg/L by exponentiating log1p values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685487e6491883248b95d1a15a4f8a65