### PR TITLE
Fix reservoir head handling in training data

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ The repository provides a simple training script `scripts/train_gnn.py` which
 expects feature and label data saved in the `data/` directory as NumPy arrays.
 Each node feature vector has the layout
 ``[base_demand, pressure, chlorine, elevation, pump_1, ..., pump_N]`` where the
-additional elements represent the speeds of all pumps in the network.  The
-helper script `scripts/data_generation.py` generates these arrays as well as the
-graph ``edge_index``.  Two dataset formats are
+additional elements represent the speeds of all pumps in the network. Reservoir
+nodes use their constant hydraulic head in the ``pressure`` slot so the model is
+given the correct supply level. The helper script `scripts/data_generation.py`
+generates these arrays as well as the graph ``edge_index``.  Two dataset formats
+are
 supported:
 
 1. **Dictionary format** – each entry of ``X`` is a dictionary containing the

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -362,7 +362,13 @@ def build_sequence_dataset(
             feat_nodes = []
             for node in wn_template.node_name_list:
                 idx = pressures.columns.get_loc(node)
-                p_t = float(pressures.iat[t, idx])
+                if node in wn_template.reservoir_name_list:
+                    # Reservoir nodes report ~0 pressure from EPANET. Use their
+                    # fixed hydraulic head instead so the surrogate is aware of
+                    # the supply level.
+                    p_t = float(wn_template.get_node(node).base_head)
+                else:
+                    p_t = float(pressures.iat[t, idx])
                 c_t = float(quality.iat[t, idx])
                 if demands is not None and node in wn_template.junction_name_list:
                     d_t = float(demands.iat[t, idx])
@@ -441,7 +447,11 @@ def build_dataset(
             feat_nodes = []
             for node in wn_template.node_name_list:
                 idx = pressures.columns.get_loc(node)
-                p_t = max(pressures.iat[i, idx], 0.0)
+                if node in wn_template.reservoir_name_list:
+                    # Use the reservoir's constant head as the pressure input
+                    p_t = float(wn_template.get_node(node).base_head)
+                else:
+                    p_t = max(pressures.iat[i, idx], 0.0)
                 c_t = max(quality.iat[i, idx], 0.0)
                 if demands is not None and node in wn_template.junction_name_list:
                     d_t = demands.iat[i, idx]

--- a/tests/test_reservoir_feature.py
+++ b/tests/test_reservoir_feature.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import numpy as np
+import wntr
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.data_generation import _run_single_scenario, build_dataset
+
+
+def test_reservoir_pressure_equals_head():
+    inp = Path(__file__).resolve().parents[1] / "CTown.inp"
+    results = _run_single_scenario((0, str(inp), 42))
+    assert results is not None
+    sim_res, scale_dict, pump_ctrl = results
+    wn = wntr.network.WaterNetworkModel(str(inp))
+    X, Y = build_dataset([(sim_res, scale_dict, pump_ctrl)], wn)
+    res_name = wn.reservoir_name_list[0]
+    idx = wn.node_name_list.index(res_name)
+    head = wn.get_node(res_name).base_head
+    assert np.allclose(X[:, idx, 1], head)
+


### PR DESCRIPTION
## Summary
- use reservoir base head as input pressure when creating datasets
- document the reservoir pressure handling in README
- add a regression test ensuring reservoir head is used

## Testing
- `pytest -k reservoir_feature -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de29d0c6c8324b6d339e5bc04aee6