### PR TITLE
Enable chlorine decay

### DIFF
--- a/CTown.inp
+++ b/CTown.inp
@@ -1181,7 +1181,7 @@ R1 SETPOINT 1.0
  Order Bulk            	1.00
  Order Tank            	1.00
  Order Wall            	1
- Global Bulk           	0.000000
+ Global Bulk            -0.05
  Global Wall           	0.000000
  Limiting Potential    	0
  Roughness Correlation 	0
@@ -1219,7 +1219,7 @@ R1 SETPOINT 1.0
  Pattern            	1
  Demand Multiplier  	1
  Emitter Exponent   	0.5000
- Quality            	NONE mg/L
+ Quality                Chlorine mg/L
  Diffusivity        	1.000000
  Tolerance          	0.01000000
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ pump failures or source quality changes.  Scenario labels are stored alongside
 the sequence arrays when ``--sequence-length`` is greater than one.
 Initial tank levels are now drawn from a Gaussian around the values in
 ``CTown.inp`` so each scenario begins with slightly different volumes.
+Chlorine decay is enabled in the example network via a global bulk reaction
+coefficient of ``-0.05`` 1/h which EPANET applies during water quality
+simulations.
 
 After scenario generation finishes a plot ``dataset_distributions_<timestamp>.png``
 is created under ``plots/`` summarising the sampled demand multipliers and pump


### PR DESCRIPTION
## Summary
- add global chlorine decay in `CTown.inp`
- document chlorine decay configuration in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68691ce37a788324ac009e495d9f839b