### PR TITLE
Add configurable residual GNN options and ablation study

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
   - `experiments_validation.py` – validate the surrogate, compare baselines and aggregate results.
   - `metrics.py` – report surrogate accuracy, MPC control and runtime metrics.
   - `mpc_control.py` – run gradient-based MPC using the trained surrogate.
+  - `ablation_study.py` – run a small grid of model variants and report validation pressure MAE.
   - `train_gnn.py` – train a graph neural network surrogate on generated data.
 - `tests/` – pytest suite containing:
   - `test_accuracy_export.py`

--- a/README.md
+++ b/README.md
@@ -118,11 +118,14 @@ python scripts/train_gnn.py \
     --x-val-path data/X_val.npy --y-val-path data/Y_val.npy \
     --edge-index-path data/edge_index.npy --edge-attr-path data/edge_attr.npy \
     --inp-path CTown.inp \
-    --epochs 100 --batch-size 32 --hidden-dim 64 --num-layers 4 \
-    --workers 8 \
+    --epochs 100 --batch-size 32 --hidden-dim 128 --num-layers 4 \
+    --lstm-hidden 64 --workers 8 \
     --dropout 0.1 --residual --early-stop-patience 10 \
     --weight-decay 1e-5
 ```
+GNN depth and width are controlled via ``--num-layers`` (choose from {4,6,8}) and ``--hidden-dim`` ({128,256}).
+Use ``--residual`` to enable skip connections and ``--use-attention`` for graph attention on node updates.
+The LSTM hidden size can be set with ``--lstm-hidden`` (64 or 128).
 If training is interrupted with ``Ctrl+C`` a final checkpoint containing the
 model, optimizer, scheduler state and epoch is saved so progress is not lost.
 To continue a previous run pass the checkpoint path via ``--resume``.  All
@@ -256,7 +259,7 @@ Scenarios that do not contain at least ``sequence_length + 1`` time steps are
 skipped with a warning so the actual dataset may be smaller than requested.
 
 The training script automatically detects such sequence files and will use the recurrent
-model. Adjust the recurrent hidden size via ``--rnn-hidden-dim`` if desired.
+model. Adjust the recurrent hidden size via ``--lstm-hidden`` (alias ``--rnn-hidden-dim``) choosing 64 or 128.
 
 Validate the resulting model with `scripts/experiments_validation.py` before
 running the MPC controller.  The validation script executes a 24‑hour
@@ -281,6 +284,15 @@ python scripts/experiments_validation.py \
     --model models/gnn_surrogate.pth --inp CTown.inp \
     --horizon 6 --iterations 50 --feedback-interval 1 \
     --run-name baseline
+```
+
+To benchmark architectural variants, run ``scripts/ablation_study.py`` which trains four configurations (baseline, residual, deep and attention) and reports validation pressure MAE along with training time.
+
+```bash
+python scripts/ablation_study.py \
+    --x-path data/X_train.npy --y-path data/Y_train.npy \
+    --edge-index-path data/edge_index.npy --edge-attr-path data/edge_attr.npy \
+    --inp-path CTown.inp --epochs 20 --batch-size 32
 ```
 
 To examine how surrogate errors accumulate without EPANET feedback, enable

