### PR TITLE
Add pump-edge embedding and tests

### DIFF
--- a/tests/test_recurrent_forward.py
+++ b/tests/test_recurrent_forward.py
@@ -1,9 +1,10 @@
 import torch
 from scripts.train_gnn import RecurrentGNNSurrogate, MultiTaskGNNSurrogate
 
-def test_recurrent_gnn_forward_shape():
-    edge_index = torch.tensor([[0,1],[1,0]], dtype=torch.long)
-    edge_attr = torch.ones(2,3)
+def test_recurrent_gnn_forward_shape_with_pump_edges():
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    edge_attr = torch.ones(2, 3)
+    edge_type = torch.tensor([1, 1], dtype=torch.long)  # pump edges
     model = RecurrentGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
@@ -15,15 +16,17 @@ def test_recurrent_gnn_forward_shape():
         dropout=0.0,
         residual=False,
         rnn_hidden_dim=5,
+        num_edge_types=2,
     )
     X_seq = torch.ones(1, 3, 2, 2)
-    out = model(X_seq, edge_index, edge_attr)
+    out = model(X_seq, edge_index, edge_attr, edge_type=edge_type)
     assert out.shape == (1, 3, 2, 1)
 
 
-def test_multitask_gnn_forward_shapes():
-    edge_index = torch.tensor([[0,1],[1,0]], dtype=torch.long)
-    edge_attr = torch.ones(2,3)
+def test_multitask_gnn_forward_shapes_with_pump_edges():
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    edge_attr = torch.ones(2, 3)
+    edge_type = torch.tensor([1, 1], dtype=torch.long)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
@@ -36,8 +39,9 @@ def test_multitask_gnn_forward_shapes():
         dropout=0.0,
         residual=False,
         rnn_hidden_dim=8,
+        num_edge_types=2,
     )
     X_seq = torch.ones(1, 3, 2, 2)
-    out = model(X_seq, edge_index, edge_attr)
+    out = model(X_seq, edge_index, edge_attr, edge_type=edge_type)
     assert out['node_outputs'].shape == (1, 3, 2, 2)
     assert out['edge_outputs'].shape == (1, 3, 2, 1)


### PR DESCRIPTION
## Summary
- Distinguish pump edges with a learnable embedding in `HydroConv` and integrate edge-type information in message passing
- Save and supply edge types—pipes, pumps, and valves—into datasets and the model
- Add unit tests ensuring recurrent GNNs process pump edges correctly

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f796ec77c8324b7a1294997942f44