### PR TITLE
Mask reservoirs in metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ create this folder if it does not yet exist. After each training run
 ``train_gnn.py`` saves two scatter plots comparing model predictions to
 EPANET results: ``pred_vs_actual_pressure_<run>.png`` and
 ``pred_vs_actual_chlorine_<run>.png``. Reservoirs and tanks are excluded from
-these plots since their pressures are fixed.
-It also writes ``error_histograms_<run>.png`` containing histograms and
-box plots of the prediction errors. Finally ``correlation_heatmap_<run>.png``
+these plots since their pressures are fixed. ``error_histograms_<run>.png``
+contains histograms and box plots of the prediction errors and the CSV
+``logs/accuracy_<run>.csv`` records MAE, RMSE, MAPE and maximum error for
+pressure and chlorine. Reservoir and tank nodes are excluded from these metrics
+so outliers from fixed heads do not skew the results. Finally ``correlation_heatmap_<run>.png``
 visualises pairwise correlations between the unnormalised training features.
 When normalization is enabled (the default) the test data is scaled using the
 training statistics. During evaluation both predictions **and** the
 corresponding ground truth labels are transformed back to physical units before
 plotting.
-In addition, ``train_gnn.py`` now writes a CSV file ``logs/accuracy_<run>.csv``
-containing MAE, RMSE, MAPE and maximum error for pressure and chlorine.
 When sequence models are used a component-wise loss curve
 ``loss_components_<run>.png`` is stored alongside ``loss_curve_<run>.png``.
 For sequence datasets a time-series example ``time_series_example_<run>.png``

--- a/tests/test_accuracy_export.py
+++ b/tests/test_accuracy_export.py
@@ -11,7 +11,8 @@ def test_save_accuracy_metrics(tmp_path):
     pred_p = np.array([9.5, 12.5])
     true_c = np.log1p(np.array([0.5, 0.4]) / 1000.0)
     pred_c = np.log1p(np.array([0.45, 0.6]) / 1000.0)
-    save_accuracy_metrics(true_p, pred_p, true_c, pred_c, "unit", logs_dir=tmp_path)
+    mask = [True, False]
+    save_accuracy_metrics(true_p, pred_p, true_c, pred_c, "unit", logs_dir=tmp_path, mask=mask)
     f = tmp_path / "accuracy_unit.csv"
     assert f.exists()
     df = pd.read_csv(f, index_col=0)

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -63,13 +63,18 @@ def test_plot_loss_components(tmp_path: Path):
 
 
 def test_plot_error_histograms(tmp_path: Path):
-    plot_error_histograms(
-        [0.1, -0.2, 0.0],
-        [0.05, -0.05, 0.1],
+    fig = plot_error_histograms(
+        [0.1, -0.2, 0.0, 0.3],
+        [0.05, -0.05, 0.1, -0.1],
         "unit",
         plots_dir=tmp_path,
+        return_fig=True,
+        mask=[True, False, True, False],
     )
     assert (tmp_path / "error_histograms_unit.png").exists()
+    # number of histogram bars should match masked data length
+    assert fig.axes[0].patches[0].get_height() > 0
+    plt = None
 
 
 def test_plot_sequence_prediction(tmp_path: Path):


### PR DESCRIPTION
## Summary
- apply node mask to accuracy metrics and error histograms
- update README accordingly
- adapt tests for new mask arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687070f4e9b883248212c18e988e18ec