### PR TITLE
Log-scale chlorine for validation features

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -184,7 +184,7 @@ def _prepare_features(
 
         feats[idx, 0] = float(demand)
         feats[idx, 1] = pressures.get(name, 0.0)
-        feats[idx, 2] = chlorine.get(name, 0.0)
+        feats[idx, 2] = np.log1p(chlorine.get(name, 0.0) / 1000.0)
         feats[idx, 3] = float(elev)
         feats[idx, 4:] = pump_t
     return feats

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -629,7 +629,7 @@ def prepare_node_features(
         if demands is not None:
             feats[:, :, 0] = demands
         feats[:, :, 1] = pressures
-        feats[:, :, 2] = chlorine
+        feats[:, :, 2] = torch.log1p(chlorine / 1000.0)
         feats[:, :, 4 : 4 + num_pumps] = pump_controls.view(batch_size, 1, -1).expand(batch_size, num_nodes, num_pumps)
         in_dim = getattr(getattr(model, "layers", [None])[0], "in_channels", None)
         if in_dim is not None:
@@ -642,7 +642,7 @@ def prepare_node_features(
     if demands is not None:
         feats[:, 0] = demands
     feats[:, 1] = pressures
-    feats[:, 2] = chlorine
+    feats[:, 2] = torch.log1p(chlorine / 1000.0)
     feats[:, 4 : 4 + num_pumps] = pump_controls.view(1, -1).expand(num_nodes, num_pumps)
     in_dim = getattr(getattr(model, "layers", [None])[0], "in_channels", None)
     if in_dim is not None:
@@ -721,7 +721,7 @@ def compute_mpc_cost(
             pred = pred * model.y_std + model.y_mean
         assert not torch.isnan(pred).any(), "NaN prediction"
         pred_p = pred[:, 0]
-        pred_c = pred[:, 1]
+        pred_c = torch.expm1(pred[:, 1]) * 1000.0
 
         # ------------------------------------------------------------------
         # Cost terms
@@ -1025,7 +1025,7 @@ def propagate_with_surrogate(
             assert not torch.isnan(pred).any(), "NaN prediction"
             pred = pred.view(batch_size, feature_template.size(0), -1)
             cur_p = pred[:, :, 0]
-            cur_c = pred[:, :, 1]
+            cur_c = torch.expm1(pred[:, :, 1]) * 1000.0
 
     if single:
         out_p = {n: float(cur_p[0, i]) for i, n in enumerate(wn.node_name_list)}

--- a/tests/test_load_surrogate.py
+++ b/tests/test_load_surrogate.py
@@ -140,4 +140,8 @@ def test_load_surrogate_gatconv_hidden_dim(tmp_path):
     torch.save(state, path)
 
     model = load_surrogate_model(torch.device('cpu'), path=str(path), use_jit=False)
-    assert model.encoder.norms[0].normalized_shape[0] == hidden
+    norm0 = model.encoder.norms[0]
+    if hasattr(norm0, "normalized_shape"):
+        assert norm0.normalized_shape[0] == hidden
+    else:
+        assert getattr(norm0, "in_channels", None) == hidden


### PR DESCRIPTION
## Summary
- log-scale chlorine inputs in `_prepare_features` and MPC feature builder for consistent validation
- convert surrogate chlorine predictions back to mg/L before computing costs or propagating state
- make surrogate loading test compatible with both torch and PyG LayerNorm implementations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cbce623808324802d925fb55dd57b