### PR TITLE
Handle interrupt but still create plots

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1749,7 +1749,7 @@ def main(args: argparse.Namespace):
                 )
                 loss = loss_tuple[0]
                 node_l, edge_l, mass_l, head_l, sym_l = loss_tuple[1:]
-                if val_loader is not None:
+                if val_loader is not None and not interrupted:
                     val_tuple = evaluate_sequence(
                         model,
                         val_loader,
@@ -1780,7 +1780,7 @@ def main(args: argparse.Namespace):
                     check_negative=not args.normalize,
                     amp=args.amp,
                 )
-                if val_loader is not None:
+                if val_loader is not None and not interrupted:
                     val_loss = evaluate(model, val_loader, device, amp=args.amp)
                 else:
                     val_loss = loss


### PR DESCRIPTION
## Summary
- allow scatter plots after keyboard interrupt

## Testing
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --x-val-path data/X_val.npy --y-val-path data/Y_val.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 5 --batch-size 8 --workers 0 --w_head 0.001 --w_mass 1.0 --w_edge 1.0 --no-amp` *(interrupted with Ctrl+C)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686331b6f3088324b857c7d64294a7c0