### PR TITLE
Add NaN check for sequence training

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1075,6 +1075,17 @@ def train_sequence(
                 break
             raise
         X_seq = X_seq.to(device)
+        if isinstance(Y_seq, dict):
+            Y_seq = {k: v.to(device) for k, v in Y_seq.items()}
+        else:
+            Y_seq = Y_seq.to(device)
+        if torch.isnan(X_seq).any() or (
+            isinstance(Y_seq, dict)
+            and any(torch.isnan(v).any() for v in Y_seq.values())
+        ) or (
+            not isinstance(Y_seq, dict) and torch.isnan(Y_seq).any()
+        ):
+            raise ValueError("NaN detected in training batch")
         if node_type is not None:
             nt = node_type.to(device)
         else:

--- a/tests/test_sequence_nan_check.py
+++ b/tests/test_sequence_nan_check.py
@@ -1,0 +1,59 @@
+import numpy as np
+import torch
+from torch.utils.data import DataLoader as TorchLoader
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import SequenceDataset, train_sequence
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.param = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, X_seq, edge_index, edge_attr, nt, et):
+        B, T, N, _ = X_seq.size()
+        E = edge_index.size(1)
+        node_out = torch.zeros(B, T, N, 2, device=X_seq.device) + self.param
+        edge_out = torch.zeros(B, T, E, 1, device=X_seq.device) + self.param
+        return {"node_outputs": node_out, "edge_outputs": edge_out}
+
+
+def test_train_sequence_nan_detection():
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    edge_attr = torch.zeros((2, 3), dtype=torch.float32)
+    T, N, E = 1, 2, 2
+    X = np.ones((1, T, N, 4), dtype=np.float32)
+    X[0, 0, 0, 0] = np.nan
+    Y = np.array(
+        [
+            {
+                "node_outputs": np.zeros((T, N, 2), dtype=np.float32),
+                "edge_outputs": np.zeros((T, E), dtype=np.float32),
+            }
+        ],
+        dtype=object,
+    )
+    ds = SequenceDataset(X, Y, edge_index.numpy(), edge_attr.numpy())
+    loader = TorchLoader(ds, batch_size=1)
+    model = DummyModel()
+    opt = torch.optim.Adam(model.parameters(), lr=0.01)
+    with pytest.raises(ValueError):
+        train_sequence(
+            model,
+            loader,
+            ds.edge_index,
+            ds.edge_attr,
+            edge_attr,
+            None,
+            None,
+            [(0, 1)],
+            opt,
+            torch.device("cpu"),
+            physics_loss=False,
+            pressure_loss=False,
+            node_mask=None,
+        )


### PR DESCRIPTION
## Summary
- detect NaNs in `train_sequence` before forward pass
- ensure exception is raised when NaNs appear via new pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686429c6fbf0832494978748e616780d