### PR TITLE
Unify feedback interval defaults and warnings

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -750,6 +750,11 @@ def main() -> None:
         help="Run N-step surrogate roll-out validation",
     )
     args = parser.parse_args()
+    if args.feedback_interval > 1:
+        print(
+            f"WARNING: --feedback-interval set to {args.feedback_interval}; "
+            "surrogate predictions may drift without hourly EPANET feedback."
+        )
     run_name = args.run_name or datetime.now().strftime("%Y%m%d_%H%M%S")
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     (


### PR DESCRIPTION
## Summary
- Default `--feedback-interval` to 1 hour in both `mpc_control.py` and `experiments_validation.py`
- Warn loudly when `--feedback-interval` exceeds 1 so long runs require explicit override
- Document hourly feedback default and override instructions in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68992465944483248032a4c0e4a3fc8a