### PR TITLE
Enable AMP in evaluate_sequence

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1259,99 +1259,100 @@ def evaluate_sequence(
                 init_press = X_seq[:, 0, model.tank_indices, 1]
                 init_levels = init_press * model.tank_areas
                 model.reset_tank_levels(init_levels)
-            preds = model(
-                X_seq,
-                edge_index.to(device),
-                edge_attr.to(device),
-                nt,
-                et,
-            )
-            if isinstance(Y_seq, dict):
-                target_nodes = Y_seq['node_outputs'].to(device)
-                pred_nodes = preds['node_outputs'].float()
-                if node_mask is not None:
-                    pred_nodes = pred_nodes[:, :, node_mask, :]
-                    target_nodes = target_nodes[:, :, node_mask, :]
-                loss_node = F.mse_loss(pred_nodes, target_nodes.float())
-                edge_target = Y_seq['edge_outputs'].unsqueeze(-1).to(device)
-                edge_preds = preds['edge_outputs'].float()
-                loss_edge = F.mse_loss(edge_preds, edge_target.float())
-                if physics_loss:
-                    flows_mb = (
-                        edge_preds.squeeze(-1)
-                        .permute(2, 0, 1)
-                        .reshape(edge_index.size(1), -1)
-                    )
-                    dem_seq = X_seq[..., 0]
-                    if dem_seq.size(1) > 1:
-                        dem_seq = torch.cat([dem_seq[:, 1:], dem_seq[:, -1:]], dim=1)
-                    demand_mb = dem_seq.permute(2, 0, 1).reshape(node_count, -1)
-                    if hasattr(model, "y_mean") and model.y_mean is not None:
-                        if isinstance(model.y_mean, dict):
-                            q_mean = model.y_mean["edge_outputs"].to(device)
-                            q_std = model.y_std["edge_outputs"].to(device)
-                            flows_mb = flows_mb * q_std + q_mean
+            with autocast(device_type=device.type, enabled=amp):
+                preds = model(
+                    X_seq,
+                    edge_index.to(device),
+                    edge_attr.to(device),
+                    nt,
+                    et,
+                )
+                if isinstance(Y_seq, dict):
+                    target_nodes = Y_seq['node_outputs'].to(device)
+                    pred_nodes = preds['node_outputs'].float()
+                    if node_mask is not None:
+                        pred_nodes = pred_nodes[:, :, node_mask, :]
+                        target_nodes = target_nodes[:, :, node_mask, :]
+                    loss_node = F.mse_loss(pred_nodes, target_nodes.float())
+                    edge_target = Y_seq['edge_outputs'].unsqueeze(-1).to(device)
+                    edge_preds = preds['edge_outputs'].float()
+                    loss_edge = F.mse_loss(edge_preds, edge_target.float())
+                    if physics_loss:
+                        flows_mb = (
+                            edge_preds.squeeze(-1)
+                            .permute(2, 0, 1)
+                            .reshape(edge_index.size(1), -1)
+                        )
+                        dem_seq = X_seq[..., 0]
+                        if dem_seq.size(1) > 1:
+                            dem_seq = torch.cat([dem_seq[:, 1:], dem_seq[:, -1:]], dim=1)
+                        demand_mb = dem_seq.permute(2, 0, 1).reshape(node_count, -1)
+                        if hasattr(model, "y_mean") and model.y_mean is not None:
+                            if isinstance(model.y_mean, dict):
+                                q_mean = model.y_mean["edge_outputs"].to(device)
+                                q_std = model.y_std["edge_outputs"].to(device)
+                                flows_mb = flows_mb * q_std + q_mean
+                            else:
+                                q_mean = model.y_mean[-1].to(device)
+                                q_std = model.y_std[-1].to(device)
+                                flows_mb = flows_mb * q_std + q_mean
+                        if hasattr(model, "x_mean") and model.x_mean is not None:
+                            dem_mean = model.x_mean[0].to(device)
+                            dem_std = model.x_std[0].to(device)
+                            demand_mb = demand_mb * dem_std + dem_mean
+                        mass_loss = compute_mass_balance_loss(
+                            flows_mb,
+                            edge_index.to(device),
+                            node_count,
+                            demand=demand_mb,
+                            node_type=nt,
+                        )
+                        sym_errors = []
+                        for i, j in edge_pairs:
+                            if et is not None:
+                                # only enforce symmetry for pipes (edge_type 0)
+                                if et[i] != 0 or et[j] != 0:
+                                    continue
+                            sym_errors.append(flows_mb[i] + flows_mb[j])
+                        if sym_errors:
+                            sym_errors = torch.stack(sym_errors, dim=0)
+                            sym_loss = torch.mean(sym_errors ** 2)
                         else:
-                            q_mean = model.y_mean[-1].to(device)
-                            q_std = model.y_std[-1].to(device)
-                            flows_mb = flows_mb * q_std + q_mean
-                    if hasattr(model, "x_mean") and model.x_mean is not None:
-                        dem_mean = model.x_mean[0].to(device)
-                        dem_std = model.x_std[0].to(device)
-                        demand_mb = demand_mb * dem_std + dem_mean
-                    mass_loss = compute_mass_balance_loss(
-                        flows_mb,
-                        edge_index.to(device),
-                        node_count,
-                        demand=demand_mb,
-                        node_type=nt,
-                    )
-                    sym_errors = []
-                    for i, j in edge_pairs:
-                        if et is not None:
-                            # only enforce symmetry for pipes (edge_type 0)
-                            if et[i] != 0 or et[j] != 0:
-                                continue
-                        sym_errors.append(flows_mb[i] + flows_mb[j])
-                    if sym_errors:
-                        sym_errors = torch.stack(sym_errors, dim=0)
-                        sym_loss = torch.mean(sym_errors ** 2)
+                            sym_loss = torch.tensor(0.0, device=device)
                     else:
+                        mass_loss = torch.tensor(0.0, device=device)
                         sym_loss = torch.tensor(0.0, device=device)
+                    if pressure_loss:
+                        press = preds['node_outputs'][..., 0].float()
+                        flow = edge_preds.squeeze(-1)
+                        if hasattr(model, 'y_mean') and model.y_mean is not None:
+                            if isinstance(model.y_mean, dict):
+                                p_mean = model.y_mean['node_outputs'][0].to(device)
+                                p_std = model.y_std['node_outputs'][0].to(device)
+                                q_mean = model.y_mean['edge_outputs'].to(device)
+                                q_std = model.y_std['edge_outputs'].to(device)
+                                press = press * p_std + p_mean
+                                flow = flow * q_std + q_mean
+                            else:
+                                press = press * model.y_std[0].to(device) + model.y_mean[0].to(device)
+                        head_loss = pressure_headloss_consistency_loss(
+                            press,
+                            flow,
+                            edge_index.to(device),
+                            edge_attr_phys.to(device),
+                            edge_type=et,
+                        )
+                    else:
+                        head_loss = torch.tensor(0.0, device=device)
+                    loss = loss_node + w_edge * loss_edge
+                    if physics_loss:
+                        loss = loss + w_mass * (mass_loss + sym_loss)
+                    if pressure_loss:
+                        loss = loss + w_head * head_loss
                 else:
-                    mass_loss = torch.tensor(0.0, device=device)
-                    sym_loss = torch.tensor(0.0, device=device)
-                if pressure_loss:
-                    press = preds['node_outputs'][..., 0].float()
-                    flow = edge_preds.squeeze(-1)
-                    if hasattr(model, 'y_mean') and model.y_mean is not None:
-                        if isinstance(model.y_mean, dict):
-                            p_mean = model.y_mean['node_outputs'][0].to(device)
-                            p_std = model.y_std['node_outputs'][0].to(device)
-                            q_mean = model.y_mean['edge_outputs'].to(device)
-                            q_std = model.y_std['edge_outputs'].to(device)
-                            press = press * p_std + p_mean
-                            flow = flow * q_std + q_mean
-                        else:
-                            press = press * model.y_std[0].to(device) + model.y_mean[0].to(device)
-                    head_loss = pressure_headloss_consistency_loss(
-                        press,
-                        flow,
-                        edge_index.to(device),
-                        edge_attr_phys.to(device),
-                        edge_type=et,
-                    )
-                else:
-                    head_loss = torch.tensor(0.0, device=device)
-                loss = loss_node + w_edge * loss_edge
-                if physics_loss:
-                    loss = loss + w_mass * (mass_loss + sym_loss)
-                if pressure_loss:
-                    loss = loss + w_head * head_loss
-            else:
-                Y_seq = Y_seq.to(device)
-                loss_node = loss_edge = mass_loss = sym_loss = torch.tensor(0.0, device=device)
-                loss = F.mse_loss(preds, Y_seq.float())
+                    Y_seq = Y_seq.to(device)
+                    loss_node = loss_edge = mass_loss = sym_loss = torch.tensor(0.0, device=device)
+                    loss = F.mse_loss(preds, Y_seq.float())
             total_loss += loss.item() * X_seq.size(0)
             node_total += loss_node.item() * X_seq.size(0)
             edge_total += loss_edge.item() * X_seq.size(0)

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -1,11 +1,18 @@
 import torch
 from torch_geometric.data import Data
 from torch_geometric.loader import DataLoader
+from torch.utils.data import DataLoader as TorchLoader
+import numpy as np
 import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from scripts.train_gnn import train, GCNEncoder
+from scripts.train_gnn import (
+    SequenceDataset,
+    MultiTaskGNNSurrogate,
+    evaluate_sequence,
+)
 
 
 def test_amp_training_runs_one_step():
@@ -15,3 +22,55 @@ def test_amp_training_runs_one_step():
     model = GCNEncoder(2,4,1)
     opt = torch.optim.Adam(model.parameters(), lr=0.01)
     train(model, loader, opt, torch.device('cpu'), amp=True)
+
+
+def test_amp_evaluate_sequence_runs():
+    if not torch.cuda.is_available():
+        return
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    edge_attr = torch.tensor(
+        [[1.0, 0.5, 100.0], [1.0, 0.5, 100.0]], dtype=torch.float32
+    )
+    T = 2
+    N = 2
+    E = 2
+    X = np.ones((1, T, N, 4), dtype=np.float32)
+    Y = np.array(
+        [
+            {
+                "node_outputs": np.zeros((T, N, 2), dtype=np.float32),
+                "edge_outputs": np.zeros((T, E), dtype=np.float32),
+            }
+        ],
+        dtype=object,
+    )
+    ds = SequenceDataset(X, Y, edge_index.numpy(), edge_attr.numpy())
+    loader = TorchLoader(ds, batch_size=1)
+    model = MultiTaskGNNSurrogate(
+        in_channels=4,
+        hidden_channels=8,
+        edge_dim=3,
+        node_output_dim=2,
+        edge_output_dim=1,
+        num_layers=2,
+        use_attention=False,
+        gat_heads=1,
+        dropout=0.0,
+        residual=False,
+        rnn_hidden_dim=4,
+    )
+    pairs = [(0, 1)]
+    evaluate_sequence(
+        model,
+        loader,
+        ds.edge_index,
+        ds.edge_attr,
+        edge_attr,
+        None,
+        None,
+        pairs,
+        torch.device("cpu"),
+        physics_loss=True,
+        pressure_loss=True,
+        amp=True,
+    )


### PR DESCRIPTION
## Summary
- ensure evaluation uses autocast for forward and physics/pressure loss computations
- add AMP evaluation test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686429c1155883248e8110c5fd5c1c6b