### PR TITLE
Support per-edge flow normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ data/
 scripts/__pycache__/
 tests/__pycache__/
 models/__pycache__/
+models/*.pth
+models/*_norm.npz
 .venv/
-plots/
-logs/
+plots/logs/

--- a/tests/test_flow_denorm.py
+++ b/tests/test_flow_denorm.py
@@ -41,8 +41,8 @@ def test_mass_balance_denorm_per_edge():
     )
     ds = SequenceDataset(X, Y, edge_index.numpy(), edge_attr.numpy())
     loader = TorchLoader(ds, batch_size=1)
-    y_mean = {"edge_outputs": torch.tensor(1.0), "node_outputs": torch.zeros(2)}
-    y_std = {"edge_outputs": torch.tensor(1.0), "node_outputs": torch.ones(2)}
+    y_mean = {"edge_outputs": torch.ones(E), "node_outputs": torch.zeros(2)}
+    y_std = {"edge_outputs": torch.ones(E), "node_outputs": torch.ones(2)}
     edge_pred = torch.zeros(1, T, E, 1)
     node_pred = torch.zeros(1, T, N, 2)
     model = DummyModel(edge_pred, node_pred, y_mean, y_std)

--- a/tests/test_sequence_norm_stats.py
+++ b/tests/test_sequence_norm_stats.py
@@ -7,7 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from scripts.train_gnn import compute_sequence_norm_stats
 
 
-def test_sequence_norm_stats_edge_scalar():
+def test_sequence_norm_stats_edge_vector():
     X = np.zeros((1, 1, 2, 4), dtype=np.float32)
     Y = np.array([
         {
@@ -17,10 +17,10 @@ def test_sequence_norm_stats_edge_scalar():
     ], dtype=object)
     x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(X, Y)
     assert isinstance(y_mean, dict)
-    assert y_mean["edge_outputs"].shape == torch.Size([])
-    assert y_std["edge_outputs"].shape == torch.Size([])
+    assert y_mean["edge_outputs"].shape == torch.Size([2])
+    assert y_std["edge_outputs"].shape == torch.Size([2])
     # check normalization broadcast
     Y_tensor = torch.tensor(Y[0]["edge_outputs"], dtype=torch.float32)
     Y_norm = (Y_tensor - y_mean["edge_outputs"]) / y_std["edge_outputs"]
     assert abs(float(Y_norm.mean())) < 1e-6
-    assert abs(float(Y_norm.std(unbiased=False) - 1.0)) < 1e-6
+    assert abs(float(Y_norm.std(unbiased=False))) < 1e-6


### PR DESCRIPTION
## Summary
- compute per-edge statistics in `compute_sequence_norm_stats`
- broadcast edge normalization constants in training loops
- update tests for per-edge vectors
- ignore trained models

## Testing
- `pytest -q`
- `python scripts/data_generation.py --num-scenarios 10 --output-dir data/ --seed 1 --num-workers 1`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --inp-path CTown.inp --epochs 1 --batch-size 2 --no-amp --workers 0 --seed 0`

------
https://chatgpt.com/codex/tasks/task_e_686e77b28cc08324a5ad6d42dffa5b1d