### PR TITLE
Fix model checkpoint loading in train_gnn

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2382,7 +2382,10 @@ def main(args: argparse.Namespace):
                 pin_memory=torch.cuda.is_available(),
                 persistent_workers=args.workers > 0,
             )
-        model.load_state_dict(torch.load(model_path, map_location=device))
+        state = torch.load(model_path, map_location=device)
+        if isinstance(state, dict) and "model_state_dict" in state:
+            state = state["model_state_dict"]
+        model.load_state_dict(state)
         model.eval()
         preds_p = []
         preds_c = []


### PR DESCRIPTION
## Summary
- fix loading saved checkpoints during evaluation by extracting `model_state_dict`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689660b623c08324a33ef6de68abd817