### PR TITLE
Augment data generation with extreme scenario sampling

### DIFF
--- a/tests/test_extreme_events.py
+++ b/tests/test_extreme_events.py
@@ -6,6 +6,6 @@ from scripts.data_generation import _run_single_scenario
 
 def test_extreme_event_label():
     inp = Path(__file__).resolve().parents[1] / 'CTown.inp'
-    res, _, _ = _run_single_scenario((0, str(inp), 123), extreme_event_prob=1.0)
+    res, _, _ = _run_single_scenario((0, str(inp), 123), extreme_rate=1.0)
     assert hasattr(res, 'scenario_type')
-    assert res.scenario_type in {'fire_flow', 'pump_failure', 'quality_variation'}
+    assert res.scenario_type != 'normal'

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 
-def _dummy_run(args, extreme_event_prob: float = 0.0):
+def _dummy_run(args, **kwargs):
     """Return a trivial result tuple for fast testing."""
     return (None, {}, {})
 


### PR DESCRIPTION
## Summary
- add localized demand surges, pump outages, pipe closures, and stress-test sampling to data generation
- expose new CLI knobs (`--extreme-rate`, `--pump-outage-rate`, `--local-surge-rate`, `--tank-level-range`) and write pressure manifest & histograms
- document scenario augmentation options in README and adjust tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68990329f7a4832489617ea7112e061e