### PR TITLE
Fix device mismatch in train_gnn forward pass

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -276,20 +276,20 @@ class RecurrentGNNSurrogate(nn.Module):
         min_p = min_c = 0.0
         if getattr(self, "y_mean", None) is not None:
             if isinstance(self.y_mean, dict):
-                p_mean = self.y_mean["node_outputs"][0]
-                p_std = self.y_std["node_outputs"][0]
+                p_mean = self.y_mean["node_outputs"][0].to(out.device)
+                p_std = self.y_std["node_outputs"][0].to(out.device)
                 if self.y_mean["node_outputs"].numel() > 1:
-                    c_mean = self.y_mean["node_outputs"][1]
-                    c_std = self.y_std["node_outputs"][1]
+                    c_mean = self.y_mean["node_outputs"][1].to(out.device)
+                    c_std = self.y_std["node_outputs"][1].to(out.device)
                 else:
                     c_mean = torch.tensor(0.0, device=out.device)
                     c_std = torch.tensor(1.0, device=out.device)
             else:
-                p_mean = self.y_mean[0]
-                p_std = self.y_std[0]
+                p_mean = self.y_mean[0].to(out.device)
+                p_std = self.y_std[0].to(out.device)
                 if self.y_mean.numel() > 1:
-                    c_mean = self.y_mean[1]
-                    c_std = self.y_std[1]
+                    c_mean = self.y_mean[1].to(out.device)
+                    c_std = self.y_std[1].to(out.device)
                 else:
                     c_mean = torch.tensor(0.0, device=out.device)
                     c_std = torch.tensor(1.0, device=out.device)
@@ -457,20 +457,20 @@ class MultiTaskGNNSurrogate(nn.Module):
         min_p = min_c = 0.0
         if getattr(self, "y_mean", None) is not None:
             if isinstance(self.y_mean, dict):
-                p_mean = self.y_mean["node_outputs"][0]
-                p_std = self.y_std["node_outputs"][0]
+                p_mean = self.y_mean["node_outputs"][0].to(node_pred.device)
+                p_std = self.y_std["node_outputs"][0].to(node_pred.device)
                 if self.y_mean["node_outputs"].numel() > 1:
-                    c_mean = self.y_mean["node_outputs"][1]
-                    c_std = self.y_std["node_outputs"][1]
+                    c_mean = self.y_mean["node_outputs"][1].to(node_pred.device)
+                    c_std = self.y_std["node_outputs"][1].to(node_pred.device)
                 else:
                     c_mean = torch.tensor(0.0, device=node_pred.device)
                     c_std = torch.tensor(1.0, device=node_pred.device)
             else:
-                p_mean = self.y_mean[0]
-                p_std = self.y_std[0]
+                p_mean = self.y_mean[0].to(node_pred.device)
+                p_std = self.y_std[0].to(node_pred.device)
                 if self.y_mean.numel() > 1:
-                    c_mean = self.y_mean[1]
-                    c_std = self.y_std[1]
+                    c_mean = self.y_mean[1].to(node_pred.device)
+                    c_std = self.y_std[1].to(node_pred.device)
                 else:
                     c_mean = torch.tensor(0.0, device=node_pred.device)
                     c_std = torch.tensor(1.0, device=node_pred.device)


### PR DESCRIPTION
## Summary
- ensure normalisation statistics are moved to the same device as the network in both surrogate models
- run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a12dad4a48324a8aca778528c3031