### PR TITLE
Randomize pipe roughness during dataset generation

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -72,6 +72,14 @@ def _build_randomized_network(
     wn.options.time.report_timestep = 3600
     wn.options.quality.parameter = "CHEMICAL"
 
+    # Randomize pipe roughness coefficients (Hazen--Williams C)
+    # to expose the surrogate to varied headloss scenarios.  Each
+    # pipe's base value is scaled by a factor between 0.7 and 1.3.
+    for pname in wn.pipe_name_list:
+        pipe = wn.get_link(pname)
+        base_c = pipe.roughness
+        pipe.roughness = base_c * random.uniform(0.7, 1.3)
+
     # Randomize initial tank levels while keeping values within the
     # feasible range.  Sample from a Gaussian centred on the original
     # value so typical operating conditions remain likely.


### PR DESCRIPTION
## Summary
- vary Hazen--Williams roughness per pipe in `data_generation.py`
- run the unit tests
- run the data generation and training pipeline

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp`

------
https://chatgpt.com/codex/tasks/task_e_685d8c9c4df08324a77c1105e948bb7b