### PR TITLE
Add correlation heatmap plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ EPANET results: ``pred_vs_actual_pressure_<run>.png`` and
 ``pred_vs_actual_chlorine_<run>.png``. Reservoir nodes are not included in
 these plots since their pressures are fixed.
 It also writes ``error_histograms_<run>.png`` containing histograms and
-box plots of the prediction errors.
+box plots of the prediction errors. Finally ``correlation_heatmap_<run>.png``
+visualises pairwise correlations between the unnormalised training features.
 When normalization is enabled (the default) the test data is scaled using the
 training statistics. During evaluation both predictions **and** the
 corresponding ground truth labels are transformed back to physical units before

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -8,6 +8,7 @@ from scripts.train_gnn import (
     plot_error_histograms,
     SequenceDataset,
     plot_sequence_prediction,
+    correlation_heatmap,
 )
 from scripts.mpc_control import plot_convergence_curve
 
@@ -101,4 +102,11 @@ def test_plot_sequence_prediction(tmp_path: Path):
 
     plot_sequence_prediction(model, ds, "unit", plots_dir=tmp_path)
     assert (tmp_path / "time_series_example_unit.png").exists()
+
+
+def test_correlation_heatmap(tmp_path: Path):
+    mat = np.random.randn(8, 3)
+    labels = ["a", "b", "c"]
+    correlation_heatmap(mat, labels, "unit", plots_dir=tmp_path)
+    assert (tmp_path / "correlation_heatmap_unit.png").exists()
 


### PR DESCRIPTION
## Summary
- add `correlation_heatmap` utility to `train_gnn.py`
- generate correlation plot after training
- document the heatmap in README
- test correlation heatmap creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686713ded224832484c7e348f87504ce