### PR TITLE
Add configurable loss weights for GNN training

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
 - `pytorchcheck.py` – quick script verifying that PyTorch Geometric runs on the configured GPU.
 - `models/`
   - `loss_utils.py` – physics-based loss helpers.
+  - `losses.py` – weighted multi-task loss utilities.
   - `gnn_surrogate.pth` – trained weights saved here after running the training script.
 - `scripts/`
   - `data_generation.py` – create randomized simulation scenarios and produce training datasets.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ training statistics. During evaluation both predictions **and** the
 corresponding ground truth labels are transformed back to physical units before
 plotting.
 When sequence models are used a component-wise loss curve
-``loss_components_<run>.png`` is stored alongside ``loss_curve_<run>.png``.
+``loss_components_<run>.png`` is stored alongside ``loss_curve_<run>.png`` and
+the per-component pressure, chlorine and flow losses are recorded each epoch in
+``training_<run>.log`` as well as TensorBoard summaries.
 For sequence datasets a time-series example ``time_series_example_<run>.png``
 plots predicted and actual pressure and chlorine for one node across all steps.
 
@@ -170,10 +172,11 @@ Reservoirs and tanks are excluded from the mass balance calculation while tank
 pressures are no longer part of the direct MSE loss.  Disable the physics terms
 with ``--no-physics-loss`` if necessary. ``--pressure_loss`` is enabled by
 default to enforce pressure–headloss consistency via the Hazen--Williams
-equation.  The mass and edge penalties keep a default weight of ``1.0`` while
-the headloss term uses ``0.25``. The relative importance can still be tuned via
-``--w_mass`` and ``--w_head`` along with the ``--w_edge`` coefficient
-controlling the flow loss.
+equation.  The mass and flow penalties keep a default weight of ``1.0`` while
+the headloss term uses ``0.25``. Node pressure and chlorine terms now have
+independent weights ``--w-press`` (default ``3.0``) and ``--w-cl`` (``1.0``),
+and pipe flows are scaled by ``--w-flow`` (``1.0``). The relative importance can
+still be tuned via these flags together with ``--w_mass`` and ``--w_head``.
 
 The trained model now supports validation loss tracking and early stopping.
 Normalization is applied automatically so the ``--normalize`` flag is optional.

