### PR TITLE
Add error histogram visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ create this folder if it does not yet exist. After each training run
 EPANET results: ``pred_vs_actual_pressure_<run>.png`` and
 ``pred_vs_actual_chlorine_<run>.png``. Reservoir nodes are not included in
 these plots since their pressures are fixed.
+It also writes ``error_histograms_<run>.png`` containing histograms and
+box plots of the prediction errors.
 When normalization is enabled (the default) the test data is scaled using the
 training statistics. During evaluation both predictions **and** the
 corresponding ground truth labels are transformed back to physical units before

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from scripts.train_gnn import predicted_vs_actual_scatter, plot_loss_components
+from scripts.train_gnn import (
+    predicted_vs_actual_scatter,
+    plot_loss_components,
+    plot_error_histograms,
+)
 from scripts.mpc_control import plot_convergence_curve
 
 
@@ -51,4 +55,14 @@ def test_plot_loss_components(tmp_path: Path):
     ]
     plot_loss_components(comps, "unit", plots_dir=tmp_path)
     assert (tmp_path / "loss_components_unit.png").exists()
+
+
+def test_plot_error_histograms(tmp_path: Path):
+    plot_error_histograms(
+        [0.1, -0.2, 0.0],
+        [0.05, -0.05, 0.1],
+        "unit",
+        plots_dir=tmp_path,
+    )
+    assert (tmp_path / "error_histograms_unit.png").exists()
 


### PR DESCRIPTION
## Summary
- add `plot_error_histograms` helper with histograms and box plots
- compute residuals at evaluation time and save error histograms
- test new plotting function in `test_visualizations`
- document error histogram output in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a3d45d7c8324940943fd80462af9