### PR TITLE
Randomize tank initial levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ scenarios may be slightly smaller than requested.
 Set ``--extreme-event-prob`` to inject rare scenarios such as fire flows,
 pump failures or source quality changes.  Scenario labels are stored alongside
 the sequence arrays when ``--sequence-length`` is greater than one.
+Initial tank levels are now drawn from a Gaussian around the values in
+``CTown.inp`` so each scenario begins with slightly different volumes.
 
 To create sequence datasets for the recurrent surrogate specify ``--sequence-length``:
 

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -72,6 +72,17 @@ def _build_randomized_network(
     wn.options.time.report_timestep = 3600
     wn.options.quality.parameter = "CHEMICAL"
 
+    # Randomize initial tank levels while keeping values within the
+    # feasible range.  Sample from a Gaussian centred on the original
+    # value so typical operating conditions remain likely.
+    for tname in wn.tank_name_list:
+        tank = wn.get_node(tname)
+        span = max(tank.max_level - tank.min_level, 1e-6)
+        std = 0.1 * span
+        level = random.gauss(tank.init_level, std)
+        level = min(max(level, tank.min_level), tank.max_level)
+        tank.init_level = level
+
     hours = int(wn.options.time.duration // wn.options.time.hydraulic_timestep)
 
     scale_dict: Dict[str, np.ndarray] = {}

--- a/tests/test_tank_initial_randomization.py
+++ b/tests/test_tank_initial_randomization.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import wntr
+from scripts.data_generation import _build_randomized_network
+
+
+def test_random_initial_tanks():
+    inp = Path(__file__).resolve().parents[1] / "CTown.inp"
+    wn_ref = wntr.network.WaterNetworkModel(str(inp))
+    base_levels = {t: wn_ref.get_node(t).init_level for t in wn_ref.tank_name_list}
+    wn_rand, _, _ = _build_randomized_network(str(inp), 0)
+    changed = False
+    for tname in wn_rand.tank_name_list:
+        tank = wn_rand.get_node(tname)
+        assert tank.min_level <= tank.init_level <= tank.max_level
+        if abs(tank.init_level - base_levels[tname]) > 1e-6:
+            changed = True
+    assert changed, "tank levels should be randomized"


### PR DESCRIPTION
## Summary
- randomize tank initial levels in `_build_randomized_network`
- document this in README
- test that initial tank levels are randomized

## Testing
- `pytest tests/test_tank_initial_randomization.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'epyt')*

------
https://chatgpt.com/codex/tasks/task_e_685aa02c45b08324b584d73b20f7369a