### PR TITLE
Expose --no-pressure-loss flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ python scripts/train_gnn.py \
     --dropout 0.1 --residual --early-stop-patience 10 \
     --weight-decay 1e-5
 ```
-Pressure–headloss consistency is now enforced by default with a weight of ``0.5``.
-Pass ``--no-pressure_loss`` if this coupling should be disabled.  To remove the
+Pressure–headloss consistency is now enforced by default with a weight of ``0.25``.
+Pass ``--no-pressure-loss`` if this coupling should be disabled.  To remove the
 mass balance penalty (still weighted ``1.0`` by default) use ``--no-physics-loss``.
 The surrogate clamps predicted pressures and chlorine concentrations to
 non-negative values and applies L2 regularization controlled by
@@ -129,7 +129,7 @@ pressures are no longer part of the direct MSE loss.  Disable the physics terms
 with ``--no-physics-loss`` if necessary. ``--pressure_loss`` is enabled by
 default to enforce pressure–headloss consistency via the Hazen--Williams
 equation.  The mass and edge penalties keep a default weight of ``1.0`` while
-the headloss term uses ``0.5``. The relative importance can still be tuned via
+the headloss term uses ``0.25``. The relative importance can still be tuned via
 ``--w_mass`` and ``--w_head`` along with the ``--w_edge`` coefficient
 controlling the flow loss.
 

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2425,6 +2425,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Add pressure-headloss consistency penalty",
     )
+    parser.add_argument(
+        "--no-pressure-loss",
+        dest="pressure_loss",
+        action="store_false",
+        help="Disable pressure-headloss consistency penalty",
+    )
     parser.set_defaults(pressure_loss=True)
     parser.add_argument(
         "--w_mass",

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,66 @@
+import numpy as np
+import subprocess
+from pathlib import Path
+import sys
+import wntr
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import build_edge_attr
+
+def test_cli_no_pressure_loss(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    data_dir = repo / "data"
+    data_dir.mkdir(exist_ok=True)
+    log_file = data_dir / "training_unit.log"
+    if log_file.exists():
+        log_file.unlink()
+
+    wn = wntr.network.WaterNetworkModel(repo / "CTown.inp")
+    node_map = {n: i for i, n in enumerate(wn.node_name_list)}
+    link = wn.get_link(wn.link_name_list[0])
+    edge_index = np.array(
+        [
+            [node_map[link.start_node.name], node_map[link.end_node.name]],
+            [node_map[link.end_node.name], node_map[link.start_node.name]],
+        ],
+        dtype=np.int64,
+    )
+    edge_attr = build_edge_attr(wn, edge_index)
+
+    np.save(tmp_path / "edge_index.npy", edge_index)
+    np.save(tmp_path / "edge_attr.npy", edge_attr)
+
+    F = 4 + len(wn.pump_name_list)
+    N = len(wn.node_name_list)
+    X = np.ones((1, N, F), dtype=np.float32)
+    Y = np.zeros((1, N, 2), dtype=np.float32)
+    np.save(tmp_path / "X.npy", X)
+    np.save(tmp_path / "Y.npy", Y)
+
+    cmd = [
+        "python",
+        str(repo / "scripts/train_gnn.py"),
+        "--x-path",
+        str(tmp_path / "X.npy"),
+        "--y-path",
+        str(tmp_path / "Y.npy"),
+        "--edge-index-path",
+        str(tmp_path / "edge_index.npy"),
+        "--edge-attr-path",
+        str(tmp_path / "edge_attr.npy"),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--run-name",
+        "unit",
+        "--output",
+        str(tmp_path / "model.pth"),
+        "--no-pressure-loss",
+    ]
+
+    subprocess.run(cmd, check=True)
+
+    assert log_file.exists()
+    log_text = log_file.read_text()
+    assert "'pressure_loss': False" in log_text


### PR DESCRIPTION
## Summary
- add `--no-pressure-loss` argument in `train_gnn.py`
- document the flag and headloss default weight in README
- test CLI parsing of `--no-pressure-loss`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb938a7c08324bb7782edbfcac8cd