### PR TITLE
Add loss component plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ corresponding ground truth labels are transformed back to physical units before
 plotting.
 In addition, ``train_gnn.py`` now writes a CSV file ``logs/accuracy_<run>.csv``
 containing MAE, RMSE, MAPE and maximum error for pressure and chlorine.
+When sequence models are used a component-wise loss curve
+``loss_components_<run>.png`` is stored alongside ``loss_curve_<run>.png``.
 
 The script automatically detects which format is provided and loads the data
 accordingly. When using the matrix format, supply the path to the shared

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from scripts.train_gnn import predicted_vs_actual_scatter
+from scripts.train_gnn import predicted_vs_actual_scatter, plot_loss_components
 from scripts.mpc_control import plot_convergence_curve
 
 
@@ -42,4 +42,13 @@ def test_convergence_curve(tmp_path: Path):
     assert (tmp_path / "mpc_convergence_unit.png").exists()
     ax = fig.axes[0]
     assert ax.get_xlabel() == "Optimization Iteration"
+
+
+def test_plot_loss_components(tmp_path: Path):
+    comps = [
+        (1.0, 2.0, 3.0, 4.0, 5.0),
+        (0.5, 1.5, 2.5, 3.5, 4.5),
+    ]
+    plot_loss_components(comps, "unit", plots_dir=tmp_path)
+    assert (tmp_path / "loss_components_unit.png").exists()
 


### PR DESCRIPTION
## Summary
- track per-component losses when training sequence models
- add `plot_loss_components` utility and tests
- document new figure in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669499baf08324bb011c79e8181abc