### PR TITLE
Restrict minima calculations to junctions

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -432,17 +432,11 @@ def run_all_pumps_on(
             {
                 "time": hour,
                 "min_pressure": max(
-                    min(
-                        pressures[n]
-                        for n in wn.junction_name_list + wn.tank_name_list
-                    ),
+                    min(pressures[n] for n in wn.junction_name_list),
                     0.0,
                 ),
                 "min_chlorine": max(
-                    min(
-                        chlorine[n]
-                        for n in wn.junction_name_list + wn.tank_name_list
-                    ),
+                    min(chlorine[n] for n in wn.junction_name_list),
                     0.0,
                 ),
                 "energy": float(energy),
@@ -473,10 +467,8 @@ def run_heuristic_baseline(
     chlorine = results.node["quality"].iloc[-1].to_dict()
 
     for hour in range(24):
-        if min(
-            pressures[n] for n in wn.junction_name_list + wn.tank_name_list
-        ) < threshold_p or min(
-            chlorine[n] for n in wn.junction_name_list + wn.tank_name_list
+        if min(pressures[n] for n in wn.junction_name_list) < threshold_p or min(
+            chlorine[n] for n in wn.junction_name_list
         ) < threshold_c:
             status = wntr.network.base.LinkStatus.Open
         else:
@@ -500,17 +492,11 @@ def run_heuristic_baseline(
             {
                 "time": hour,
                 "min_pressure": max(
-                    min(
-                        pressures[n]
-                        for n in wn.junction_name_list + wn.tank_name_list
-                    ),
+                    min(pressures[n] for n in wn.junction_name_list),
                     0.0,
                 ),
                 "min_chlorine": max(
-                    min(
-                        chlorine[n]
-                        for n in wn.junction_name_list + wn.tank_name_list
-                    ),
+                    min(chlorine[n] for n in wn.junction_name_list),
                     0.0,
                 ),
                 "energy": float(energy),

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -537,6 +537,13 @@ def load_surrogate_model(
 
     model.load_state_dict(state, strict=False)
 
+    # ensure LayerNorm modules expose ``normalized_shape`` for compatibility
+    enc = getattr(model, "encoder", None)
+    if enc is not None:
+        for norm in getattr(enc, "norms", []):
+            if not hasattr(norm, "normalized_shape") and hasattr(norm, "weight"):
+                norm.normalized_shape = (norm.weight.numel(),)
+
     # store expected edge attribute dimension for input checks
     model.edge_dim = edge_dim if edge_dim is not None else 0
 
@@ -1223,14 +1230,8 @@ def simulate_closed_loop(
             cur_c = torch.tensor([chlorine[n] for n in wn.node_name_list], dtype=torch.float32, device=device)
             end = time.time()
             energy = energy_first
-        min_p = max(
-            min(pressures[n] for n in wn.junction_name_list + wn.tank_name_list),
-            0.0,
-        )
-        min_c = max(
-            min(chlorine[n] for n in wn.junction_name_list + wn.tank_name_list),
-            0.0,
-        )
+        min_p = max(min(pressures[n] for n in wn.junction_name_list), 0.0)
+        min_c = max(min(chlorine[n] for n in wn.junction_name_list), 0.0)
         if min_p < Pmin:
             pressure_violations += 1
         if min_c < Cmin:


### PR DESCRIPTION
## Summary
- Compute pressure and chlorine minima over junction nodes only for baseline strategies and MPC, avoiding tanks from skewing results.
- Ensure loaded LayerNorm modules expose `normalized_shape` for compatibility when rebuilding surrogates.

## Testing
- `python scripts/experiments_validation.py --model models/gnn_surrogate.pth --inp CTown.inp --iterations 1 --horizon 1 --no-jit` *(failed: edge attr mismatch)*
- `python - <<'PY' ... (custom run of simulate_closed_loop, run_heuristic_baseline, run_all_pumps_on)`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cbe1aa4208324b72367d1aecd10f7