### PR TITLE
Tune training scheduler and loss weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ python scripts/train_gnn.py \
     --dropout 0.1 --residual --early-stop-patience 10 \
     --weight-decay 1e-5
 ```
-Pressure–headloss consistency is now enforced by default with a unit weight.
+Pressure–headloss consistency is now enforced by default with a weight of ``0.5``.
 Pass ``--no-pressure_loss`` if this coupling should be disabled.  To remove the
-mass balance penalty (also weighted by ``1.0`` by default) use ``--no-physics-loss``.
+mass balance penalty (still weighted ``1.0`` by default) use ``--no-physics-loss``.
 The surrogate clamps predicted pressures and chlorine concentrations to
 non-negative values and applies L2 regularization controlled by
 ``--weight-decay`` (default ``1e-5``) to avoid degenerate solutions.
@@ -106,9 +106,10 @@ Reservoirs and tanks are excluded from the mass balance calculation while tank
 pressures are no longer part of the direct MSE loss.  Disable the physics terms
 with ``--no-physics-loss`` if necessary. ``--pressure_loss`` is enabled by
 default to enforce pressure–headloss consistency via the Hazen--Williams
-equation.  By default all penalties have a weight of ``1.0``. The relative
-importance can be tuned via ``--w_mass`` and ``--w_head`` along with the
-``--w_edge`` coefficient controlling the flow loss.
+equation.  The mass and edge penalties keep a default weight of ``1.0`` while
+the headloss term uses ``0.5``. The relative importance can still be tuned via
+``--w_mass`` and ``--w_head`` along with the ``--w_edge`` coefficient
+controlling the flow loss.
 
 The trained model now supports validation loss tracking and early stopping.
 Normalization is applied automatically so the ``--normalize`` flag is optional.

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1580,7 +1580,7 @@ def main(args: argparse.Namespace):
     optimizer = torch.optim.Adam(
         model.parameters(), lr=args.lr, weight_decay=args.weight_decay
     )
-    scheduler = ReduceLROnPlateau(optimizer, mode='min', factor=0.5, patience=3)
+    scheduler = ReduceLROnPlateau(optimizer, mode='min', factor=0.5, patience=6)
 
     # prepare logging
     run_name = args.run_name or datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -1972,7 +1972,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--w_head",
         type=float,
-        default=1.0,
+        default=0.5,
         help="Weight of the head loss consistency term",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- keep the optimizer learning rate unchanged longer by raising `ReduceLROnPlateau` patience
- lower default `--w_head` to 0.5 to reduce the pressure–headloss penalty
- document new defaults in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d98efe39483248114535c1d4b56dc