### PR TITLE
Handle short sequences in data generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ python scripts/data_generation.py \
 ```
 This will also generate ``scenario_train.npy`` etc. recording the type of each
 scenario.
+Scenarios that do not contain at least ``sequence_length + 1`` time steps are
+skipped with a warning so the actual dataset may be smaller than requested.
 
 The training script automatically detects such sequence files and will use the recurrent
 model. Adjust the recurrent hidden size via ``--rnn-hidden-dim`` if desired.

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -380,9 +380,11 @@ def build_sequence_dataset(
         flows_arr, energy_arr = extract_additional_targets(sim_results, wn_template)
 
         if len(times) <= seq_len:
-            raise ValueError(
-                f"Not enough timesteps ({len(times)}) for sequence length {seq_len}"
+            warnings.warn(
+                "Skipping scenario with only "
+                f"{len(times)} timesteps (need {seq_len + 1})"
             )
+            continue
 
         X_seq: List[np.ndarray] = []
         node_out_seq: List[np.ndarray] = []
@@ -436,6 +438,11 @@ def build_sequence_dataset(
             "edge_outputs": np.stack(edge_out_seq).astype(np.float32),
             "pump_energy": np.stack(energy_seq).astype(np.float32),
         })
+
+    if not X_list:
+        raise ValueError(
+            f"No scenarios contained at least {seq_len + 1} timesteps"
+        )
 
     X = np.stack(X_list).astype(np.float32)
     Y = np.array(Y_list, dtype=object)


### PR DESCRIPTION
## Summary
- skip scenarios with too few timesteps when creating sequence datasets
- mention this behavior in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc5ee89648324a62712d88206691d