### PR TITLE
Increase physics loss defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ python scripts/train_gnn.py \
     --epochs 100 --batch-size 32 --hidden-dim 64 --num-layers 4 \
     --dropout 0.1 --residual --early-stop-patience 10
 ```
-Pressure–headloss consistency is now enforced by default.  Pass
-``--no-pressure_loss`` if this coupling should be disabled.  To remove the
-mass balance penalty use ``--no-physics-loss``.
+Pressure–headloss consistency is now enforced by default with a unit weight.
+Pass ``--no-pressure_loss`` if this coupling should be disabled.  To remove the
+mass balance penalty (also weighted by ``1.0`` by default) use ``--no-physics-loss``.
 
 For large graphs you can reduce memory usage by training on subgraphs.
 Passing ``--cluster-batch-size <N>`` partitions the network into clusters of
@@ -99,9 +99,10 @@ conservation of predicted flows.  Because each pipe appears twice in the graph
 (forward and reverse), the loss divides the imbalance by two so that equal and
 opposite flows cancel correctly.  Disable the term with ``--no-physics-loss``
 if necessary.  ``--pressure_loss`` is enabled by default to enforce
-pressure–headloss consistency via the Hazen--Williams equation.  The
-relative importance of the penalties can be tuned via ``--w_mass``,
-``--w_head`` and the new ``--w_edge`` coefficient controlling the flow loss.
+pressure–headloss consistency via the Hazen--Williams equation.  By default
+both penalties have a weight of ``1.0``. The relative importance can be tuned via
+``--w_mass`` and ``--w_head`` along with the ``--w_edge`` coefficient controlling
+the flow loss.
 
 The trained model now supports validation loss tracking and early stopping.
 Normalization is applied automatically so the ``--normalize`` flag is optional.

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -910,8 +910,8 @@ def train_sequence(
     device,
     physics_loss: bool = False,
     pressure_loss: bool = False,
-    w_mass: float = 0.5,
-    w_head: float = 0.1,
+    w_mass: float = 1.0,
+    w_head: float = 1.0,
     w_edge: float = 1.0,
 ) -> tuple[float, float, float, float, float, float]:
     model.train()
@@ -1006,8 +1006,8 @@ def evaluate_sequence(
     device,
     physics_loss: bool = False,
     pressure_loss: bool = False,
-    w_mass: float = 0.5,
-    w_head: float = 0.1,
+    w_mass: float = 1.0,
+    w_head: float = 1.0,
     w_edge: float = 1.0,
 ) -> tuple[float, float, float, float, float]:
     model.eval()
@@ -1734,13 +1734,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--w_mass",
         type=float,
-        default=0.5,
+        default=1.0,
         help="Weight of the mass conservation loss term",
     )
     parser.add_argument(
         "--w_head",
         type=float,
-        default=0.1,
+        default=1.0,
         help="Weight of the head loss consistency term",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- raise mass balance and headloss weights to 1.0
- document new defaults in README

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/test_small --seed 1`
- `python scripts/train_gnn.py --x-path data/test_small/X_train.npy --y-path data/test_small/Y_train.npy --x-val-path data/test_small/X_val.npy --y-val-path data/test_small/Y_val.npy --edge-index-path data/test_small/edge_index.npy --inp-path CTown.inp --epochs 2 --batch-size 2 --run-name quick_test --w_mass 1.0 --w_head 1.0`


------
https://chatgpt.com/codex/tasks/task_e_68556c933ff48324ab5a22d0ddea79d5