### PR TITLE
Handle reservoir pressure outputs

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -429,7 +429,10 @@ def build_sequence_dataset(
             out_nodes = []
             for node in wn_template.node_name_list:
                 idx = pressures.columns.get_loc(node)
-                p_next = float(pressures.iat[t + 1, idx])
+                if node in wn_template.reservoir_name_list:
+                    p_next = float(wn_template.get_node(node).base_head)
+                else:
+                    p_next = float(pressures.iat[t + 1, idx])
                 c_next = float(quality.iat[t + 1, idx])
                 out_nodes.append([max(p_next, MIN_PRESSURE), max(c_next, 0.0)])
             node_out_seq.append(np.array(out_nodes, dtype=np.float64))
@@ -523,7 +526,10 @@ def build_dataset(
             out_nodes = []
             for node in wn_template.node_name_list:
                 idx = pressures.columns.get_loc(node)
-                p_next = max(pressures.iat[i + 1, idx], MIN_PRESSURE)
+                if node in wn_template.reservoir_name_list:
+                    p_next = float(wn_template.get_node(node).base_head)
+                else:
+                    p_next = max(pressures.iat[i + 1, idx], MIN_PRESSURE)
                 c_next = max(quality.iat[i + 1, idx], 0.0)
                 out_nodes.append([p_next, c_next])
             Y_list.append({

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -185,7 +185,11 @@ def _prepare_features(
             elev = 0.0
 
         feats[idx, 0] = float(demand)
-        feats[idx, 1] = pressures.get(name, 0.0)
+        if name in wn.reservoir_name_list:
+            p_val = float(node.base_head)
+        else:
+            p_val = pressures.get(name, 0.0)
+        feats[idx, 1] = p_val
         feats[idx, 2] = np.log1p(chlorine.get(name, 0.0) / 1000.0)
         feats[idx, 3] = float(elev)
         feats[idx, 4:] = pump_t
@@ -316,6 +320,9 @@ def validate_surrogate(
                 pred_p = node_pred[:, 0].cpu().numpy()
                 pred_c = node_pred[:, 1].cpu().numpy()
                 y_true_p = pressures_df.iloc[i + 1].to_numpy()
+                for j, name in enumerate(wn.node_name_list):
+                    if name in wn.reservoir_name_list:
+                        y_true_p[j] = wn.get_node(name).base_head
                 y_true_c = chlorine_df.iloc[i + 1].to_numpy()
                 # chlorine predictions were trained in log space so convert
                 # predictions back to mg/L before computing errors

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -1116,6 +1116,11 @@ def simulate_closed_loop(
     c_arr = results.node["quality"].iloc[0].to_numpy(dtype=np.float32)
     pressures = dict(zip(wn.node_name_list, p_arr))
     chlorine = dict(zip(wn.node_name_list, c_arr))
+    for res_name in wn.reservoir_name_list:
+        idx = node_idx[res_name]
+        head = wn.get_node(res_name).base_head
+        p_arr[idx] = head
+        pressures[res_name] = head
     # Keep state tensors on GPU to avoid repeated host transfers
     cur_p = (
         torch.from_numpy(p_arr)
@@ -1199,6 +1204,11 @@ def simulate_closed_loop(
             c_arr = results.node["quality"].iloc[-1].to_numpy(dtype=np.float32)
             pressures = dict(zip(wn.node_name_list, p_arr))
             chlorine = dict(zip(wn.node_name_list, c_arr))
+            for res_name in wn.reservoir_name_list:
+                idx = node_idx[res_name]
+                head = wn.get_node(res_name).base_head
+                p_arr[idx] = head
+                pressures[res_name] = head
             # Using non_blocking transfer for EPANET output
             cur_p = (
                 torch.from_numpy(p_arr)

--- a/tests/test_reservoir_feature.py
+++ b/tests/test_reservoir_feature.py
@@ -18,4 +18,6 @@ def test_reservoir_pressure_equals_head():
     idx = wn.node_name_list.index(res_name)
     head = wn.get_node(res_name).base_head
     assert np.allclose(X[:, idx, 1], head)
+    y_press = np.array([y["node_outputs"][idx, 0] for y in Y])
+    assert np.allclose(y_press, head)
 


### PR DESCRIPTION
## Summary
- Ensure reservoir nodes use their base head for pressure targets during data generation, aligning outputs with input features.
- Update validation and MPC routines to treat reservoir pressures as constant heads rather than EPANET-reported zero values.
- Extend reservoir feature test to verify output pressures equal reservoir heads.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5ca1e9588324a910f977a03cbe9a