### PR TITLE
Fix dtype mismatch in HydroConv with AMP

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -85,7 +85,7 @@ class HydroConv(MessagePassing):
         for t, lin in enumerate(self.lin):
             idx = node_type == t
             if torch.any(idx):
-                out[idx] = lin(aggr[idx])
+                out[idx] = lin(aggr[idx]).to(out.dtype)
         return out
 
     def message(self, x_i: torch.Tensor, x_j: torch.Tensor, edge_attr: torch.Tensor, edge_type: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary
- fix dtype mismatch with AMP inside `HydroConv.forward`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff1d606e08324b9e0c9a2b9310625