### PR TITLE
Add edge attribute dimension checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,12 @@ diverging over long horizons.  It now also reports mean absolute error (MAE)
  ground truth are denormalized and chlorine values are exponentiated so the
  resulting errors are reported in physical units.  Pressures below 5 m are
  clipped to this lower bound during validation so metrics match the training
- distribution.  All metrics are written to
+distribution.  All metrics are written to
 ``logs/surrogate_metrics.json`` for reproducibility.
+
+If the dimension of ``edge_attr.npy`` does not match the value stored in the
+surrogate checkpoint, ``validate_surrogate`` now raises a ``ValueError``.
+Regenerate the dataset or retrain the surrogate when this occurs.
 
 Typical validation command:
 
@@ -285,6 +289,8 @@ have no effect on the predictions.
 `simulate_closed_loop` now performs the same check and raises a `ValueError`
 when the loaded model does not include pump controls so that experiment scripts
 fail fast instead of silently optimising with zero gradients.
+It also verifies that the provided edge attributes match the model's expected
+dimension and aborts with an error when they differ.
 
 ## Reporting Key Performance Metrics
 

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -209,6 +209,13 @@ def validate_surrogate(
     are automatically unpacked.
     """
 
+    if edge_attr is not None and hasattr(model, "edge_dim"):
+        if edge_attr.size(1) != model.edge_dim:
+            raise ValueError(
+                f"Edge attribute dimension mismatch: model expects {model.edge_dim}, "
+                f"but received {edge_attr.size(1)}."
+            )
+
     rmse_p = 0.0
     rmse_c = 0.0
     mae_p = 0.0

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -496,6 +496,9 @@ def load_surrogate_model(
 
     model.load_state_dict(state, strict=False)
 
+    # store expected edge attribute dimension for input checks
+    model.edge_dim = edge_dim if edge_dim is not None else 0
+
     norm_path = str(full_path.with_suffix("")) + "_norm.npz"
     if os.path.exists(norm_path):
         arr = np.load(norm_path)
@@ -1029,6 +1032,13 @@ def simulate_closed_loop(
         raise ValueError(
             "Loaded model was trained without pump controls - rerun train_gnn.py"
         )
+
+    if edge_attr is not None and hasattr(model, "edge_dim"):
+        if edge_attr.size(1) != model.edge_dim:
+            raise ValueError(
+                f"Edge attribute dimension mismatch: model expects {model.edge_dim}, "
+                f"but received {edge_attr.size(1)}."
+            )
 
     log = []
     pressure_violations = 0

--- a/tests/test_mpc_input_check.py
+++ b/tests/test_mpc_input_check.py
@@ -52,3 +52,46 @@ def test_simulate_closed_loop_requires_pump_inputs():
             Cmin=0.2,
             feedback_interval=0,
         )
+
+
+def test_simulate_closed_loop_checks_edge_dim():
+    device = torch.device("cpu")
+    (
+        wn,
+        node_to_index,
+        pump_names,
+        edge_index,
+        edge_attr,
+        node_types,
+        edge_types,
+        template,
+    ) = load_network("CTown.inp", return_edge_attr=True, return_features=True)
+
+    class EdgeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = torch.nn.ModuleList([DummyConv(4 + len(pump_names))])
+            self.edge_dim = 2  # expect fewer edge attributes than provided
+
+        def forward(self, x, edge_index, edge_attr=None, node_types=None, edge_types=None):
+            return torch.zeros(x.size(0), 2)
+
+    model = EdgeModel().to(device)
+    with pytest.raises(ValueError):
+        simulate_closed_loop(
+            wn,
+            model,
+            edge_index.to(device),
+            edge_attr.to(device),
+            template.to(device),
+            torch.tensor(node_types, dtype=torch.long, device=device),
+            torch.tensor(edge_types, dtype=torch.long, device=device),
+            horizon=2,
+            iterations=1,
+            node_to_index=node_to_index,
+            pump_names=pump_names,
+            device=device,
+            Pmin=20.0,
+            Cmin=0.2,
+            feedback_interval=0,
+        )


### PR DESCRIPTION
## Summary
- store `edge_dim` on models when loading weights
- validate edge attribute sizes in `validate_surrogate` and `simulate_closed_loop`
- document the new errors in README
- add unit tests for edge dimension mismatch handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719a43981c8324a9182abfd4f3ee33