### PR TITLE
feat: add temp file cleanup helper

### DIFF
--- a/tests/test_tempfile_cleanup.py
+++ b/tests/test_tempfile_cleanup.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import scripts.data_generation as dg  # noqa: E402
+
+
+def test_temp_files_cleanup_on_failure(tmp_path, monkeypatch):
+    # Redirect temporary files to the pytest-provided directory
+    monkeypatch.setattr(dg, "TEMP_DIR", tmp_path)
+
+    class FailingSim:
+        def __init__(self, wn):
+            pass
+
+        def run_sim(self, file_prefix):
+            Path(f"{file_prefix}.rpt").touch()
+            raise dg.wntr.epanet.exceptions.EpanetException("fail")
+
+    monkeypatch.setattr(dg.wntr.sim, "EpanetSimulator", FailingSim)
+
+    res = dg._run_single_scenario((0, str(dg.REPO_ROOT / "CTown.inp"), 42))
+    assert res is None
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary
- ensure EPANET simulation temp files are always deleted using a new `temp_simulation_files` context manager
- simplify `_run_single_scenario` to use the helper for automatic cleanup
- test that failed simulations leave no stray temp files behind

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9e6bdb408324b8e55fbd5a766b62