### PR TITLE
Preserve zero elevations in data generation

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -418,7 +418,10 @@ def build_sequence_dataset(
                     elev = wn_template.get_node(node).base_head
                 else:
                     n = wn_template.get_node(node)
-                    elev = getattr(n, "elevation", None) or getattr(n, "base_head", 0.0)
+                    if getattr(n, "elevation", None) is not None:
+                        elev = n.elevation
+                    else:
+                        elev = getattr(n, "base_head", 0.0)
                 if elev is None:
                     elev = 0.0
                 feat = [d_t, p_t, c_t, elev]
@@ -511,7 +514,10 @@ def build_dataset(
                     elev = wn_template.get_node(node).base_head
                 else:
                     n = wn_template.get_node(node)
-                    elev = getattr(n, "elevation", None) or getattr(n, "base_head", 0.0)
+                    if getattr(n, "elevation", None) is not None:
+                        elev = n.elevation
+                    else:
+                        elev = getattr(n, "base_head", 0.0)
                 if elev is None:
                     elev = 0.0
 


### PR DESCRIPTION
## Summary
- Avoid clobbering zero elevation values when building datasets
- Use explicit None checks instead of `or` fallbacks for node elevations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5ca092988324b0248ef2e7466715