### PR TITLE
Fix validation metrics to ignore tank nodes

### DIFF
--- a/tests/test_validate_surrogate.py
+++ b/tests/test_validate_surrogate.py
@@ -3,6 +3,7 @@ import torch
 import wntr
 import sys
 from pathlib import Path
+import numpy as np
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(REPO_ROOT))
@@ -75,3 +76,44 @@ def test_validate_surrogate_clips_low_pressure():
     # clipped to 5 m -> prediction (0) minus 5 yields -5
     assert arr.shape[0] >= 1
     assert abs(arr[0, 0] + 5.0) < 1e-6
+
+
+def test_validate_surrogate_respects_node_mask():
+    """Metrics should ignore nodes marked as tanks/reservoirs."""
+    device = torch.device('cpu')
+    wn, node_to_index, pump_names, edge_index, node_types, edge_types = load_network('CTown.inp')
+    wn.options.time.duration = 2 * 3600
+    wn.options.time.hydraulic_timestep = 3600
+    wn.options.time.quality_timestep = 3600
+    wn.options.time.report_timestep = 3600
+    sim = wntr.sim.EpanetSimulator(wn)
+    res = sim.run_sim(str(TEMP_DIR / "temp_mask"))
+    model = DummyModel().to(device)
+    custom_types = [0] + [1] * (len(node_types) - 1)
+    metrics, arr, times = validate_surrogate(
+        model,
+        edge_index,
+        None,
+        wn,
+        [res],
+        device,
+        "test_mask",
+        torch.tensor(custom_types, dtype=torch.long),
+        torch.tensor(edge_types, dtype=torch.long),
+    )
+    p_df = res.node["pressure"].clip(lower=5.0)
+    c_df = res.node["quality"]
+    vals_p = [p_df.iloc[i + 1, 0] for i in range(len(p_df.index) - 1)]
+    vals_c = [c_df.iloc[i + 1, 0] for i in range(len(c_df.index) - 1)]
+    expected_rmse_p = np.sqrt(np.mean(np.square(vals_p)))
+    expected_mae_p = np.mean(np.abs(vals_p))
+    expected_max_p = np.max(np.abs(vals_p))
+    expected_rmse_c = np.sqrt(np.mean(np.square(vals_c)))
+    expected_mae_c = np.mean(np.abs(vals_c))
+    expected_max_c = np.max(np.abs(vals_c))
+    assert abs(metrics["pressure_rmse"] - expected_rmse_p) < 1e-6
+    assert abs(metrics["pressure_mae"] - expected_mae_p) < 1e-6
+    assert abs(metrics["pressure_max_error"] - expected_max_p) < 1e-6
+    assert abs(metrics["chlorine_rmse"] - expected_rmse_c) < 1e-6
+    assert abs(metrics["chlorine_mae"] - expected_mae_c) < 1e-6
+    assert abs(metrics["chlorine_max_error"] - expected_max_c) < 1e-6


### PR DESCRIPTION
## Summary
- apply junction mask to validation metrics so tank/reservoir nodes are ignored
- test that masked nodes don't affect error statistics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0b2f5e4883248d5cb0741bdb2682