### PR TITLE
Fix multi-output label handling in training

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -559,7 +559,15 @@ def load_dataset(
             node_feat = torch.tensor(node_feat, dtype=torch.float32)
             if torch.isnan(node_feat).any():
                 node_feat = torch.nan_to_num(node_feat)
-            data = Data(x=node_feat, edge_index=edge_index, y=torch.tensor(label))
+            if isinstance(label, dict):
+                # ``label`` may contain multiple targets (e.g., edge labels).
+                # Only use the node-level outputs during training.
+                label = label["node_outputs"]
+            data = Data(
+                x=node_feat,
+                edge_index=edge_index,
+                y=torch.tensor(label, dtype=torch.float32),
+            )
             if edge_attr_tensor is not None:
                 data.edge_attr = edge_attr_tensor
             if node_type_tensor is not None:


### PR DESCRIPTION
## Summary
- load only `node_outputs` from label dictionaries in matrix-format datasets

## Testing
- `python pytorchcheck.py` *(fails: no NVIDIA GPU)*
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --no-amp`

------
https://chatgpt.com/codex/tasks/task_e_6867ef3930188324b44413f93129c436