### PR TITLE
Export accuracy metrics during training

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ When normalization is enabled (the default) the test data is scaled using the
 training statistics. During evaluation both predictions **and** the
 corresponding ground truth labels are transformed back to physical units before
 plotting.
+In addition, ``train_gnn.py`` now writes a CSV file ``logs/accuracy_<run>.csv``
+containing MAE, RMSE, MAPE and maximum error for pressure and chlorine.
 
 The script automatically detects which format is provided and loads the data
 accordingly. When using the matrix format, supply the path to the shared

--- a/tests/test_accuracy_export.py
+++ b/tests/test_accuracy_export.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import save_accuracy_metrics
+
+def test_save_accuracy_metrics(tmp_path):
+    true_p = np.array([10.0, 12.0])
+    pred_p = np.array([9.5, 12.5])
+    true_c = np.log1p(np.array([0.5, 0.4]))
+    pred_c = np.log1p(np.array([0.45, 0.6]))
+    save_accuracy_metrics(true_p, pred_p, true_c, pred_c, "unit", logs_dir=tmp_path)
+    f = tmp_path / "accuracy_unit.csv"
+    assert f.exists()
+    df = pd.read_csv(f, index_col=0)
+    assert "Pressure (m)" in df.columns
+    assert "Chlorine (mg/L)" in df.columns


### PR DESCRIPTION
## Summary
- compute accuracy metrics with helper functions and export to `logs/accuracy_<run>.csv`
- document new behaviour in `README`
- add `save_accuracy_metrics` helper and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d86af6208324842ce8265cda5e21