### PR TITLE
Ensure epoch progress is printed

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ mass balance penalty (still weighted ``1.0`` by default) use ``--no-physics-loss
 The surrogate clamps predicted pressures and chlorine concentrations to
 non-negative values and applies L2 regularization controlled by
 ``--weight-decay`` (default ``1e-5``) to avoid degenerate solutions.
+Even when the physics-based loss is disabled with ``--no-physics-loss``
+the script prints the current epoch number so progress remains visible in
+the terminal.
 
 For large graphs you can reduce memory usage by training on subgraphs.
 Passing ``--cluster-batch-size <N>`` partitions the network into clusters of

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2058,6 +2058,8 @@ def main(args: argparse.Namespace):
                 if args.pressure_loss:
                     msg += f", head={head_l:.3f}"
                 print(msg)
+            else:
+                print(f"Epoch {epoch}")
             if val_loss < best_val - 1e-6:
                 best_val = val_loss
                 patience = 0


### PR DESCRIPTION
## Summary
- print current epoch even when physics loss is disabled
- document this behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef29668688324a75f90feaf97d34c