### PR TITLE
Fix tank level initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ number of parameters and can speed up optimisation.
 
 The surrogate now applies temporal self-attention after the LSTM to re-weight
 each node's history and updates tank pressures explicitly from predicted
-flows. Tank levels are reset automatically at the start of each MPC run.
+flows. Before predicting a sequence the current tank volumes must be passed to
+``model.reset_tank_levels`` which the MPC script handles automatically.
 
 Example usage:
 


### PR DESCRIPTION
## Summary
- let `reset_tank_levels` accept initial volumes
- initialize tank levels from the current state during training and MPC
- note the new initialization requirement in the README

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 1 --batch-size 2`
- `python scripts/mpc_control.py --horizon 2 --iterations 1 --no-jit`

------
https://chatgpt.com/codex/tasks/task_e_6855688d01e88324a8f59de137411453