### PR TITLE
Fix output scaling in surrogate validation

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -291,7 +291,15 @@ def validate_surrogate(
                         node_pred = pred
                         flow_pred = None
                 if hasattr(model, "y_mean") and model.y_mean is not None:
-                    node_pred = node_pred * model.y_std + model.y_mean
+                    if isinstance(model.y_mean, dict):
+                        y_mean_node = model.y_mean["node_outputs"].to(node_pred.device)
+                        y_std_node = model.y_std["node_outputs"].to(node_pred.device)
+                        node_pred = node_pred * y_std_node + y_mean_node
+                    else:
+                        node_pred = (
+                            node_pred * model.y_std.to(node_pred.device)
+                            + model.y_mean.to(node_pred.device)
+                        )
                 pred_p = node_pred[:, 0].cpu().numpy()
                 pred_c = node_pred[:, 1].cpu().numpy()
                 y_true_p = pressures_df.iloc[i + 1].to_numpy()


### PR DESCRIPTION
## Summary
- un-normalize node outputs using dict stats when validating
- expand surrogate validation tests for dict-based y_mean

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0dda9a348324bdc39ac53aec9760