### PR TITLE
Expand demand scaling range for data generation

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -102,8 +102,9 @@ def _build_randomized_network(
         else:
             base_mult = np.array(ts.pattern.multipliers, dtype=float)
         multipliers = base_mult.copy()
-        noise = 1.0 + np.random.normal(0.0, 0.05, size=len(multipliers))
-        multipliers = multipliers * noise
+        # Sample demand multipliers uniformly in [0.8, 1.2] for broader variation
+        scale_factors = np.random.uniform(0.8, 1.2, size=len(multipliers))
+        multipliers = multipliers * scale_factors
         multipliers = np.clip(multipliers, a_min=0.0, a_max=None)
         pat_name = f"{jname}_pat_{idx}"
         wn.add_pattern(pat_name, wntr.network.elements.Pattern(pat_name, multipliers))

--- a/tests/test_demand_scaling.py
+++ b/tests/test_demand_scaling.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import random
+import numpy as np
+import wntr
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.data_generation import _build_randomized_network
+
+
+def test_demand_multiplier_range():
+    inp = Path(__file__).resolve().parents[1] / "CTown.inp"
+
+    base_wn = wntr.network.WaterNetworkModel(str(inp))
+    base_patterns = {}
+    for jname in base_wn.junction_name_list:
+        ts = base_wn.get_node(jname).demand_timeseries_list[0]
+        if ts.pattern is None:
+            base_mult = np.ones(168, dtype=float)
+        else:
+            base_mult = np.array(ts.pattern.multipliers, dtype=float)
+        base_patterns[jname] = base_mult
+
+    random.seed(42)
+    np.random.seed(42)
+    _, scale_dict, _ = _build_randomized_network(str(inp), idx=0)
+
+    for jname, scaled in scale_dict.items():
+        base_mult = base_patterns[jname][: len(scaled)]
+        ratio = scaled / base_mult
+        assert np.all(ratio >= 0.8)
+        assert np.all(ratio <= 1.2)
+


### PR DESCRIPTION
## Summary
- broaden demand scaling to sample uniformly from `[0.8, 1.2]`
- test demand scaling range

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data --seed 3 --num-workers 1`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 1`

------
https://chatgpt.com/codex/tasks/task_e_685d8fad95788324b77dd35fc8b5e6a6