### PR TITLE
Add dataset distribution plotting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
   - `test_headloss_loss.py` – pressure‑headloss consistency penalty.
   - `test_metrics.py` – metric helper functions generate expected tables.
   - `test_visualizations.py` – plotting utilities create labelled images.
+  - `test_dataset_distributions.py` – dataset distribution plot is generated.
 
 ## Architecture Overview
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ the sequence arrays when ``--sequence-length`` is greater than one.
 Initial tank levels are now drawn from a Gaussian around the values in
 ``CTown.inp`` so each scenario begins with slightly different volumes.
 
+After scenario generation finishes a plot ``dataset_distributions_<timestamp>.png``
+is created under ``plots/`` summarising the sampled demand multipliers and pump
+speed settings.  Checking this figure helps ensure the dataset spans diverse
+operating conditions before proceeding to training.
+
 To create sequence datasets for the recurrent surrogate specify ``--sequence-length``:
 
 ```bash

--- a/tests/test_dataset_distributions.py
+++ b/tests/test_dataset_distributions.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.data_generation import plot_dataset_distributions
+
+
+def test_plot_dataset_distributions(tmp_path: Path):
+    plot_dataset_distributions([0.8, 1.0, 1.2], [0.0, 0.5, 1.0], "unit", plots_dir=tmp_path)
+    assert (tmp_path / "dataset_distributions_unit.png").exists()


### PR DESCRIPTION
## Summary
- plot distributions of demand multipliers and pump speeds after scenario generation
- document new dataset distribution plots in README
- test dataset distribution plotting utility
- list new test in AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b88986b083249bbdffc7cd3c63da