### PR TITLE
feat: add continuous pump speed scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,11 @@ Chlorine decay is enabled in the example network via a global bulk reaction
 coefficient of ``-0.05`` 1/h which EPANET applies during water quality
 simulations.
 Pipe roughness coefficients are left unchanged; only demand multipliers and
-pump schedules vary between scenarios. Pump speeds are sampled from the
-discrete set ``{0.0, 0.5, 1.0}`` and evolve according to a low-probability
-Markov process (≈20% chance of change per hour). On/off transitions require
-at least two hours of dwell time to avoid rapid cycling, and at least one
-pump remains active at any given hour.
+pump schedules vary between scenarios. Pump speeds now follow a continuous
+randomization strategy: each pump starts from a value in ``[0.3, 0.9]`` and is
+perturbed by small, temporally correlated Gaussian noise each hour. A short
+dwell time around the ``0.05`` threshold prevents rapid cycling and a safeguard
+ensures at least one pump remains active at any time.
 
 After scenario generation finishes a plot ``dataset_distributions_<timestamp>.png``
 is created under ``plots/`` summarising the sampled demand multipliers and pump


### PR DESCRIPTION
## Summary
- switch pump scheduling to a continuous Gaussian random walk with clamping and dwell enforcement
- document continuous pump-speed randomization in README and docstrings
- add tests for continuous correlated pump speeds and ensure at least one pump remains active

## Testing
- `pytest tests/test_pump_controls.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6eff0060832494cd8fa9b6de3e21