### PR TITLE
Enable fractional pump speeds in MPC controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ are installed before continuing.
 The repository provides a simple training script `scripts/train_gnn.py` which
 expects feature and label data saved in the `data/` directory as NumPy arrays.
 Each node feature vector has the layout
-``[base_demand, pressure, chlorine, elevation, pump_1, ..., pump_N]`` where the
-additional elements represent the speeds of all pumps in the network. Reservoir
-nodes use their constant hydraulic head in the ``pressure`` slot so the model is
-given the correct supply level. The helper script `scripts/data_generation.py`
+``[base_demand, pressure, chlorine, elevation, pump_1, ..., pump_N]`` where each
+``pump_i`` denotes the fractional pump speed in ``[0, 1]`` rather than a binary
+on/off flag. Reservoir nodes use their constant hydraulic head in the
+``pressure`` slot so the model is given the correct supply level. The helper
+script `scripts/data_generation.py`
 generates these arrays as well as the graph ``edge_index``.  Two dataset formats
 are
 supported:
@@ -280,8 +281,8 @@ dedicated energy output and ties the optimisation to physical principles.
 By default the controller loads the most recent ``.pth`` file found in the
 ``models`` directory so retraining will automatically use the newest weights.
 
-This executes a 24‑hour closed loop simulation where pump actions are optimized
-at each hour.  EPANET is only called every 24 hours (controlled by
+This executes a 24‑hour closed loop simulation where fractional pump speeds are
+optimized at each hour.  EPANET is only called every 24 hours (controlled by
 ``--feedback-interval``) and all intermediate updates rely on the GNN surrogate
 running entirely on a CUDA device.  Results are written to
 `data/mpc_history.csv`.  A summary listing constraint violations and total

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -268,7 +268,7 @@ def validate_surrogate(
             demand_df = res.node.get("demand")
             pump_df = res.link["setting"][wn.pump_name_list]
             times = pressures_df.index
-            pump_array = pump_df.values
+            pump_array = np.clip(pump_df.values, 0.0, 1.0)
             for i in range(len(times) - 1):
                 p = pressures_df.iloc[i].to_dict()
                 c = chlorine_df.iloc[i].to_dict()

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -17,3 +17,27 @@ def test_pump_energy_not_nan():
     results = sim.run_sim(str(TEMP_DIR / "temp"))
     energy_df = pump_energy(results.link['flowrate'][wn.pump_name_list], results.node['head'], wn)
     assert not energy_df[wn.pump_name_list].isna().any().any(), 'energy contains NaN'
+
+
+def _simulate_speed(speed: float):
+    wn = wntr.network.WaterNetworkModel('CTown.inp')
+    for pn in wn.pump_name_list:
+        pump = wn.get_link(pn)
+        pump.initial_status = wntr.network.base.LinkStatus.Open
+        pump.base_speed = speed
+    wn.options.time.hydraulic_timestep = 3600
+    wn.options.time.duration = 3600
+    wn.options.time.report_timestep = 3600
+    sim = wntr.sim.EpanetSimulator(wn)
+    results = sim.run_sim(str(TEMP_DIR / f"temp_{speed}"))
+    flows = results.link['flowrate'][wn.pump_name_list].iloc[-1].abs().sum()
+    energy_df = pump_energy(results.link['flowrate'][wn.pump_name_list], results.node['head'], wn)
+    energy = energy_df[wn.pump_name_list].iloc[-1].sum()
+    return flows, energy
+
+
+def test_fractional_pump_speed_affects_flow_and_energy():
+    flow_half, energy_half = _simulate_speed(0.5)
+    flow_full, energy_full = _simulate_speed(1.0)
+    assert flow_half < flow_full
+    assert energy_half < energy_full

--- a/tests/test_energy_clamp.py
+++ b/tests/test_energy_clamp.py
@@ -7,7 +7,7 @@ from scripts.mpc_control import compute_mpc_cost
 
 def test_negative_flow_headloss_clamped():
     wn = wntr.network.WaterNetworkModel('CTown.inp')
-    u = torch.zeros((1, 1))
+    speeds = torch.zeros((1, 1))
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
     edge_attr = torch.zeros((1, 3))
     node_types = torch.zeros(2, dtype=torch.long)
@@ -28,7 +28,7 @@ def test_negative_flow_headloss_clamped():
     pump_info = [(0, 0, 1)]
     with pytest.warns(RuntimeWarning):
         cost, energy = compute_mpc_cost(
-            u,
+            speeds,
             wn,
             model,
             edge_index,


### PR DESCRIPTION
## Summary
- Treat pumps as continuous-speed devices in MPC logic
- Clamp and forward fractional pump speeds to EPANET
- Document and test variable-speed pump behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f89822b888324bafd1d39fbf75c9d