### PR TITLE
Add pump curve loss and integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
   - `test_extreme_events.py`
   - `test_flow_denorm.py`
   - `test_headloss_loss.py`
+  - `test_pump_curve_loss.py`
   - `test_hydroconv.py`
   - `test_interrupt_dataloader.py`
   - `test_interrupt_handler.py`

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ accordingly. When using the matrix format, supply the path to the shared
 ``edge_index`` file via ``--edge-index-path`` (defaults to ``data/edge_index.npy``).
 Edge attributes describing pipe length, diameter and roughness are stored in
 ``edge_attr.npy`` by ``scripts/data_generation.py``. ``train_gnn.py`` loads this
-file by default via ``--edge-attr-path``.
+file by default via ``--edge-attr-path``. Pump curve coefficients are saved as
+``pump_coeffs.npy`` and included in a dedicated pump curve loss during training
+(``--pump-loss``) with weight ``--w_pump``.
 
 Training performs node-wise regression and by default optimizes the mean
 absolute error (MAE).  Specify ``--loss-fn`` to switch between MAE (``mae``),
@@ -185,8 +187,8 @@ python scripts/data_generation.py \
     --num-scenarios 2000 --output-dir data/ --seed 42 \
     --extreme-event-prob 0.2
 ```
-The generation step writes ``edge_index.npy``, ``edge_attr.npy`` and
-``edge_type.npy`` alongside the feature and label arrays. It utilizes all available CPU cores by default. The value
+The generation step writes ``edge_index.npy``, ``edge_attr.npy``, ``edge_type.npy`` and
+``pump_coeffs.npy`` alongside the feature and label arrays. It utilizes all available CPU cores by default. The value
 ``2000`` matches the new default of ``--num-scenarios``. Use
 ``--num-workers`` to override the number of parallel workers if needed.
 If a particular random configuration causes EPANET to fail to produce results,

--- a/tests/test_pump_curve_loss.py
+++ b/tests/test_pump_curve_loss.py
@@ -1,0 +1,12 @@
+import torch
+from models.loss_utils import pump_curve_loss
+
+
+def test_pump_curve_loss_zero():
+    # coefficients from CTown pump curve
+    coeffs = torch.tensor([[70.0, 909.8618175228993, 1.3569154488567239]], dtype=torch.float32)
+    flow = torch.tensor([0.06], dtype=torch.float32)
+    edge_index = torch.tensor([[0], [1]], dtype=torch.long)
+    edge_type = torch.tensor([1], dtype=torch.long)
+    loss = pump_curve_loss(flow, coeffs, edge_index, edge_type)
+    assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)


### PR DESCRIPTION
## Summary
- add `pump_curve_loss` to penalize flow predictions that violate pump head–flow curves
- export pump curve coefficients during data generation and load them for training
- integrate pump curve penalty into GNN training with new CLI options and weights
- document new behaviour and add regression test

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f73eb00a883249ffbe055df603fb6