### PR TITLE
refactor: derive coords from network object

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ pip install -r requirements.txt
 ```
 
 This installs PyTorch, PyTorch Geometric, `numpy`, `scikit-learn`, `wntr`,
-`pandas`, `matplotlib`, `networkx` and `epyt` along with other dependencies.
+`pandas`, `matplotlib`, and `networkx` along with other dependencies.
 
 ## Testing Protocols
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 ```
 
 This installs PyTorch, PyTorch Geometric, `numpy`, `scikit-learn`, `wntr`,
-`pandas`, `matplotlib`, `networkx` and `epyt` which are required for the
+`pandas`, `matplotlib`, and `networkx` which are required for the
 training and control scripts.
 
 ## Quick GPU check

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ wntr
 pandas
 matplotlib
 networkx
-epyt


### PR DESCRIPTION
## Summary
- Accept a `WaterNetworkModel` in `pressure_error_heatmap` and pull node coordinates from it
- Drop `epyt` dependency and update docs/requirements accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fc4c6d41c8324bc4e249a6d959c1c