### PR TITLE
Fix tank dynamics unit conversion

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -445,7 +445,8 @@ class MultiTaskGNNSurrogate(nn.Module):
                     else:
                         net.append((flows[:, t, edges] * signs).sum(dim=1))
                 net_flow = torch.stack(net, dim=1)
-                delta_vol = net_flow * 3600.0
+                # Net flow is in L/s; convert to m³ over one hour
+                delta_vol = net_flow * 3600.0 * 0.001
                 self.tank_levels += delta_vol
                 # Prevent negative volumes accumulating
                 self.tank_levels = self.tank_levels.clamp(min=0.0)

--- a/tests/test_tank_dynamics.py
+++ b/tests/test_tank_dynamics.py
@@ -28,4 +28,4 @@ def test_tank_pressure_update():
     model.tank_signs = [torch.tensor([1.0])]
     X = torch.zeros(1,1,2,2)
     out = model(X, edge_index, edge_attr)
-    assert torch.isclose(out['node_outputs'][0,0,0,0], torch.tensor(3600.0))
+    assert torch.isclose(out['node_outputs'][0,0,0,0], torch.tensor(3.6))


### PR DESCRIPTION
## Summary
- convert tank net flow from L/s to m^3 when updating volume
- adjust tank dynamics test to expect 3.6 m rise for 1 L/s inflow

## Testing
- `PYTHONPATH=. pytest tests/test_tank_dynamics.py`


------
https://chatgpt.com/codex/tasks/task_e_688f7026dd6083248722f8a8dacea12f