### PR TITLE
Skip reservoirs and tanks in scatter plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ saved under the top-level ``plots/`` directory.  The scripts automatically
 create this folder if it does not yet exist. After each training run
 ``train_gnn.py`` saves two scatter plots comparing model predictions to
 EPANET results: ``pred_vs_actual_pressure_<run>.png`` and
-``pred_vs_actual_chlorine_<run>.png``. Reservoir nodes are not included in
+``pred_vs_actual_chlorine_<run>.png``. Reservoirs and tanks are excluded from
 these plots since their pressures are fixed.
 It also writes ``error_histograms_<run>.png`` containing histograms and
 box plots of the prediction errors. Finally ``correlation_heatmap_<run>.png``

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2231,11 +2231,10 @@ def main(args: argparse.Namespace):
             err_p = preds_p - true_p
             err_c = preds_c - true_c
 
-            res_mask = np.array([
-                n not in wn.reservoir_name_list for n in wn.node_name_list
-            ])
-            repeat = preds_p.size // res_mask.size
-            full_mask = np.tile(res_mask, repeat)
+            exclude = set(wn.reservoir_name_list) | set(wn.tank_name_list)
+            node_mask = np.array([n not in exclude for n in wn.node_name_list])
+            repeat = preds_p.size // node_mask.size
+            full_mask = np.tile(node_mask, repeat)
 
             save_scatter_plots(
                 true_p,


### PR DESCRIPTION
## Summary
- ignore reservoirs and tanks when masking points for scatter plots
- document scatter plot mask update

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --x-val-path data/X_val.npy --y-val-path data/Y_val.npy --epochs 2 --inp-path CTown.inp --no-amp`

------
https://chatgpt.com/codex/tasks/task_e_68693235cee48324bb9bcf6cdd7f6e90