### PR TITLE
Fix chlorine unit scaling

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -370,7 +370,7 @@ def build_sequence_dataset(
         if wn_template.options.quality.parameter.upper() == "CHEMICAL":
             # convert mg/L to g/L used by CHEMICAL quality models before
             # taking the logarithm so the surrogate sees reasonable scales
-            quality_df = quality_df * 1000.0
+            quality_df = quality_df / 1000.0
         quality = np.log1p(quality_df)
         demands = sim_results.node.get("demand")
         if demands is not None:
@@ -464,7 +464,7 @@ def build_dataset(
         if wn_template.options.quality.parameter.upper() == "CHEMICAL":
             # CHEMICAL quality models return mg/L, scale to g/L before
             # applying the log transform
-            quality_df = quality_df * 1000.0
+            quality_df = quality_df / 1000.0
         quality = np.log1p(quality_df)
         demands = sim_results.node.get("demand")
         times = pressures.index

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -306,7 +306,7 @@ def validate_surrogate(
                 y_true_c = chlorine_df.iloc[i + 1].to_numpy()
                 # chlorine predictions were trained in log space so convert
                 # predictions back to mg/L before computing errors
-                pred_c = np.expm1(pred_c)
+                pred_c = np.expm1(pred_c) * 1000.0
 
                 diff_p = pred_p - y_true_p
                 diff_c = pred_c - y_true_c

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -624,8 +624,8 @@ def predicted_vs_actual_scatter(
 
     # chlorine values are stored in log space (log1p). Convert back to mg/L
     # before plotting so the axes reflect physical units.
-    tc = np.expm1(tc)
-    pc = np.expm1(pc)
+    tc = np.expm1(tc) * 1000.0
+    pc = np.expm1(pc) * 1000.0
 
     fig, axes = plt.subplots(1, 2, figsize=(10, 4))
 
@@ -704,7 +704,12 @@ def save_accuracy_metrics(
     if logs_dir is None:
         logs_dir = REPO_ROOT / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
-    df = accuracy_metrics(true_p, preds_p, np.expm1(true_c), np.expm1(preds_c))
+    df = accuracy_metrics(
+        true_p,
+        preds_p,
+        np.expm1(true_c) * 1000.0,
+        np.expm1(preds_c) * 1000.0,
+    )
     export_table(df, str(logs_dir / f"accuracy_{run_name}.csv"))
 
 
@@ -888,8 +893,8 @@ def plot_sequence_prediction(
     axes[0].legend()
 
     if pred_np.shape[-1] >= 2:
-        axes[1].plot(time, np.expm1(true_np[:, node_idx, 1]), label="Actual")
-        axes[1].plot(time, np.expm1(pred_np[:, node_idx, 1]), "--", label="Predicted")
+        axes[1].plot(time, np.expm1(true_np[:, node_idx, 1]) * 1000.0, label="Actual")
+        axes[1].plot(time, np.expm1(pred_np[:, node_idx, 1]) * 1000.0, "--", label="Predicted")
         axes[1].set_xlabel("Timestep")
         axes[1].set_ylabel("Chlorine (mg/L)")
         axes[1].set_title(f"Node {node_idx} Chlorine")

--- a/tests/test_accuracy_export.py
+++ b/tests/test_accuracy_export.py
@@ -9,8 +9,8 @@ from scripts.train_gnn import save_accuracy_metrics
 def test_save_accuracy_metrics(tmp_path):
     true_p = np.array([10.0, 12.0])
     pred_p = np.array([9.5, 12.5])
-    true_c = np.log1p(np.array([0.5, 0.4]))
-    pred_c = np.log1p(np.array([0.45, 0.6]))
+    true_c = np.log1p(np.array([0.5, 0.4]) / 1000.0)
+    pred_c = np.log1p(np.array([0.45, 0.6]) / 1000.0)
     save_accuracy_metrics(true_p, pred_p, true_c, pred_c, "unit", logs_dir=tmp_path)
     f = tmp_path / "accuracy_unit.csv"
     assert f.exists()


### PR DESCRIPTION
## Summary
- fix conversion of chlorine concentrations from mg/L to g/L in dataset generation
- update scaling back to mg/L in training and evaluation scripts
- adjust accuracy metrics test for new units

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d782777b48324922858deda7f3f51