### PR TITLE
Clamp outputs and add weight decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,15 @@ python scripts/train_gnn.py \
     --x-val-path data/X_val.npy --y-val-path data/Y_val.npy \
     --edge-index-path data/edge_index.npy --inp-path CTown.inp \
     --epochs 100 --batch-size 32 --hidden-dim 64 --num-layers 4 \
-    --dropout 0.1 --residual --early-stop-patience 10
+    --dropout 0.1 --residual --early-stop-patience 10 \
+    --weight-decay 1e-5
 ```
 Pressure–headloss consistency is now enforced by default with a unit weight.
 Pass ``--no-pressure_loss`` if this coupling should be disabled.  To remove the
 mass balance penalty (also weighted by ``1.0`` by default) use ``--no-physics-loss``.
+The surrogate clamps predicted pressures and chlorine concentrations to
+non-negative values and applies L2 regularization controlled by
+``--weight-decay`` (default ``1e-5``) to avoid degenerate solutions.
 
 For large graphs you can reduce memory usage by training on subgraphs.
 Passing ``--cluster-batch-size <N>`` partitions the network into clusters of

--- a/tests/test_output_clamp.py
+++ b/tests/test_output_clamp.py
@@ -1,0 +1,54 @@
+import torch
+from scripts.train_gnn import RecurrentGNNSurrogate, MultiTaskGNNSurrogate
+
+
+def test_recurrent_output_clamp():
+    edge_index = torch.tensor([[0], [1]], dtype=torch.long)
+    edge_attr = torch.ones(1, 3)
+    model = RecurrentGNNSurrogate(
+        in_channels=2,
+        hidden_channels=4,
+        edge_dim=3,
+        output_dim=2,
+        num_layers=1,
+        use_attention=False,
+        gat_heads=1,
+        dropout=0.0,
+        residual=False,
+        rnn_hidden_dim=4,
+    )
+    model.decoder.weight.data.zero_()
+    model.decoder.bias.data.fill_(-1.0)
+    X = torch.zeros(1, 1, 2, 2)
+    out = model(X, edge_index, edge_attr)
+    assert torch.all(out >= 0)
+
+
+def test_multitask_output_clamp_and_tank_level():
+    edge_index = torch.tensor([[0], [1]], dtype=torch.long)
+    edge_attr = torch.ones(1, 3)
+    model = MultiTaskGNNSurrogate(
+        in_channels=2,
+        hidden_channels=4,
+        edge_dim=3,
+        node_output_dim=2,
+        edge_output_dim=1,
+        num_layers=1,
+        use_attention=False,
+        gat_heads=1,
+        dropout=0.0,
+        residual=False,
+        rnn_hidden_dim=4,
+    )
+    model.node_decoder.weight.data.zero_()
+    model.node_decoder.bias.data.fill_(0.0)
+    model.edge_decoder.weight.data.zero_()
+    model.edge_decoder.bias.data.fill_(-1.0)
+    model.tank_indices = torch.tensor([0])
+    model.tank_areas = torch.tensor([1.0])
+    model.tank_edges = [torch.tensor([0])]
+    model.tank_signs = [torch.tensor([1.0])]
+    X = torch.zeros(1, 1, 2, 2)
+    out = model(X, edge_index, edge_attr)
+    assert torch.all(out['node_outputs'] >= 0)
+    assert torch.all(model.tank_levels >= 0)


### PR DESCRIPTION
## Summary
- clamp pressure and chlorine predictions in GNN models
- prevent tank levels from dropping below zero
- add weight decay option in training script
- document new option and clamping behaviour in README
- test output clamping for single and multi-task models

## Testing
- `PYTHONPATH=$PWD pytest tests/test_output_clamp.py -q`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595e5bd4ac8324bdda3c393757cd6b