### PR TITLE
Fix flow units in pressure-headloss loss

### DIFF
--- a/models/loss_utils.py
+++ b/models/loss_utils.py
@@ -116,12 +116,15 @@ def pressure_headloss_consistency_loss(
     p_tgt = p[:, tgt]
     pred_hl = (p_src - p_tgt).abs()
 
-    # Hazen--Williams head loss formula (SI units)
+    # Hazen--Williams head loss formula (SI units). Flows are stored in L/s
+    # so convert to m^3/s before applying the equation.
     const = 10.67
     length = length[pipe_mask]
     diam = diam[pipe_mask]
     rough = rough[pipe_mask]
-    hw_hl = const * length * q.abs()[:, pipe_mask].pow(1.852) / (
+    # convert flow from L/s to m^3/s before applying Hazen--Williams
+    q_m3 = q[:, pipe_mask] * 0.001
+    hw_hl = const * length * q_m3.abs().pow(1.852) / (
         rough.pow(1.852) * diam.pow(4.87)
     )
 

--- a/tests/test_headloss_loss.py
+++ b/tests/test_headloss_loss.py
@@ -6,7 +6,8 @@ def test_headloss_consistency_zero():
     edge_attr = torch.tensor([[1000.0, 0.5, 100.0]], dtype=torch.float32)
     flow = torch.tensor([0.1], dtype=torch.float32)
     const = 10.67
-    hl = const * edge_attr[0,0] * flow.abs().pow(1.852) / (
+    q_m3 = flow * 0.001
+    hl = const * edge_attr[0,0] * q_m3.abs().pow(1.852) / (
         edge_attr[0,2].pow(1.852) * edge_attr[0,1].pow(4.87)
     )
     pressures = torch.tensor([50.0 + hl.item(), 50.0], dtype=torch.float32)


### PR DESCRIPTION
## Summary
- fix flow units in `pressure_headloss_consistency_loss`
- update test to use converted units

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 2 --output-dir data/ --seed 0`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 1 --batch-size 4 --x-val-path none --y-val-path none --no-amp`

------
https://chatgpt.com/codex/tasks/task_e_6867f040522c8324b51dbb3325687c05