### PR TITLE
Refactor energy handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,9 @@ loading the EPANET network (``--inp-path``).  If the dimension does not match
 continuous targets are predicted per node.
 
 When datasets were generated with ``scripts/data_generation.py`` after this
-update, each time step also stores pipe flow rates and pump energy
-consumption. ``train_gnn.py`` automatically detects such multi-task arrays and
-switches to a ``MultiTaskGNNSurrogate`` model which optimizes a weighted loss
-over all targets.
+update, each time step also stores pipe flow rates. ``train_gnn.py``
+automatically detects such multi-task arrays and switches to a
+``MultiTaskGNNSurrogate`` model which optimizes node and edge losses.
 
 The GNN architecture has been refactored to support **heterogeneous graphs**.
 Node embeddings are now conditioned on the component type (junction, tank,
@@ -192,10 +191,9 @@ inference.  Use ``--no-jit`` to disable this.  ``propagate_with_surrogate`` can
 also accept lists of pressure/chlorine dictionaries to evaluate multiple
 scenarios in parallel.
 
-Pump energy usage in the MPC cost function is estimated from the surrogate
-predictions. When the model was trained with ``pump_energy`` targets these
-predicted energy values are penalised directly; otherwise the controller falls
-back to the previous ``u[t]**2`` term.
+Pump energy usage in the MPC cost function is computed from predicted flows and
+head gains using the EPANET power equations. This removes the need for a
+dedicated energy output and ties the optimisation to physical principles.
 
 By default the controller loads the most recent ``.pth`` file found in the
 ``models`` directory so retraining will automatically use the newest weights.

--- a/tests/test_load_surrogate.py
+++ b/tests/test_load_surrogate.py
@@ -82,10 +82,8 @@ def test_load_surrogate_handles_multitask_norm(tmp_path):
         y_std_node=np.ones(1),
         y_mean_edge=np.zeros(1),
         y_std_edge=np.ones(1),
-        y_mean_energy=np.zeros(1),
-        y_std_energy=np.ones(1),
     )
     model = load_surrogate_model(torch.device('cpu'), path=str(path), use_jit=False)
     assert model.y_mean is not None
-    assert model.y_mean_energy is not None
-    assert model.y_std_energy is not None
+    assert model.y_mean_energy is None
+    assert model.y_std_energy is None

--- a/tests/test_physics_training.py
+++ b/tests/test_physics_training.py
@@ -26,7 +26,6 @@ def test_train_sequence_with_physics_losses():
             {
                 "node_outputs": np.zeros((T, N, 2), dtype=np.float32),
                 "edge_outputs": np.zeros((T, E), dtype=np.float32),
-                "pump_energy": np.zeros((T, 1), dtype=np.float32),
             }
         ],
         dtype=object,
@@ -39,7 +38,6 @@ def test_train_sequence_with_physics_losses():
         edge_dim=3,
         node_output_dim=2,
         edge_output_dim=1,
-        energy_output_dim=1,
         num_layers=2,
         use_attention=False,
         gat_heads=1,
@@ -62,5 +60,5 @@ def test_train_sequence_with_physics_losses():
         pressure_loss=True,
     )
     # mass and head losses should be finite numbers
+    assert torch.isfinite(torch.tensor(loss_tuple[3]))
     assert torch.isfinite(torch.tensor(loss_tuple[4]))
-    assert torch.isfinite(torch.tensor(loss_tuple[5]))

--- a/tests/test_recurrent_forward.py
+++ b/tests/test_recurrent_forward.py
@@ -30,7 +30,6 @@ def test_multitask_gnn_forward_shapes():
         edge_dim=3,
         node_output_dim=2,
         edge_output_dim=1,
-        energy_output_dim=1,
         num_layers=2,
         use_attention=False,
         gat_heads=1,
@@ -42,4 +41,3 @@ def test_multitask_gnn_forward_shapes():
     out = model(X_seq, edge_index, edge_attr)
     assert out['node_outputs'].shape == (1, 3, 2, 2)
     assert out['edge_outputs'].shape == (1, 3, 2, 1)
-    assert out['pump_energy'].shape == (1, 3, 1)

--- a/tests/test_tank_dynamics.py
+++ b/tests/test_tank_dynamics.py
@@ -10,7 +10,6 @@ def test_tank_pressure_update():
         edge_dim=3,
         node_output_dim=2,
         edge_output_dim=1,
-        energy_output_dim=1,
         num_layers=1,
         use_attention=False,
         gat_heads=1,


### PR DESCRIPTION
## Summary
- compute pump energy from predicted flows and heads in MPC
- drop energy decoder and training loss
- update surrogate loader and dataset logic
- adjust tests and docs for physics-based energy

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 2 --output-dir data/ --sequence-length 1`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 1 --batch-size 1 --normalize --x-val-path '' --y-val-path ''`
- `python scripts/mpc_control.py --horizon 2 --iterations 5 --feedback-interval 24 --no-jit`


------
https://chatgpt.com/codex/tasks/task_e_685571c58cac83248761be17b60b6b00