### PR TITLE
Fix quality variation source strength

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -53,7 +53,11 @@ def simulate_extreme_event(
             if source in wn.node_name_list:
                 n = wn.get_node(source)
                 if hasattr(n, "initial_quality"):
-                    n.initial_quality *= random.uniform(0.5, 1.5)
+                    factor = random.uniform(0.5, 1.5)
+                    n.initial_quality *= factor
+                    src = wn.get_source(source, None)
+                    if src is not None:
+                        src.strength *= factor
 
 
 


### PR DESCRIPTION
## Summary
- update simulate_extreme_event to also scale source strength when altering node quality

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 1 --no-amp`

------
https://chatgpt.com/codex/tasks/task_e_686932299a8883248eed44dd697f4e07