### PR TITLE
Adjust mass loss for tanks

### DIFF
--- a/models/loss_utils.py
+++ b/models/loss_utils.py
@@ -9,6 +9,7 @@ def compute_mass_balance_loss(
     edge_index: torch.Tensor,
     node_count: int,
     demand: Optional[torch.Tensor] = None,
+    node_type: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Return mean squared node imbalance for predicted flows.
 
@@ -22,6 +23,9 @@ def compute_mass_balance_loss(
         Edge index tensor of shape ``[2, E]`` defining flow directions.
     node_count : int
         Total number of nodes in the graph.
+    node_type : torch.Tensor, optional
+        Integer node type array identifying tanks (value ``1``). Tank nodes
+        are ignored in the imbalance calculation when provided.
     """
     if pred_flows.dim() == 1:
         flows = pred_flows.unsqueeze(1)
@@ -45,6 +49,10 @@ def compute_mass_balance_loss(
     if demand is not None:
         dem = demand.reshape(node_count, -1)
         node_balance[:, : dem.shape[1]] -= dem
+
+    if node_type is not None:
+        mask = node_type.reshape(node_count) == 1
+        node_balance[mask] = 0
 
     return torch.mean(node_balance ** 2)
 

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -323,6 +323,7 @@ def validate_surrogate(
                         flow_pred,
                         edge_index,
                         len(wn.node_name_list),
+                        node_type=node_types_tensor,
                     )
                     mass_total += mass_loss.item()
                     mass_count += 1

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -966,6 +966,7 @@ def train_sequence(
                     edge_index.to(device),
                     node_count,
                     demand=demand_mb,
+                    node_type=node_type,
                 )
             else:
                 mass_loss = torch.tensor(0.0, device=device)
@@ -1072,6 +1073,7 @@ def evaluate_sequence(
                         edge_index.to(device),
                         node_count,
                         demand=demand_mb,
+                        node_type=node_type,
                     )
                 else:
                     mass_loss = torch.tensor(0.0, device=device)

--- a/tests/test_mass_balance.py
+++ b/tests/test_mass_balance.py
@@ -26,3 +26,14 @@ def test_mass_balance_with_demand():
     demand = torch.tensor([1.0, 0.0])
     loss = compute_mass_balance_loss(flows, edge_index, 2, demand=demand)
     assert torch.allclose(loss, torch.tensor(2.5))
+
+
+def test_mass_balance_ignore_tank_nodes():
+    """Tank nodes should not contribute to mass loss."""
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    flows = torch.tensor([1.0, -1.0])
+    node_type = torch.tensor([0, 1])
+    loss = compute_mass_balance_loss(
+        flows, edge_index, 2, node_type=node_type
+    )
+    assert torch.allclose(loss, torch.tensor(0.5))


### PR DESCRIPTION
## Summary
- allow `compute_mass_balance_loss` to skip tank nodes
- propagate node types to mass balance loss during training and evaluation
- track tank-free mass balance in experiment validation
- test ignoring tanks in the mass loss calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ab5bd4708324b8d0b9e72e091392