### PR TITLE
Add optional progress bar for data generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ The generation step writes ``edge_index.npy``, ``edge_attr.npy``, ``edge_type.np
 ``pump_coeffs.npy`` alongside the feature and label arrays. It utilizes all available CPU cores by default. The value
 ``2000`` matches the new default of ``--num-scenarios``. Use
 ``--num-workers`` to override the number of parallel workers if needed.
+Pass ``--show-progress`` to display a live progress bar during simulation
+when ``tqdm`` is installed.
 If a particular random configuration causes EPANET to fail to produce results,
 the script now skips it after a few retries so the actual number of generated
 scenarios may be slightly smaller than requested.

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _dummy_run(args, extreme_event_prob: float = 0.0):
+    """Return a trivial result tuple for fast testing."""
+    return (None, {}, {})
+
+
+def test_run_scenarios_show_progress(monkeypatch):
+    import scripts.data_generation as dg
+
+    monkeypatch.setattr(dg, "_run_single_scenario", _dummy_run)
+    results = dg.run_scenarios("foo", 3, num_workers=2, show_progress=True)
+    assert len(results) == 3
+
+
+def test_run_scenarios_show_progress_no_tqdm(monkeypatch):
+    import scripts.data_generation as dg
+
+    monkeypatch.setattr(dg, "_run_single_scenario", _dummy_run)
+    monkeypatch.setattr(dg, "tqdm", None)
+    results = dg.run_scenarios("foo", 2, num_workers=2, show_progress=True)
+    assert len(results) == 2
+
+
+def test_data_generation_cli_show_progress(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    cmd = [
+        sys.executable,
+        str(repo / "scripts/data_generation.py"),
+        "--num-scenarios",
+        "0",
+        "--output-dir",
+        str(tmp_path),
+        "--show-progress",
+    ]
+    subprocess.run(cmd, check=True)
+


### PR DESCRIPTION
## Summary
- show progress during scenario simulation with an optional tqdm bar
- add `--show-progress` flag to `scripts/data_generation.py`
- document progress option in README and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f9b0f7a94832480c482eb53c057ff