### PR TITLE
Add pressure bias correction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Once the surrogate model is trained you can run gradient-based MPC using
 python scripts/mpc_control.py \
     --horizon 6 --iterations 50 --feedback-interval 24 \
     --Pmin 20.0 --Cmin 0.2 --energy-scale 1e-9 \
-    --w_p 100 --w_c 100 --w_e 1.0 --profile
+    --w_p 100 --w_c 100 --w_e 1.0 --bias-correction --bias-window 24 --profile
 ```
 
 Pass ``--profile`` to print the runtime of each MPC optimisation step. The
@@ -329,6 +329,12 @@ scenarios in parallel.
 Use ``--skip-normalization`` to disable input normalization and feed raw
 features into the surrogate for ablation studies. Outputs are always
 de-normalized back to physical units.
+
+Passing ``--bias-correction`` maintains a rolling mean of the last
+``--bias-window`` EPANET–surrogate pressure residuals and subtracts it
+from future surrogate predictions. Bias estimates reset whenever ground
+truth feedback is applied, and the magnitude range of the current bias is
+logged each hour.
 
 ``mpc_control.py`` exposes weights on pressure, chlorine and energy terms as
 ``--w_p``, ``--w_c`` and ``--w_e`` respectively.  The default configuration

--- a/tests/test_pressure_bias_correction.py
+++ b/tests/test_pressure_bias_correction.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+
+from scripts.mpc_control import PressureBiasCorrector
+
+
+def test_bias_corrector_update_apply_reset():
+    bc = PressureBiasCorrector(num_nodes=3, window=2)
+    node_map = {"a": 0, "b": 1, "c": 2}
+    pressures = {"a": 10.0, "b": 20.0, "c": 30.0}
+
+    bc.update(np.array([1.0, -2.0, 0.5]))
+    corrected = bc.apply(dict(pressures), node_map)
+    assert corrected["a"] == pytest.approx(9.0)
+    assert corrected["b"] == pytest.approx(22.0)
+
+    bc.update(np.array([2.0, -4.0, 1.0]))
+    assert bc.bias[0] == pytest.approx(1.5)  # rolling mean
+
+    bc.reset()
+    corrected_reset = bc.apply(dict(pressures), node_map)
+    assert corrected_reset["a"] == pytest.approx(10.0)
+    assert np.allclose(bc.bias, 0.0)


### PR DESCRIPTION
## Summary
- add optional pressure bias corrector that rolls recent EPANET–surrogate residuals
- log bias magnitude range each hour and expose CLI flags
- document bias correction usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689917055c148324af56edc80e8145cb