### PR TITLE
Add DataLoader worker config

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ python scripts/train_gnn.py \
     --x-val-path data/X_val.npy --y-val-path data/Y_val.npy \
     --edge-index-path data/edge_index.npy --inp-path CTown.inp \
     --epochs 100 --batch-size 32 --hidden-dim 64 --num-layers 4 \
+    --workers 8 \
     --dropout 0.1 --residual --early-stop-patience 10 \
     --weight-decay 1e-5
 ```
@@ -120,6 +121,8 @@ checkpoints.  Normalization statistics are saved alongside the weights and
 automatically applied by the inference scripts.
 You may cancel training early with ``Ctrl+C``.  The loop exits gracefully,
 keeping the best model on disk and producing the usual plots.
+Data is loaded in parallel using multiple worker processes; pass ``--workers``
+to adjust the number (default ``5``).
 
 To achieve good predictive accuracy the surrogate should be trained on a large
 collection of EPANET simulations.  The data generation script accepts a

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -974,7 +974,7 @@ def train(model, loader, optimizer, device, check_negative=True):
     model.train()
     total_loss = 0
     for batch in loader:
-        batch = batch.to(device)
+        batch = batch.to(device, non_blocking=True)
         if torch.isnan(batch.x).any() or torch.isnan(batch.y).any():
             raise ValueError("NaN detected in training batch")
         if check_negative and ((batch.x[:, 1] < 0).any() or (batch.y[:, 0] < 0).any()):
@@ -1002,7 +1002,7 @@ def evaluate(model, loader, device):
     total_loss = 0
     with torch.no_grad():
         for batch in loader:
-            batch = batch.to(device)
+            batch = batch.to(device, non_blocking=True)
             out = model(
                 batch.x,
                 batch.edge_index,
@@ -1362,7 +1362,14 @@ def main(args: argparse.Namespace):
             node_type=node_types,
             edge_type=edge_types,
         )
-        loader = TorchLoader(data_ds, batch_size=args.batch_size, shuffle=True)
+        loader = TorchLoader(
+            data_ds,
+            batch_size=args.batch_size,
+            shuffle=True,
+            num_workers=args.workers,
+            pin_memory=torch.cuda.is_available(),
+            persistent_workers=args.workers > 0,
+        )
     else:
         data_list = load_dataset(
             args.x_path,
@@ -1372,7 +1379,14 @@ def main(args: argparse.Namespace):
             node_type=node_types,
             edge_type=edge_types,
         )
-        loader = DataLoader(data_list, batch_size=args.batch_size, shuffle=True)
+        loader = DataLoader(
+            data_list,
+            batch_size=args.batch_size,
+            shuffle=True,
+            num_workers=args.workers,
+            pin_memory=torch.cuda.is_available(),
+            persistent_workers=args.workers > 0,
+        )
 
 
     if args.x_val_path and os.path.exists(args.x_val_path):
@@ -1390,7 +1404,13 @@ def main(args: argparse.Namespace):
                 node_type=node_types,
                 edge_type=edge_types,
             )
-            val_loader = TorchLoader(val_ds, batch_size=args.batch_size)
+            val_loader = TorchLoader(
+                val_ds,
+                batch_size=args.batch_size,
+                num_workers=args.workers,
+                pin_memory=torch.cuda.is_available(),
+                persistent_workers=args.workers > 0,
+            )
             val_list = val_ds
         else:
             val_list = load_dataset(
@@ -1401,7 +1421,13 @@ def main(args: argparse.Namespace):
                 node_type=node_types,
                 edge_type=edge_types,
             )
-            val_loader = DataLoader(val_list, batch_size=args.batch_size)
+            val_loader = DataLoader(
+                val_list,
+                batch_size=args.batch_size,
+                num_workers=args.workers,
+                pin_memory=torch.cuda.is_available(),
+                persistent_workers=args.workers > 0,
+            )
     else:
         val_list = []
         val_loader = None
@@ -1462,15 +1488,41 @@ def main(args: argparse.Namespace):
         if args.neighbor_sampling:
             sample_size = args.cluster_batch_size or max(1, int(0.2 * data_list[0].num_nodes))
             data_list = NeighborSampleDataset(data_list, edge_index_np, sample_size)
-            loader = DataLoader(data_list, batch_size=args.batch_size, shuffle=True)
-            if val_loader is not None:
-                val_loader = DataLoader(NeighborSampleDataset(val_list, edge_index_np, sample_size), batch_size=args.batch_size)
+        loader = DataLoader(
+            data_list,
+            batch_size=args.batch_size,
+            shuffle=True,
+            num_workers=args.workers,
+            pin_memory=torch.cuda.is_available(),
+            persistent_workers=args.workers > 0,
+        )
+        if val_loader is not None:
+            val_loader = DataLoader(
+                NeighborSampleDataset(val_list, edge_index_np, sample_size),
+                batch_size=args.batch_size,
+                num_workers=args.workers,
+                pin_memory=torch.cuda.is_available(),
+                persistent_workers=args.workers > 0,
+            )
         elif args.cluster_batch_size > 0:
             clusters = partition_graph_greedy(edge_index_np, data_list[0].num_nodes, args.cluster_batch_size)
             data_list = ClusterSampleDataset(data_list, clusters)
-            loader = DataLoader(data_list, batch_size=args.batch_size, shuffle=True)
+            loader = DataLoader(
+                data_list,
+                batch_size=args.batch_size,
+                shuffle=True,
+                num_workers=args.workers,
+                pin_memory=torch.cuda.is_available(),
+                persistent_workers=args.workers > 0,
+            )
             if val_loader is not None:
-                val_loader = DataLoader(ClusterSampleDataset(val_list, clusters), batch_size=args.batch_size)
+                val_loader = DataLoader(
+                    ClusterSampleDataset(val_list, clusters),
+                    batch_size=args.batch_size,
+                    num_workers=args.workers,
+                    pin_memory=torch.cuda.is_available(),
+                    persistent_workers=args.workers > 0,
+                )
 
     expected_in_dim = 4 + len(wn.pump_name_list)
 
@@ -1751,7 +1803,13 @@ def main(args: argparse.Namespace):
                     edge_mean,
                     edge_std,
                 )
-            test_loader = TorchLoader(test_ds, batch_size=args.batch_size)
+            test_loader = TorchLoader(
+                test_ds,
+                batch_size=args.batch_size,
+                num_workers=args.workers,
+                pin_memory=torch.cuda.is_available(),
+                persistent_workers=args.workers > 0,
+            )
         else:
             test_list = load_dataset(
                 args.x_test_path,
@@ -1763,7 +1821,13 @@ def main(args: argparse.Namespace):
             )
             if args.normalize:
                 apply_normalization(test_list, x_mean, x_std, y_mean, y_std, edge_mean, edge_std)
-            test_loader = DataLoader(test_list, batch_size=args.batch_size)
+            test_loader = DataLoader(
+                test_list,
+                batch_size=args.batch_size,
+                num_workers=args.workers,
+                pin_memory=torch.cuda.is_available(),
+                persistent_workers=args.workers > 0,
+            )
         model.load_state_dict(torch.load(model_path, map_location=device))
         model.eval()
         preds_p = []
@@ -1804,7 +1868,7 @@ def main(args: argparse.Namespace):
                     true_c.extend(Y_node[..., 1].cpu().numpy().ravel())
             else:
                 for batch in test_loader:
-                    batch = batch.to(device)
+                    batch = batch.to(device, non_blocking=True)
                     out = model(
                         batch.x,
                         batch.edge_index,
@@ -1887,6 +1951,12 @@ if __name__ == "__main__":
         type=int,
         default=32,
         help="Training batch size",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=5,
+        help="Number of DataLoader workers",
     )
     parser.add_argument(
         "--hidden-dim",

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,17 @@
+import torch
+from torch_geometric.data import Data
+from torch_geometric.loader import DataLoader
+
+
+def test_workers_dataloader():
+    edge = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    d = Data(x=torch.ones(2, 2), edge_index=edge, y=torch.zeros(2, 1))
+    loader = DataLoader(
+        [d, d],
+        batch_size=1,
+        num_workers=2,
+        pin_memory=torch.cuda.is_available(),
+        persistent_workers=True,
+    )
+    for _ in loader:
+        pass


### PR DESCRIPTION
## Summary
- extend `train_gnn.py` with `--workers`
- use workers, pin_memory and persistent_workers in all DataLoader constructors
- move batches to device with `non_blocking=True`
- document new option and show usage in README
- test that dataloaders accept worker settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe283a284832496cb1fe19ac47c36