### PR TITLE
Implement Markov pump schedule with dwell time

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,11 @@ Chlorine decay is enabled in the example network via a global bulk reaction
 coefficient of ``-0.05`` 1/h which EPANET applies during water quality
 simulations.
 Pipe roughness coefficients are left unchanged; only demand multipliers and
-pump schedules vary between scenarios.
+pump schedules vary between scenarios. Pump speeds are sampled from the
+discrete set ``{0.0, 0.5, 1.0}`` and evolve according to a low-probability
+Markov process (≈20% chance of change per hour). On/off transitions require
+at least two hours of dwell time to avoid rapid cycling, and at least one
+pump remains active at any given hour.
 
 After scenario generation finishes a plot ``dataset_distributions_<timestamp>.png``
 is created under ``plots/`` summarising the sampled demand multipliers and pump

--- a/tests/test_pump_controls.py
+++ b/tests/test_pump_controls.py
@@ -1,13 +1,44 @@
 import sys
 from pathlib import Path
+import random
+import numpy as np
+import torch
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from scripts.data_generation import _run_single_scenario
 
 
-def test_at_least_one_pump_active_per_hour():
+def _run_scenario():
     inp = Path(__file__).resolve().parents[1] / 'CTown.inp'
-    res, scale, controls = _run_single_scenario((0, str(inp), 42))
+    py_state = random.getstate()
+    np_state = np.random.get_state()
+    torch_state = torch.random.get_rng_state()
+    try:
+        return _run_single_scenario((0, str(inp), 42))
+    finally:
+        random.setstate(py_state)
+        np.random.set_state(np_state)
+        torch.random.set_rng_state(torch_state)
+
+
+def test_at_least_one_pump_active_per_hour():
+    res, scale, controls = _run_scenario()
     hours = len(next(iter(controls.values())))
     for h in range(hours):
         assert any(controls[p][h] > 0 for p in controls)
+
+
+def test_pump_min_dwell_time():
+    res, scale, controls = _run_scenario()
+    for speeds in controls.values():
+        prev_state = speeds[0] > 0
+        dwell = 1
+        for spd in speeds[1:]:
+            state = spd > 0
+            if state != prev_state:
+                assert dwell >= 2
+                dwell = 1
+                prev_state = state
+            else:
+                dwell += 1
 

--- a/tests/test_reservoir_mask.py
+++ b/tests/test_reservoir_mask.py
@@ -52,7 +52,6 @@ def test_reservoir_node_excluded_from_loss():
         pred["node_outputs"][:, :, mask, :],
         Y_seq["node_outputs"].unsqueeze(0)[:, :, mask, :],
     ).item()
-
     loss_tuple = train_sequence(
         model,
         loader,
@@ -67,6 +66,7 @@ def test_reservoir_node_excluded_from_loss():
         physics_loss=False,
         pressure_loss=False,
         node_mask=mask,
+        loss_fn="mse",
     )
     assert abs(loss_tuple[1] - expected) < 1e-6
 


### PR DESCRIPTION
## Summary
- Introduce Markov-style pump scheduling with discrete speed levels and enforced dwell time
- Document Markov pump scheduling strategy and dwell time in README
- Guard random seeds in pump control tests and add dwell-time validation
- Fix reservoir mask test to use explicit MSE loss

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e70952b448324ad00bcdd3be2b033