### PR TITLE
Ensure scatter plot after interrupt

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ checkpoints.  Normalization statistics are saved alongside the weights and
 automatically applied by the inference scripts.
 You may cancel training early with ``Ctrl+C``.  The loop exits gracefully,
 keeping the best model on disk and producing the usual plots.
+When interrupted, the current epoch finishes before evaluation so scatter plots
+are still generated from the test set.
 Data is loaded in parallel using multiple worker processes; pass ``--workers``
 to adjust the number (default ``5``).
 

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1861,7 +1861,7 @@ def main(args: argparse.Namespace):
         plt.close()
 
     # scatter plot of predictions vs actual on test set
-    if not interrupted and args.x_test_path and os.path.exists(args.x_test_path):
+    if args.x_test_path and os.path.exists(args.x_test_path):
         if seq_mode:
             Xt = np.load(args.x_test_path, allow_pickle=True)
             Yt = np.load(args.y_test_path, allow_pickle=True)

--- a/tests/test_scatter_interrupt.py
+++ b/tests/test_scatter_interrupt.py
@@ -1,0 +1,20 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import scripts.train_gnn as train_gnn
+
+
+def test_scatter_plots_generated_when_interrupted(tmp_path):
+    train_gnn.interrupted = True
+    try:
+        p_true = np.array([1.0, 2.0])
+        p_pred = np.array([1.1, 2.1])
+        c_true = np.array([0.1, 0.2])
+        c_pred = np.array([0.11, 0.19])
+        train_gnn.save_scatter_plots(p_true, p_pred, c_true, c_pred, "unit", plots_dir=tmp_path)
+        assert (tmp_path / "pred_vs_actual_pressure_unit.png").exists()
+        assert (tmp_path / "pred_vs_actual_chlorine_unit.png").exists()
+    finally:
+        train_gnn.interrupted = False


### PR DESCRIPTION
## Summary
- generate test scatter plot even when training is interrupted
- update documentation clarifying scatterplots are saved after Ctrl+C
- add regression test for interrupted scatter generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864317a0b30832488f3c141685ac070