### PR TITLE
Add training resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ python scripts/train_gnn.py \
     --dropout 0.1 --residual --early-stop-patience 10 \
     --weight-decay 1e-5
 ```
+If training is interrupted with ``Ctrl+C`` a final checkpoint containing the
+model, optimizer, scheduler state and epoch is saved so progress is not lost.
+To continue a previous run pass the checkpoint path via ``--resume``.  All
+standard arguments still need to be supplied:
+
+```bash
+python scripts/train_gnn.py \
+    --resume models/gnn_surrogate_20240101.pth \
+    --x-path data/X_train.npy --y-path data/Y_train.npy \
+    --edge-index-path data/edge_index.npy --edge-attr-path data/edge_attr.npy \
+    --inp-path CTown.inp --epochs 100 --batch-size 32
+```
+Training will continue from the stored epoch and future checkpoints are written
+back to the same file so the run can be resumed repeatedly.
 Add ``--loss-fn huber`` to the command above to train with Huber loss or
 ``--loss-fn mse`` to minimize mean squared error instead.
 Pass ``--no-progress`` to disable the training progress bars or

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -293,6 +293,8 @@ def load_surrogate_model(
             f"{full_path} not found. Run train_gnn.py to generate the surrogate weights."
         )
     state = torch.load(str(full_path), map_location=device)
+    if isinstance(state, dict) and "model_state_dict" in state:
+        state = state["model_state_dict"]
 
     # Support both the current ``layers.X`` style parameter names as well as
     # older checkpoints that used ``conv1``/``conv2``.  If the latter is

--- a/tests/test_interrupt_handler.py
+++ b/tests/test_interrupt_handler.py
@@ -1,12 +1,25 @@
 import sys
 from pathlib import Path
 
+import torch
+from torch import nn
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from scripts.train_gnn import handle_keyboard_interrupt
 
 
-def test_handle_keyboard_interrupt(capsys):
-    handle_keyboard_interrupt("foo/bar.pth")
+def test_handle_keyboard_interrupt(tmp_path, capsys):
+    model = nn.Linear(1, 1)
+    optimizer = torch.optim.Adam(model.parameters())
+    scheduler = ReduceLROnPlateau(optimizer)
+    ckpt = tmp_path / "ckpt.pth"
+    handle_keyboard_interrupt(str(ckpt), model, optimizer, scheduler, 5)
     captured = capsys.readouterr()
     assert "Training interrupted" in captured.out
-    assert "foo/bar.pth" in captured.out
+    assert str(ckpt) in captured.out
+    state = torch.load(ckpt)
+    assert state["epoch"] == 5
+    assert "model_state_dict" in state
+    assert "optimizer_state_dict" in state
+    assert "scheduler_state_dict" in state


### PR DESCRIPTION
## Summary
- add `--resume` option to `train_gnn.py` and persist model, optimizer, scheduler and epoch in checkpoints
- load checkpoints when `--resume` is provided and continue training from saved epoch
- save final training state on keyboard interrupt and allow `load_surrogate_model` to read new checkpoint format
- document resume workflow in `README`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa855c900832492d7d1a0bbeab3d8