--- a/models/losses.py
+++ b/models/losses.py
@@ -1,0 +1,50 @@
+"""Loss helpers for weighted multi-task training."""
+from typing import Tuple
+import torch
+import torch.nn.functional as F
+
+
+def _apply_loss(pred: torch.Tensor, target: torch.Tensor, loss_fn: str) -> torch.Tensor:
+    """Apply the selected pointwise loss between ``pred`` and ``target``."""
+    if loss_fn == "mse":
+        return F.mse_loss(pred, target)
+    if loss_fn == "huber":
+        return F.smooth_l1_loss(pred, target, beta=1.0)
+    return F.l1_loss(pred, target)
+
+
+def weighted_mtl_loss(
+    pred_nodes: torch.Tensor,
+    target_nodes: torch.Tensor,
+    edge_preds: torch.Tensor,
+    edge_target: torch.Tensor,
+    *,
+    loss_fn: str = "mae",
+    w_press: float = 3.0,
+    w_cl: float = 1.0,
+    w_flow: float = 1.0,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return total and component losses for pressure, chlorine and flow.
+
+    Parameters
+    ----------
+    pred_nodes: ``[..., num_nodes, 2]``
+        Predicted node outputs where channel ``0`` is pressure and ``1`` is
+        chlorine.
+    target_nodes: same shape as ``pred_nodes``
+        Ground truth node outputs.
+    edge_preds: ``[..., num_edges, 1]``
+        Predicted edge flows.
+    edge_target: same shape as ``edge_preds``
+        Ground truth edge flows.
+    loss_fn: {"mae", "mse", "huber"}
+        Base loss applied per component.
+    w_press, w_cl, w_flow: float
+        Weights for pressure, chlorine and flow losses respectively.
+    """
+    press_loss = _apply_loss(pred_nodes[..., 0], target_nodes[..., 0], loss_fn)
+    cl_loss = _apply_loss(pred_nodes[..., 1], target_nodes[..., 1], loss_fn)
+    flow_loss = _apply_loss(edge_preds, edge_target, loss_fn)
+    total = w_press * press_loss + w_cl * cl_loss + w_flow * flow_loss
+    return total, press_loss, cl_loss, flow_loss
+

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -64,3 +64,69 @@ def test_cli_no_pressure_loss(tmp_path):
     assert log_file.exists()
     log_text = log_file.read_text()
     assert "'pressure_loss': False" in log_text
+
+
+def test_cli_loss_weights(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    data_dir = repo / "data"
+    data_dir.mkdir(exist_ok=True)
+    log_file = data_dir / "training_unit_weights.log"
+    if log_file.exists():
+        log_file.unlink()
+
+    wn = wntr.network.WaterNetworkModel(repo / "CTown.inp")
+    node_map = {n: i for i, n in enumerate(wn.node_name_list)}
+    link = wn.get_link(wn.link_name_list[0])
+    edge_index = np.array(
+        [
+            [node_map[link.start_node.name], node_map[link.end_node.name]],
+            [node_map[link.end_node.name], node_map[link.start_node.name]],
+        ],
+        dtype=np.int64,
+    )
+    edge_attr = build_edge_attr(wn, edge_index)
+
+    np.save(tmp_path / "edge_index.npy", edge_index)
+    np.save(tmp_path / "edge_attr.npy", edge_attr)
+
+    F = 4 + len(wn.pump_name_list)
+    N = len(wn.node_name_list)
+    X = np.ones((1, N, F), dtype=np.float32)
+    Y = np.zeros((1, N, 2), dtype=np.float32)
+    np.save(tmp_path / "X.npy", X)
+    np.save(tmp_path / "Y.npy", Y)
+
+    cmd = [
+        "python",
+        str(repo / "scripts/train_gnn.py"),
+        "--x-path",
+        str(tmp_path / "X.npy"),
+        "--y-path",
+        str(tmp_path / "Y.npy"),
+        "--edge-index-path",
+        str(tmp_path / "edge_index.npy"),
+        "--edge-attr-path",
+        str(tmp_path / "edge_attr.npy"),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--run-name",
+        "unit_weights",
+        "--output",
+        str(tmp_path / "model.pth"),
+        "--w-press",
+        "2.5",
+        "--w-cl",
+        "0.5",
+        "--w-flow",
+        "1.5",
+    ]
+
+    subprocess.run(cmd, check=True)
+
+    assert log_file.exists()
+    log_text = log_file.read_text()
+    assert "'w_press': 2.5" in log_text
+    assert "'w_cl': 0.5" in log_text
+    assert "'w_flow': 1.5" in log_text

--- a/tests/test_reservoir_mask.py
+++ b/tests/test_reservoir_mask.py
@@ -48,9 +48,9 @@ def test_reservoir_node_excluded_from_loss():
     X_seq, Y_seq = ds[0]
     with torch.no_grad():
         pred = model(X_seq.unsqueeze(0), ds.edge_index, ds.edge_attr, None, None)
-    expected = F.mse_loss(
-        pred["node_outputs"][:, :, mask, :],
-        Y_seq["node_outputs"].unsqueeze(0)[:, :, mask, :],
+    expected_p = F.mse_loss(
+        pred["node_outputs"][:, :, mask, 0],
+        Y_seq["node_outputs"].unsqueeze(0)[:, :, mask, 0],
     ).item()
     loss_tuple = train_sequence(
         model,
@@ -68,7 +68,7 @@ def test_reservoir_node_excluded_from_loss():
         node_mask=mask,
         loss_fn="mse",
     )
-    assert abs(loss_tuple[1] - expected) < 1e-6
+    assert abs(loss_tuple[1] - expected_p) < 1e-6
 
 
 def test_build_loss_mask_ctown():


### PR DESCRIPTION
## Summary
- introduce `weighted_mtl_loss` helper for pressure, chlorine and flow components
- expose `--w-press`, `--w-cl` and `--w-flow` flags in `train_gnn.py`
- log per-component losses to TensorBoard and training CSV

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6898f760222c8324be35888ff9266167