### PR TITLE
Fix hidden dim inference for GATConv

### DIFF
--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -494,12 +494,16 @@ def load_surrogate_model(
     elif isinstance(conv_layers[0], GATConv):
         edge_dim = conv_layers[0].edge_dim
 
+    hidden_dim = conv_layers[0].out_channels
+    if isinstance(conv_layers[0], GATConv) and getattr(conv_layers[0], "concat", True):
+        hidden_dim = hidden_dim * conv_layers[0].heads
+
     if multitask:
         node_out_dim, rnn_hidden_dim = state["node_decoder.weight"].shape
         edge_out_dim = state["edge_decoder.weight"].shape[0]
         model = MultiTaskGNNSurrogate(
             in_channels=conv_layers[0].in_channels,
-            hidden_channels=conv_layers[0].out_channels,
+            hidden_channels=hidden_dim,
             edge_dim=edge_dim if edge_dim is not None else 0,
             node_output_dim=node_out_dim,
             edge_output_dim=edge_out_dim,
@@ -516,7 +520,7 @@ def load_surrogate_model(
         out_dim, rnn_hidden_dim = state["decoder.weight"].shape
         model = RecurrentGNNSurrogate(
             in_channels=conv_layers[0].in_channels,
-            hidden_channels=conv_layers[0].out_channels,
+            hidden_channels=hidden_dim,
             edge_dim=edge_dim if edge_dim is not None else 0,
             output_dim=out_dim,
             num_layers=len(conv_layers),

--- a/tests/test_load_surrogate.py
+++ b/tests/test_load_surrogate.py
@@ -112,3 +112,32 @@ def test_load_surrogate_gatconv_edge_dim(tmp_path):
     model = load_surrogate_model(torch.device('cpu'), path=str(path), use_jit=False)
     assert isinstance(model.layers[0], GATConv)
     assert model.edge_dim == edge_dim
+
+
+def test_load_surrogate_gatconv_hidden_dim(tmp_path):
+    heads = 3
+    in_c = 4
+    out_per_head = 5
+    edge_dim = 2
+    hidden = heads * out_per_head
+    state = {
+        'layers.0.lin_src.weight': torch.zeros(heads * out_per_head, in_c),
+        'layers.0.att_src': torch.zeros(1, heads, out_per_head),
+        'layers.0.att_dst': torch.zeros(1, heads, out_per_head),
+        'layers.0.att_edge': torch.zeros(1, heads, out_per_head),
+        'layers.0.lin_edge.weight': torch.zeros(heads * out_per_head, edge_dim),
+        'layers.0.bias': torch.zeros(heads * out_per_head),
+        'node_decoder.weight': torch.zeros(2, 16),
+        'node_decoder.bias': torch.zeros(2),
+        'edge_decoder.weight': torch.zeros(1, 48),
+        'edge_decoder.bias': torch.zeros(1),
+        'rnn.weight_ih_l0': torch.zeros(64, hidden),
+        'rnn.weight_hh_l0': torch.zeros(64, 16),
+        'rnn.bias_ih_l0': torch.zeros(64),
+        'rnn.bias_hh_l0': torch.zeros(64),
+    }
+    path = tmp_path / 'model.pth'
+    torch.save(state, path)
+
+    model = load_surrogate_model(torch.device('cpu'), path=str(path), use_jit=False)
+    assert model.encoder.norms[0].normalized_shape[0] == hidden


### PR DESCRIPTION
## Summary
- fix hidden dimension inference when loading models with GATConv
- test that MultiTask checkpoints using attention restore correct hidden dim

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6871bdf7b04883249371d121c2c3489c