### PR TITLE
Exclude reservoirs from scatter plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ saved under the top-level ``plots/`` directory.  The scripts automatically
 create this folder if it does not yet exist. After each training run
 ``train_gnn.py`` saves two scatter plots comparing model predictions to
 EPANET results: ``pred_vs_actual_pressure_<run>.png`` and
-``pred_vs_actual_chlorine_<run>.png``.
+``pred_vs_actual_chlorine_<run>.png``. Reservoir nodes are not included in
+these plots since their pressures are fixed.
 When normalization is enabled (the default) the test data is scaled using the
 training statistics. During evaluation both predictions **and** the
 corresponding ground truth labels are transformed back to physical units before

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -14,3 +14,22 @@ def test_save_scatter_plots(tmp_path):
     save_scatter_plots(p_true, p_pred, c_true, c_pred, "unit", plots_dir=tmp_path)
     assert (tmp_path / "pred_vs_actual_pressure_unit.png").exists()
     assert (tmp_path / "pred_vs_actual_chlorine_unit.png").exists()
+
+
+def test_save_scatter_plots_mask(tmp_path):
+    p_true = np.array([1.0, 2.0, 3.0, 4.0])
+    p_pred = np.array([1.0, 2.1, 3.0, 4.2])
+    c_true = np.array([0.1, 0.2, 0.3, 0.4])
+    c_pred = np.array([0.1, 0.21, 0.31, 0.41])
+    mask = [True, False, True, False]
+    save_scatter_plots(
+        p_true,
+        p_pred,
+        c_true,
+        c_pred,
+        "unit",
+        plots_dir=tmp_path,
+        mask=mask,
+    )
+    assert (tmp_path / "pred_vs_actual_pressure_unit.png").exists()
+    assert (tmp_path / "pred_vs_actual_chlorine_unit.png").exists()

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -21,6 +21,22 @@ def test_predicted_vs_actual_scatter(tmp_path: Path):
     plt = None
 
 
+def test_predicted_vs_actual_scatter_mask(tmp_path: Path):
+    fig = predicted_vs_actual_scatter(
+        [1.0, 2.0, 3.0, 4.0],
+        [1.0, 2.1, 2.9, 4.1],
+        [0.1, 0.2, 0.3, 0.4],
+        [0.1, 0.21, 0.29, 0.39],
+        "unit",
+        plots_dir=tmp_path,
+        return_fig=True,
+        mask=[True, False, True, False],
+    )
+    assert (tmp_path / "pred_vs_actual_unit.png").exists()
+    ax0 = fig.axes[0]
+    assert ax0.collections[0].get_offsets().shape[0] == 2
+
+
 def test_convergence_curve(tmp_path: Path):
     fig = plot_convergence_curve([5, 4, 3, 2, 1], "unit", plots_dir=tmp_path, return_fig=True)
     assert (tmp_path / "mpc_convergence_unit.png").exists()


### PR DESCRIPTION
## Summary
- allow `predicted_vs_actual_scatter` and `save_scatter_plots` to apply a mask
- filter reservoir nodes when creating scatter plots after training
- document that reservoir nodes are excluded
- test scatter plot masking for both functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653824ffa08324a023c742e39912bb