### PR TITLE
Fix flow normalization

### DIFF
--- a/tests/test_flow_denorm.py
+++ b/tests/test_flow_denorm.py
@@ -41,8 +41,8 @@ def test_mass_balance_denorm_per_edge():
     )
     ds = SequenceDataset(X, Y, edge_index.numpy(), edge_attr.numpy())
     loader = TorchLoader(ds, batch_size=1)
-    y_mean = {"edge_outputs": torch.tensor([1.0, 2.0]), "node_outputs": torch.zeros(2)}
-    y_std = {"edge_outputs": torch.ones(2), "node_outputs": torch.ones(2)}
+    y_mean = {"edge_outputs": torch.tensor(1.0), "node_outputs": torch.zeros(2)}
+    y_std = {"edge_outputs": torch.tensor(1.0), "node_outputs": torch.ones(2)}
     edge_pred = torch.zeros(1, T, E, 1)
     node_pred = torch.zeros(1, T, N, 2)
     model = DummyModel(edge_pred, node_pred, y_mean, y_std)
@@ -61,4 +61,4 @@ def test_mass_balance_denorm_per_edge():
         physics_loss=True,
         pressure_loss=False,
     )
-    assert abs(losses[3] - 0.25) < 1e-6
+    assert abs(losses[3]) < 1e-6

--- a/tests/test_sequence_norm_stats.py
+++ b/tests/test_sequence_norm_stats.py
@@ -1,0 +1,26 @@
+import numpy as np
+import torch
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import compute_sequence_norm_stats
+
+
+def test_sequence_norm_stats_edge_scalar():
+    X = np.zeros((1, 1, 2, 4), dtype=np.float32)
+    Y = np.array([
+        {
+            "node_outputs": np.zeros((1, 2, 2), dtype=np.float32),
+            "edge_outputs": np.array([[1.0, -1.0]], dtype=np.float32),
+        }
+    ], dtype=object)
+    x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(X, Y)
+    assert isinstance(y_mean, dict)
+    assert y_mean["edge_outputs"].shape == torch.Size([])
+    assert y_std["edge_outputs"].shape == torch.Size([])
+    # check normalization broadcast
+    Y_tensor = torch.tensor(Y[0]["edge_outputs"], dtype=torch.float32)
+    Y_norm = (Y_tensor - y_mean["edge_outputs"]) / y_std["edge_outputs"]
+    assert abs(float(Y_norm.mean())) < 1e-6
+    assert abs(float(Y_norm.std(unbiased=False) - 1.0)) < 1e-6


### PR DESCRIPTION
## Summary
- compute global statistics for edge flow normalization
- broadcast updated stats in training loss calculations
- update mass balance test to use scalar mean
- add unit test for sequence normalization stats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ddcb517d48324884a159b4baa63a5