--- a/models/gnn_surrogate.py
+++ b/models/gnn_surrogate.py
@@ -1,0 +1,454 @@
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.nn import MultiheadAttention
+from torch_geometric.nn import GCNConv, GATConv, LayerNorm, MessagePassing
+from typing import Optional, Sequence
+
+
+class HydroConv(MessagePassing):
+    """Mass-conserving convolution supporting heterogeneous components."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        edge_dim: int,
+        num_node_types: int = 1,
+        num_edge_types: int = 1,
+    ) -> None:
+        super().__init__(aggr="add")
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.num_node_types = num_node_types
+        self.num_edge_types = num_edge_types
+
+        self.lin = nn.ModuleList(
+            [nn.Linear(in_channels, out_channels) for _ in range(num_node_types)]
+        )
+
+        self.edge_mlps = nn.ModuleList(
+            [nn.Sequential(nn.Linear(edge_dim, 1), nn.Softplus()) for _ in range(num_edge_types)]
+        )
+
+        self.edge_type_emb = (
+            nn.Embedding(num_edge_types, edge_dim) if num_edge_types > 1 else None
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_attr: Optional[torch.Tensor] = None,
+        node_type: Optional[torch.Tensor] = None,
+        edge_type: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if edge_attr is None:
+            raise ValueError("edge_attr cannot be None for HydroConv")
+
+        if node_type is None:
+            node_type = torch.zeros(x.size(0), dtype=torch.long, device=x.device)
+        if edge_type is None:
+            edge_type = torch.zeros(edge_index.size(1), dtype=torch.long, device=edge_index.device)
+
+        aggr = self.propagate(edge_index, x=x, edge_attr=edge_attr, edge_type=edge_type)
+        out = torch.zeros((x.size(0), self.out_channels), device=x.device, dtype=aggr.dtype)
+        for t, lin in enumerate(self.lin):
+            idx = node_type == t
+            if torch.any(idx):
+                out[idx] = lin(aggr[idx]).to(out.dtype)
+        return out
+
+    def message(
+        self,
+        x_i: torch.Tensor,
+        x_j: torch.Tensor,
+        edge_attr: torch.Tensor,
+        edge_type: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.edge_type_emb is not None:
+            edge_attr = edge_attr + self.edge_type_emb(edge_type)
+        weight = torch.zeros(edge_attr.size(0), 1, device=edge_attr.device)
+        for t, mlp in enumerate(self.edge_mlps):
+            idx = edge_type == t
+            if torch.any(idx):
+                weight[idx] = mlp(edge_attr[idx]).to(weight.dtype)
+        return weight * (x_j - x_i)
+
+
+class EnhancedGNNEncoder(nn.Module):
+    """Flexible GNN encoder supporting heterogeneous graphs and attention."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        out_channels: int,
+        num_layers: int = 2,
+        dropout: float = 0.0,
+        activation: str = "relu",
+        residual: bool = False,
+        edge_dim: Optional[int] = None,
+        use_attention: bool = False,
+        gat_heads: int = 4,
+        share_weights: bool = False,
+        num_node_types: int = 1,
+        num_edge_types: int = 1,
+    ) -> None:
+        super().__init__()
+
+        self.use_attention = use_attention
+        self.dropout = dropout
+        self.residual = residual
+        self.act_fn = getattr(F, activation)
+        self.share_weights = share_weights
+        self.num_node_types = num_node_types
+        self.num_edge_types = num_edge_types
+
+        def make_conv(in_c: int, out_c: int):
+            if use_attention:
+                return GATConv(in_c, out_c // gat_heads, heads=gat_heads, edge_dim=edge_dim)
+            if edge_dim is not None:
+                return HydroConv(
+                    in_c,
+                    out_c,
+                    edge_dim,
+                    num_node_types=self.num_node_types,
+                    num_edge_types=self.num_edge_types,
+                )
+            return GCNConv(in_c, out_c)
+
+        self.convs = nn.ModuleList()
+        self.norms = nn.ModuleList()
+
+        if share_weights:
+            first = make_conv(in_channels, hidden_channels)
+            self.convs.append(first)
+            shared = first if in_channels == hidden_channels else make_conv(hidden_channels, hidden_channels)
+            for _ in range(num_layers - 1):
+                self.convs.append(shared)
+        else:
+            for i in range(num_layers):
+                in_c = in_channels if i == 0 else hidden_channels
+                self.convs.append(make_conv(in_c, hidden_channels))
+
+        for _ in range(num_layers):
+            self.norms.append(LayerNorm(hidden_channels))
+
+        self.fc_out = nn.Linear(hidden_channels, out_channels)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_attr: Optional[torch.Tensor] = None,
+        node_type: Optional[torch.Tensor] = None,
+        edge_type: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        for conv, norm in zip(self.convs, self.norms):
+            identity = x
+            if isinstance(conv, HydroConv):
+                x = conv(x, edge_index, edge_attr, node_type, edge_type)
+            elif conv.__class__.__name__ == "GATConv":
+                x = conv(x, edge_index, edge_attr)
+            else:
+                x = conv(x, edge_index)
+            x = self.act_fn(x)
+            x = F.dropout(x, p=self.dropout, training=self.training)
+            x = norm(x)
+            if self.residual and identity.shape == x.shape:
+                x = x + identity
+        return self.fc_out(x)
+
+
+class RecurrentGNNSurrogate(nn.Module):
+    """GNN encoder followed by an LSTM for sequence prediction."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        edge_dim: int,
+        output_dim: int,
+        num_layers: int,
+        use_attention: bool,
+        gat_heads: int,
+        dropout: float,
+        residual: bool,
+        rnn_hidden_dim: int,
+        share_weights: bool = False,
+        num_node_types: int = 1,
+        num_edge_types: int = 1,
+    ) -> None:
+        super().__init__()
+        self.encoder = EnhancedGNNEncoder(
+            in_channels,
+            hidden_channels,
+            hidden_channels,
+            num_layers=num_layers,
+            dropout=dropout,
+            residual=residual,
+            edge_dim=edge_dim,
+            use_attention=use_attention,
+            gat_heads=gat_heads,
+            share_weights=share_weights,
+            num_node_types=num_node_types,
+            num_edge_types=num_edge_types,
+        )
+        self.rnn = nn.LSTM(hidden_channels, rnn_hidden_dim, batch_first=True)
+        self.decoder = nn.Linear(rnn_hidden_dim, output_dim)
+
+    def forward(
+        self,
+        X_seq: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_attr: torch.Tensor,
+        node_type: Optional[torch.Tensor] = None,
+        edge_type: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        batch_size, T, num_nodes, in_dim = X_seq.size()
+        device = X_seq.device
+        E = edge_index.size(1)
+        batch_edge_index = edge_index.repeat(1, batch_size) + (
+            torch.arange(batch_size, device=device).repeat_interleave(E) * num_nodes
+        )
+        edge_attr_rep = edge_attr.repeat(batch_size, 1) if edge_attr is not None else None
+        node_type_rep = (
+            node_type.repeat(batch_size) if node_type is not None else None
+        )
+        edge_type_rep = (
+            edge_type.repeat(batch_size) if edge_type is not None else None
+        )
+
+        node_embeddings = []
+        for t in range(T):
+            x_t = X_seq[:, t].reshape(batch_size * num_nodes, in_dim)
+            gnn_out = self.encoder(
+                x_t,
+                batch_edge_index,
+                edge_attr_rep,
+                node_type_rep,
+                edge_type_rep,
+            )
+            gnn_out = gnn_out.view(batch_size, num_nodes, -1)
+            node_embeddings.append(gnn_out)
+
+        emb = torch.stack(node_embeddings, dim=1)
+        rnn_in = emb.permute(0, 2, 1, 3).reshape(batch_size * num_nodes, T, -1)
+        rnn_out, _ = self.rnn(rnn_in)
+        rnn_out = rnn_out.reshape(batch_size, num_nodes, T, -1).permute(0, 2, 1, 3)
+        out = self.decoder(rnn_out)
+        out = out.clone()
+        min_p = min_c = 0.0
+        if getattr(self, "y_mean", None) is not None:
+            if isinstance(self.y_mean, dict):
+                p_mean = self.y_mean["node_outputs"][0].to(out.device)
+                p_std = self.y_std["node_outputs"][0].to(out.device)
+                if self.y_mean["node_outputs"].numel() > 1:
+                    c_mean = self.y_mean["node_outputs"][1].to(out.device)
+                    c_std = self.y_std["node_outputs"][1].to(out.device)
+                else:
+                    c_mean = torch.tensor(0.0, device=out.device)
+                    c_std = torch.tensor(1.0, device=out.device)
+            else:
+                p_mean = self.y_mean[0].to(out.device)
+                p_std = self.y_std[0].to(out.device)
+                if self.y_mean.numel() > 1:
+                    c_mean = self.y_mean[1].to(out.device)
+                    c_std = self.y_std[1].to(out.device)
+                else:
+                    c_mean = torch.tensor(0.0, device=out.device)
+                    c_std = torch.tensor(1.0, device=out.device)
+            min_p = -p_mean / p_std
+            min_c = -c_mean / c_std
+
+        if out.size(-1) >= 1:
+            comps = [torch.clamp(out[..., 0], min=min_p).unsqueeze(-1)]
+            if out.size(-1) >= 2:
+                comps.append(torch.clamp(out[..., 1], min=min_c).unsqueeze(-1))
+                if out.size(-1) > 2:
+                    comps.append(out[..., 2:])
+            out = torch.cat(comps, dim=-1)
+        return out
+
+
+class MultiTaskGNNSurrogate(nn.Module):
+    """Recurrent GNN surrogate predicting node and edge level targets."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_channels: int,
+        edge_dim: int,
+        node_output_dim: int,
+        edge_output_dim: int,
+        num_layers: int,
+        use_attention: bool,
+        gat_heads: int,
+        dropout: float,
+        residual: bool,
+        rnn_hidden_dim: int,
+        share_weights: bool = False,
+        num_node_types: int = 1,
+        num_edge_types: int = 1,
+    ) -> None:
+        super().__init__()
+        self.encoder = EnhancedGNNEncoder(
+            in_channels,
+            hidden_channels,
+            hidden_channels,
+            num_layers=num_layers,
+            dropout=dropout,
+            residual=residual,
+            edge_dim=edge_dim,
+            use_attention=use_attention,
+            gat_heads=gat_heads,
+            share_weights=share_weights,
+            num_node_types=num_node_types,
+            num_edge_types=num_edge_types,
+        )
+        self.rnn = nn.LSTM(hidden_channels, rnn_hidden_dim, batch_first=True)
+        self.time_att = MultiheadAttention(rnn_hidden_dim, num_heads=4, batch_first=True)
+        self.node_decoder = nn.Linear(rnn_hidden_dim, node_output_dim)
+        self.edge_decoder = nn.Linear(rnn_hidden_dim * 3, edge_output_dim)
+
+    def reset_tank_levels(
+        self,
+        init_levels: Optional[torch.Tensor] = None,
+        batch_size: int = 1,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        if not hasattr(self, "tank_indices"):
+            return
+        if device is None:
+            device = next(self.parameters()).device
+        if init_levels is None:
+            init_levels = torch.zeros(batch_size, len(self.tank_indices), device=device)
+        else:
+            init_levels = init_levels.to(device)
+        self.tank_levels = init_levels
+
+    def forward(
+        self,
+        X_seq: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_attr: torch.Tensor,
+        node_type: Optional[torch.Tensor] = None,
+        edge_type: Optional[torch.Tensor] = None,
+    ):
+        batch_size, T, num_nodes, in_dim = X_seq.size()
+        device = X_seq.device
+        E = edge_index.size(1)
+        batch_edge_index = edge_index.repeat(1, batch_size) + (
+            torch.arange(batch_size, device=device).repeat_interleave(E) * num_nodes
+        )
+        edge_attr_rep = edge_attr.repeat(batch_size, 1) if edge_attr is not None else None
+        node_type_rep = (
+            node_type.repeat(batch_size) if node_type is not None else None
+        )
+        edge_type_rep = (
+            edge_type.repeat(batch_size) if edge_type is not None else None
+        )
+
+        node_embeddings = []
+        for t in range(T):
+            x_t = X_seq[:, t].reshape(batch_size * num_nodes, in_dim)
+            gnn_out = self.encoder(
+                x_t,
+                batch_edge_index,
+                edge_attr_rep,
+                node_type_rep,
+                edge_type_rep,
+            )
+            gnn_out = gnn_out.view(batch_size, num_nodes, -1)
+            node_embeddings.append(gnn_out)
+
+        emb = torch.stack(node_embeddings, dim=1)
+        rnn_in = emb.permute(0, 2, 1, 3).reshape(batch_size * num_nodes, T, -1)
+        rnn_out, _ = self.rnn(rnn_in)
+        rnn_out = rnn_out.reshape(batch_size, num_nodes, T, -1).permute(0, 2, 1, 3)
+
+        att_in = rnn_out.reshape(batch_size * num_nodes, T, -1)
+        att_out, _ = self.time_att(att_in, att_in, att_in)
+        att_out = att_out.reshape(batch_size, num_nodes, T, -1).permute(0, 2, 1, 3)
+
+        node_pred = self.node_decoder(att_out)
+        node_pred = node_pred.clone()
+
+        src = edge_index[0]
+        tgt = edge_index[1]
+        h_src = att_out[:, :, src, :]
+        h_tgt = att_out[:, :, tgt, :]
+        h_diff = h_src - h_tgt
+        edge_emb = torch.cat([h_src, h_tgt, h_diff], dim=-1)
+        edge_pred = self.edge_decoder(edge_emb)
+
+        if hasattr(self, "tank_indices") and len(getattr(self, "tank_indices")) > 0:
+            if not hasattr(self, "tank_levels") or self.tank_levels.size(0) != batch_size:
+                self.tank_levels = torch.zeros(batch_size, len(self.tank_indices), device=device)
+            flows = edge_pred[..., 0]
+            updates = torch.zeros(batch_size, T, num_nodes, device=device)
+            for t in range(T):
+                net = []
+                for edges, signs in zip(self.tank_edges, self.tank_signs):
+                    if edges.numel() == 0:
+                        net.append(torch.zeros(batch_size, device=device))
+                    else:
+                        net.append((flows[:, t, edges] * signs).sum(dim=1))
+                net_flow = torch.stack(net, dim=1)
+                delta_vol = net_flow * 3600.0 * 0.001
+                self.tank_levels += delta_vol
+                self.tank_levels = self.tank_levels.clamp(min=0.0)
+                delta_h = delta_vol / self.tank_areas
+                for i, tank_idx in enumerate(self.tank_indices):
+                    updates[:, t, tank_idx] = delta_h[:, i]
+            update_tensor = torch.zeros_like(node_pred)
+            update_tensor[..., 0] = updates
+            node_pred = node_pred + update_tensor
+
+        min_p = min_c = 0.0
+        if getattr(self, "y_mean", None) is not None:
+            if isinstance(self.y_mean, dict):
+                p_mean = self.y_mean["node_outputs"][0].to(node_pred.device)
+                p_std = self.y_std["node_outputs"][0].to(node_pred.device)
+                if self.y_mean["node_outputs"].numel() > 1:
+                    c_mean = self.y_mean["node_outputs"][1].to(node_pred.device)
+                    c_std = self.y_std["node_outputs"][1].to(node_pred.device)
+                else:
+                    c_mean = torch.tensor(0.0, device=node_pred.device)
+                    c_std = torch.tensor(1.0, device=node_pred.device)
+            else:
+                p_mean = self.y_mean[0].to(node_pred.device)
+                p_std = self.y_std[0].to(node_pred.device)
+                if self.y_mean.numel() > 1:
+                    c_mean = self.y_mean[1].to(node_pred.device)
+                    c_std = self.y_std[1].to(node_pred.device)
+                else:
+                    c_mean = torch.tensor(0.0, device=node_pred.device)
+                    c_std = torch.tensor(1.0, device=node_pred.device)
+            min_p = -p_mean / p_std
+            min_c = -c_mean / c_std
+
+        if node_pred.size(-1) >= 1:
+            comps = [torch.clamp(node_pred[..., 0], min=min_p).unsqueeze(-1)]
+            if node_pred.size(-1) >= 2:
+                comps.append(torch.clamp(node_pred[..., 1], min=min_c).unsqueeze(-1))
+                if node_pred.size(-1) > 2:
+                    comps.append(node_pred[..., 2:])
+            node_pred = torch.cat(comps, dim=-1)
+
+        return {
+            "node_outputs": node_pred,
+            "edge_outputs": edge_pred,
+        }
+
+
+GCNEncoder = EnhancedGNNEncoder
+
+__all__ = [
+    "HydroConv",
+    "EnhancedGNNEncoder",
+    "GCNEncoder",
+    "RecurrentGNNSurrogate",
+    "MultiTaskGNNSurrogate",
+]

--- a/scripts/ablation_study.py
+++ b/scripts/ablation_study.py
@@ -1,0 +1,65 @@
+import argparse
+import subprocess
+import time
+from pathlib import Path
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LOG_DIR = REPO_ROOT / "logs"
+MODEL_DIR = REPO_ROOT / "models"
+
+
+def run_config(base_cmd, name):
+    cmd = base_cmd + ["--run-name", name, "--output", str(MODEL_DIR / f"{name}.pth")]
+    start = time.time()
+    subprocess.run(cmd, check=True)
+    elapsed = time.time() - start
+    df = pd.read_csv(LOG_DIR / f"accuracy_{name}.csv", index_col=0)
+    mae = float(df.loc["Mean Absolute Error (MAE)", "Pressure (m)"])
+    return mae, elapsed
+
+
+def main():
+    p = argparse.ArgumentParser(description="Run ablation studies for the GNN surrogate")
+    p.add_argument("--x-path", required=True)
+    p.add_argument("--y-path", required=True)
+    p.add_argument("--edge-index-path", required=True)
+    p.add_argument("--edge-attr-path")
+    p.add_argument("--inp-path", required=True)
+    p.add_argument("--epochs", type=int, default=10)
+    p.add_argument("--batch-size", type=int, default=32)
+    args = p.parse_args()
+
+    base_cmd = [
+        "python", str(REPO_ROOT / "scripts" / "train_gnn.py"),
+        "--x-path", args.x_path,
+        "--y-path", args.y_path,
+        "--edge-index-path", args.edge_index_path,
+        "--inp-path", args.inp_path,
+        "--epochs", str(args.epochs),
+        "--batch-size", str(args.batch_size),
+    ]
+    if args.edge_attr_path:
+        base_cmd += ["--edge-attr-path", args.edge_attr_path]
+
+    configs = [
+        ("baseline", []),
+        ("residual", ["--residual"]),
+        ("deep", ["--num-layers", "8", "--hidden-dim", "256", "--residual"]),
+        ("attention", ["--use-attention"]),
+    ]
+
+    results = []
+    for name, extra in configs:
+        mae, t = run_config(base_cmd + extra, name)
+        results.append((name, mae, t))
+
+    baseline_mae, baseline_time = results[0][1], results[0][2]
+    for name, mae, t in results:
+        impr = (baseline_mae - mae) / baseline_mae if baseline_mae else 0.0
+        speed = t / baseline_time if baseline_time else 0.0
+        print(f"{name}: MAE={mae:.4f} m, improvement={impr*100:.1f}%, time x{speed:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -9,12 +9,10 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import nn
-from torch.nn import MultiheadAttention
 from torch.amp import autocast, GradScaler
 from torch_geometric.data import Data
 from torch_geometric.loader import DataLoader
 from torch.utils.data import Dataset, DataLoader as TorchLoader
-from torch_geometric.nn import GCNConv, MessagePassing, GATConv, LayerNorm
 from torch_geometric.utils import subgraph, k_hop_subgraph
 import wntr
 import matplotlib.pyplot as plt
@@ -39,485 +37,16 @@ from models.losses import (
     pressure_headloss_consistency_loss,
 )
 from models.loss_utils import pump_curve_loss
+from models.gnn_surrogate import (
+    HydroConv,
+    EnhancedGNNEncoder,
+    GCNEncoder,
+    RecurrentGNNSurrogate,
+    MultiTaskGNNSurrogate,
+)
 
 from scripts.metrics import accuracy_metrics, export_table
 
-
-class HydroConv(MessagePassing):
-    """Mass-conserving convolution supporting heterogeneous components."""
-
-    def __init__(
-        self,
-        in_channels: int,
-        out_channels: int,
-        edge_dim: int,
-        num_node_types: int = 1,
-        num_edge_types: int = 1,
-    ) -> None:
-        super().__init__(aggr="add")
-        self.in_channels = in_channels
-        self.out_channels = out_channels
-        self.num_node_types = num_node_types
-        self.num_edge_types = num_edge_types
-
-        # Separate linear layers per node type so different components can
-        # learn distinct transformations.
-        self.lin = nn.ModuleList(
-            [nn.Linear(in_channels, out_channels) for _ in range(num_node_types)]
-        )
-
-        # Each edge type obtains its own small MLP to compute a transmissibility
-        # weight from the edge attributes.
-        self.edge_mlps = nn.ModuleList(
-            [nn.Sequential(nn.Linear(edge_dim, 1), nn.Softplus()) for _ in range(num_edge_types)]
-        )
-
-        # Learnable embedding so that pump edges can obtain a dedicated bias in
-        # the message passing step.  This keeps the interface flexible for any
-        # number of edge types while explicitly distinguishing pumps.
-        self.edge_type_emb = (
-            nn.Embedding(num_edge_types, edge_dim) if num_edge_types > 1 else None
-        )
-
-    def forward(
-        self,
-        x: torch.Tensor,
-        edge_index: torch.Tensor,
-        edge_attr: Optional[torch.Tensor] = None,
-        node_type: Optional[torch.Tensor] = None,
-        edge_type: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        """Run convolution with optional node/edge type information."""
-
-        if edge_attr is None:
-            raise ValueError("edge_attr cannot be None for HydroConv")
-
-        if node_type is None:
-            node_type = torch.zeros(x.size(0), dtype=torch.long, device=x.device)
-        if edge_type is None:
-            edge_type = torch.zeros(edge_index.size(1), dtype=torch.long, device=edge_index.device)
-
-        aggr = self.propagate(edge_index, x=x, edge_attr=edge_attr, edge_type=edge_type)
-        out = torch.zeros((x.size(0), self.out_channels), device=x.device, dtype=aggr.dtype)
-        for t, lin in enumerate(self.lin):
-            idx = node_type == t
-            if torch.any(idx):
-                out[idx] = lin(aggr[idx]).to(out.dtype)
-        return out
-
-    def message(
-        self,
-        x_i: torch.Tensor,
-        x_j: torch.Tensor,
-        edge_attr: torch.Tensor,
-        edge_type: torch.Tensor,
-    ) -> torch.Tensor:
-        if self.edge_type_emb is not None:
-            edge_attr = edge_attr + self.edge_type_emb(edge_type)
-        weight = torch.zeros(edge_attr.size(0), 1, device=edge_attr.device)
-        for t, mlp in enumerate(self.edge_mlps):
-            idx = edge_type == t
-            if torch.any(idx):
-                weight[idx] = mlp(edge_attr[idx]).to(weight.dtype)
-        return weight * (x_j - x_i)
-
-
-class EnhancedGNNEncoder(nn.Module):
-    """Flexible GNN encoder supporting heterogeneous graphs and attention.
-
-    The forward pass expects explicit tensor arguments so that the model can be
-    compiled with TorchScript.  ``x`` is a node feature matrix of shape
-    ``[N, F]`` and ``edge_index`` contains the directed edges with shape
-    ``[2, E]``. Optional edge attributes and type indices can also be provided.
-    """
-
-    def __init__(
-        self,
-        in_channels: int,
-        hidden_channels: int,
-        out_channels: int,
-        num_layers: int = 2,
-        dropout: float = 0.0,
-        activation: str = "relu",
-        residual: bool = False,
-        edge_dim: Optional[int] = None,
-        use_attention: bool = False,
-        gat_heads: int = 4,
-        share_weights: bool = False,
-        num_node_types: int = 1,
-        num_edge_types: int = 1,
-    ) -> None:
-        super().__init__()
-
-        self.use_attention = use_attention
-        self.dropout = dropout
-        self.residual = residual
-        self.act_fn = getattr(F, activation)
-        self.share_weights = share_weights
-        self.num_node_types = num_node_types
-        self.num_edge_types = num_edge_types
-
-        def make_conv(in_c: int, out_c: int):
-            if use_attention:
-                return GATConv(in_c, out_c // gat_heads, heads=gat_heads, edge_dim=edge_dim)
-            if edge_dim is not None:
-                return HydroConv(
-                    in_c,
-                    out_c,
-                    edge_dim,
-                    num_node_types=self.num_node_types,
-                    num_edge_types=self.num_edge_types,
-                )
-            return GCNConv(in_c, out_c)
-
-        self.convs = nn.ModuleList()
-        self.norms = nn.ModuleList()
-
-        if share_weights:
-            first = make_conv(in_channels, hidden_channels)
-            self.convs.append(first)
-            shared = first if in_channels == hidden_channels else make_conv(hidden_channels, hidden_channels)
-            for _ in range(num_layers - 1):
-                self.convs.append(shared)
-        else:
-            for i in range(num_layers):
-                in_c = in_channels if i == 0 else hidden_channels
-                self.convs.append(make_conv(in_c, hidden_channels))
-
-        for _ in range(num_layers):
-            self.norms.append(LayerNorm(hidden_channels))
-
-        self.fc_out = nn.Linear(hidden_channels, out_channels)
-
-    def forward(
-        self,
-        x: torch.Tensor,
-        edge_index: torch.Tensor,
-        edge_attr: Optional[torch.Tensor] = None,
-        node_type: Optional[torch.Tensor] = None,
-        edge_type: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        for conv, norm in zip(self.convs, self.norms):
-            identity = x
-            if isinstance(conv, HydroConv):
-                x = conv(x, edge_index, edge_attr, node_type, edge_type)
-            elif conv.__class__.__name__ == "GATConv":
-                x = conv(x, edge_index, edge_attr)
-            else:
-                x = conv(x, edge_index)
-            x = self.act_fn(x)
-            x = F.dropout(x, p=self.dropout, training=self.training)
-            x = norm(x)
-            if self.residual and identity.shape == x.shape:
-                x = x + identity
-        return self.fc_out(x)
-
-
-# Backwards compatibility for tests and older scripts
-GCNEncoder = EnhancedGNNEncoder
-
-
-class RecurrentGNNSurrogate(nn.Module):
-    """GNN encoder followed by an LSTM for sequence prediction."""
-
-    def __init__(
-        self,
-        in_channels: int,
-        hidden_channels: int,
-        edge_dim: int,
-        output_dim: int,
-        num_layers: int,
-        use_attention: bool,
-        gat_heads: int,
-        dropout: float,
-        residual: bool,
-        rnn_hidden_dim: int,
-        share_weights: bool = False,
-        num_node_types: int = 1,
-        num_edge_types: int = 1,
-    ) -> None:
-        super().__init__()
-        self.encoder = EnhancedGNNEncoder(
-            in_channels,
-            hidden_channels,
-            hidden_channels,
-            num_layers=num_layers,
-            dropout=dropout,
-            residual=residual,
-            edge_dim=edge_dim,
-            use_attention=use_attention,
-            gat_heads=gat_heads,
-            share_weights=share_weights,
-            num_node_types=num_node_types,
-            num_edge_types=num_edge_types,
-        )
-        self.rnn = nn.LSTM(hidden_channels, rnn_hidden_dim, batch_first=True)
-        self.decoder = nn.Linear(rnn_hidden_dim, output_dim)
-
-    def forward(
-        self,
-        X_seq: torch.Tensor,
-        edge_index: torch.Tensor,
-        edge_attr: torch.Tensor,
-        node_type: Optional[torch.Tensor] = None,
-        edge_type: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        batch_size, T, num_nodes, in_dim = X_seq.size()
-        device = X_seq.device
-        E = edge_index.size(1)
-        # Expand edge index for ``batch_size`` separate graphs
-        batch_edge_index = edge_index.repeat(1, batch_size) + (
-            torch.arange(batch_size, device=device).repeat_interleave(E) * num_nodes
-        )
-        edge_attr_rep = edge_attr.repeat(batch_size, 1) if edge_attr is not None else None
-        node_type_rep = (
-            node_type.repeat(batch_size) if node_type is not None else None
-        )
-        edge_type_rep = (
-            edge_type.repeat(batch_size) if edge_type is not None else None
-        )
-
-        node_embeddings = []
-        for t in range(T):
-            x_t = X_seq[:, t].reshape(batch_size * num_nodes, in_dim)
-            gnn_out = self.encoder(
-                x_t,
-                batch_edge_index,
-                edge_attr_rep,
-                node_type_rep,
-                edge_type_rep,
-            )  # [batch_size*num_nodes, hidden]
-            gnn_out = gnn_out.view(batch_size, num_nodes, -1)
-            node_embeddings.append(gnn_out)
-
-        emb = torch.stack(node_embeddings, dim=1)  # [B, T, N, H]
-        # reshape so each node has its own sequence in the batch dimension
-        rnn_in = emb.permute(0, 2, 1, 3).reshape(batch_size * num_nodes, T, -1)
-        rnn_out, _ = self.rnn(rnn_in)
-        rnn_out = rnn_out.reshape(batch_size, num_nodes, T, -1).permute(0, 2, 1, 3)
-        out = self.decoder(rnn_out)
-        # Clamp pressure and chlorine in the normalized domain so that 0
-        # corresponds to 0 in physical units when denormalised.
-        out = out.clone()
-        min_p = min_c = 0.0
-        if getattr(self, "y_mean", None) is not None:
-            if isinstance(self.y_mean, dict):
-                p_mean = self.y_mean["node_outputs"][0].to(out.device)
-                p_std = self.y_std["node_outputs"][0].to(out.device)
-                if self.y_mean["node_outputs"].numel() > 1:
-                    c_mean = self.y_mean["node_outputs"][1].to(out.device)
-                    c_std = self.y_std["node_outputs"][1].to(out.device)
-                else:
-                    c_mean = torch.tensor(0.0, device=out.device)
-                    c_std = torch.tensor(1.0, device=out.device)
-            else:
-                p_mean = self.y_mean[0].to(out.device)
-                p_std = self.y_std[0].to(out.device)
-                if self.y_mean.numel() > 1:
-                    c_mean = self.y_mean[1].to(out.device)
-                    c_std = self.y_std[1].to(out.device)
-                else:
-                    c_mean = torch.tensor(0.0, device=out.device)
-                    c_std = torch.tensor(1.0, device=out.device)
-            min_p = -p_mean / p_std
-            min_c = -c_mean / c_std
-
-        if out.size(-1) >= 1:
-            out[..., 0] = torch.clamp(out[..., 0], min=min_p)
-        if out.size(-1) >= 2:
-            out[..., 1] = torch.clamp(out[..., 1], min=min_c)
-        return out
-
-
-class MultiTaskGNNSurrogate(nn.Module):
-    """Recurrent GNN surrogate predicting node and edge level targets."""
-
-    def __init__(
-        self,
-        in_channels: int,
-        hidden_channels: int,
-        edge_dim: int,
-        node_output_dim: int,
-        edge_output_dim: int,
-        num_layers: int,
-        use_attention: bool,
-        gat_heads: int,
-        dropout: float,
-        residual: bool,
-        rnn_hidden_dim: int,
-        share_weights: bool = False,
-        num_node_types: int = 1,
-        num_edge_types: int = 1,
-    ) -> None:
-        super().__init__()
-        self.encoder = EnhancedGNNEncoder(
-            in_channels,
-            hidden_channels,
-            hidden_channels,
-            num_layers=num_layers,
-            dropout=dropout,
-            residual=residual,
-            edge_dim=edge_dim,
-            use_attention=use_attention,
-            gat_heads=gat_heads,
-            share_weights=share_weights,
-            num_node_types=num_node_types,
-            num_edge_types=num_edge_types,
-        )
-        self.rnn = nn.LSTM(hidden_channels, rnn_hidden_dim, batch_first=True)
-        self.time_att = MultiheadAttention(rnn_hidden_dim, num_heads=4, batch_first=True)
-        self.node_decoder = nn.Linear(rnn_hidden_dim, node_output_dim)
-
-        self.edge_decoder = nn.Linear(rnn_hidden_dim * 3, edge_output_dim)
-
-
-    def reset_tank_levels(
-        self,
-        init_levels: Optional[torch.Tensor] = None,
-        batch_size: int = 1,
-        device: Optional[torch.device] = None,
-    ) -> None:
-        """Initialize internal tank volumes.
-
-        Parameters
-        ----------
-        init_levels : torch.Tensor, optional
-            Tensor of initial tank volumes (``[B, num_tanks]``).  When ``None``
-            the levels are reset to zero.
-        batch_size : int
-            Number of sequences in the batch when ``init_levels`` is ``None``.
-        device : torch.device, optional
-            Target device for the tensor.
-        """
-        if not hasattr(self, "tank_indices"):
-            return
-        if device is None:
-            device = next(self.parameters()).device
-        if init_levels is None:
-            init_levels = torch.zeros(batch_size, len(self.tank_indices), device=device)
-        else:
-            init_levels = init_levels.to(device)
-        self.tank_levels = init_levels
-
-    def forward(
-        self,
-        X_seq: torch.Tensor,
-        edge_index: torch.Tensor,
-        edge_attr: torch.Tensor,
-        node_type: Optional[torch.Tensor] = None,
-        edge_type: Optional[torch.Tensor] = None,
-    ):
-        batch_size, T, num_nodes, in_dim = X_seq.size()
-        device = X_seq.device
-        E = edge_index.size(1)
-        batch_edge_index = edge_index.repeat(1, batch_size) + (
-            torch.arange(batch_size, device=device).repeat_interleave(E) * num_nodes
-        )
-        edge_attr_rep = edge_attr.repeat(batch_size, 1) if edge_attr is not None else None
-        node_type_rep = (
-            node_type.repeat(batch_size) if node_type is not None else None
-        )
-        edge_type_rep = (
-            edge_type.repeat(batch_size) if edge_type is not None else None
-        )
-
-        node_embeddings = []
-        for t in range(T):
-            x_t = X_seq[:, t].reshape(batch_size * num_nodes, in_dim)
-            gnn_out = self.encoder(
-                x_t,
-                batch_edge_index,
-                edge_attr_rep,
-                node_type_rep,
-                edge_type_rep,
-            )
-            gnn_out = gnn_out.view(batch_size, num_nodes, -1)
-            node_embeddings.append(gnn_out)
-
-        emb = torch.stack(node_embeddings, dim=1)
-        rnn_in = emb.permute(0, 2, 1, 3).reshape(batch_size * num_nodes, T, -1)
-        rnn_out, _ = self.rnn(rnn_in)
-        rnn_out = rnn_out.reshape(batch_size, num_nodes, T, -1).permute(0, 2, 1, 3)
-
-        # apply temporal self-attention so each node can weigh its history
-        att_in = rnn_out.reshape(batch_size * num_nodes, T, -1)
-        att_out, _ = self.time_att(att_in, att_in, att_in)
-        att_out = att_out.reshape(batch_size, num_nodes, T, -1).permute(0, 2, 1, 3)
-
-        node_pred = self.node_decoder(att_out)
-        node_pred = node_pred.clone()
-
-        src = edge_index[0]
-        tgt = edge_index[1]
-        h_src = att_out[:, :, src, :]
-        h_tgt = att_out[:, :, tgt, :]
-        h_diff = h_src - h_tgt
-        edge_emb = torch.cat([h_src, h_tgt, h_diff], dim=-1)
-        edge_pred = self.edge_decoder(edge_emb)
-
-        if hasattr(self, "tank_indices") and len(getattr(self, "tank_indices")) > 0:
-            if not hasattr(self, "tank_levels") or self.tank_levels.size(0) != batch_size:
-                self.tank_levels = torch.zeros(batch_size, len(self.tank_indices), device=device)
-            flows = edge_pred[..., 0]  # [B, T, E]
-            updates = torch.zeros(batch_size, T, num_nodes, device=device)
-            for t in range(T):
-                net = []
-                for edges, signs in zip(self.tank_edges, self.tank_signs):
-                    if edges.numel() == 0:
-                        net.append(torch.zeros(batch_size, device=device))
-                    else:
-                        net.append((flows[:, t, edges] * signs).sum(dim=1))
-                net_flow = torch.stack(net, dim=1)
-                # Net flow is in L/s; convert to m³ over one hour
-                delta_vol = net_flow * 3600.0 * 0.001
-                self.tank_levels += delta_vol
-                # Prevent negative volumes accumulating
-                self.tank_levels = self.tank_levels.clamp(min=0.0)
-                delta_h = delta_vol / self.tank_areas
-                for i, tank_idx in enumerate(self.tank_indices):
-                    updates[:, t, tank_idx] = delta_h[:, i]
-            update_tensor = torch.zeros_like(node_pred)
-            update_tensor[..., 0] = updates
-            node_pred = node_pred + update_tensor
-        # Clamp pressure and chlorine in normalized units so that the lower
-        # bound corresponds to 0 in physical units.
-        min_p = min_c = 0.0
-        if getattr(self, "y_mean", None) is not None:
-            if isinstance(self.y_mean, dict):
-                p_mean = self.y_mean["node_outputs"][0].to(node_pred.device)
-                p_std = self.y_std["node_outputs"][0].to(node_pred.device)
-                if self.y_mean["node_outputs"].numel() > 1:
-                    c_mean = self.y_mean["node_outputs"][1].to(node_pred.device)
-                    c_std = self.y_std["node_outputs"][1].to(node_pred.device)
-                else:
-                    c_mean = torch.tensor(0.0, device=node_pred.device)
-                    c_std = torch.tensor(1.0, device=node_pred.device)
-            else:
-                p_mean = self.y_mean[0].to(node_pred.device)
-                p_std = self.y_std[0].to(node_pred.device)
-                if self.y_mean.numel() > 1:
-                    c_mean = self.y_mean[1].to(node_pred.device)
-                    c_std = self.y_std[1].to(node_pred.device)
-                else:
-                    c_mean = torch.tensor(0.0, device=node_pred.device)
-                    c_std = torch.tensor(1.0, device=node_pred.device)
-            min_p = -p_mean / p_std
-            min_c = -c_mean / c_std
-
-        pressure = torch.clamp(node_pred[..., 0], min=min_p)
-        if node_pred.size(-1) >= 2:
-            chlorine = torch.clamp(node_pred[..., 1], min=min_c)
-            other = node_pred[..., 2:]
-            node_pred = torch.cat(
-                [pressure.unsqueeze(-1), chlorine.unsqueeze(-1), other], dim=-1
-            )
-        else:
-            node_pred = pressure.unsqueeze(-1)
-
-        return {
-            "node_outputs": node_pred,
-            "edge_outputs": edge_pred,
-        }
 
 
 def load_dataset(
@@ -2696,7 +2225,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--hidden-dim",
         type=int,
-        default=64,
+        choices=[128, 256],
+        default=128,
         help="Hidden dimension",
     )
     parser.add_argument("--use-attention", action="store_true",
@@ -2705,7 +2235,7 @@ if __name__ == "__main__":
                         help="Number of attention heads for GATConv (if attention is enabled)")
     parser.add_argument("--dropout", type=float, default=0.1,
                         help="Dropout rate applied after each GNN layer")
-    parser.add_argument("--num-layers", type=int, default=4,
+    parser.add_argument("--num-layers", type=int, choices=[4, 6, 8], default=4,
                         help="Number of convolutional layers in the GNN model")
     parser.add_argument(
         "--activation",
@@ -2723,10 +2253,12 @@ if __name__ == "__main__":
         help="Reuse the same convolution weights across GNN layers",
     )
     parser.add_argument(
-        "--rnn-hidden-dim",
+        "--rnn-hidden-dim", "--lstm-hidden",
+        dest="rnn_hidden_dim",
         type=int,
+        choices=[64, 128],
         default=64,
-        help="Hidden dimension of the recurrent layer when sequence data is used",
+        help="Hidden dimension of the recurrent LSTM layer",
     )
     parser.add_argument(
         "--output-dim",


### PR DESCRIPTION
## Summary
- extract surrogate models into `models/gnn_surrogate.py` with optional residual connections and attention
- expand training CLI with selectable depth, width and LSTM sizes, and add ablation study runner
- document new options and script in README and AGENTS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68990db510e0832491fc91e273de0a81