### PR TITLE
Fix duplicate temp file cleanup

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -226,14 +226,6 @@ def _run_single_scenario(
         except PermissionError:
             warnings.warn(f"Could not remove file {f}")
 
-    for ext in [".inp", ".rpt", ".bin", ".hyd", ".msx", ".msx-rpt", ".msx-bin", ".check.msx"]:
-        f = f"{prefix}{ext}"
-        try:
-            os.remove(f)
-        except FileNotFoundError:
-            pass
-        except PermissionError:
-            warnings.warn(f"Could not remove file {f}")
 
     flows = sim_results.link["flowrate"]
     heads = sim_results.node["head"]


### PR DESCRIPTION
## Summary
- remove redundant cleanup loop from `_run_single_scenario`

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --no-amp --epochs 1`


------
https://chatgpt.com/codex/tasks/task_e_686932603ac88324a3010c7ed25b3556