### PR TITLE
Add tests for checkpoint normalization and key loading

### DIFF
--- a/tests/test_checkpoint_norm_io.py
+++ b/tests/test_checkpoint_norm_io.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.mpc_control import load_surrogate_model, EPS
+
+
+def test_checkpoint_norm_io(tmp_path):
+    torch.manual_seed(0)
+    state = {
+        'layers.0.lin.weight': torch.randn(2, 5),
+        'layers.0.bias': torch.zeros(2),
+    }
+    ckpt = tmp_path / 'model.pth'
+    torch.save(state, ckpt)
+    np.savez(
+        tmp_path / 'model_norm.npz',
+        x_mean=np.zeros(5),
+        x_std=np.ones(5),
+        y_mean=np.zeros(2),
+        y_std=np.ones(2),
+    )
+    model = load_surrogate_model(torch.device('cpu'), path=str(ckpt), use_jit=False)
+    assert model.x_mean.shape == (5,)
+    assert model.x_std.shape == (5,)
+    assert model.y_mean.shape == (2,)
+    assert model.y_std.shape == (2,)
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    x_norm = torch.randn(2, 5)
+    with torch.no_grad():
+        out_norm = model(x_norm, edge_index)
+        x_raw = x_norm * (model.x_std + EPS) + model.x_mean
+        out_manual = model((x_raw - model.x_mean) / (model.x_std + EPS), edge_index)
+    assert torch.allclose(out_norm, out_manual, atol=1e-6)

--- a/tests/test_load_surrogate_model.py
+++ b/tests/test_load_surrogate_model.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.mpc_control import load_surrogate_model
+
+
+def test_missing_decoder_bias_raises(tmp_path):
+    state = {
+        'layers.0.lin.weight': torch.zeros(1, 1),
+        'layers.0.bias': torch.zeros(1),
+        'rnn.weight_ih_l0': torch.zeros(4, 1),
+        'rnn.weight_hh_l0': torch.zeros(4, 1),
+        'rnn.bias_ih_l0': torch.zeros(4),
+        'rnn.bias_hh_l0': torch.zeros(4),
+        'decoder.weight': torch.zeros(1, 1),
+        # 'decoder.bias' intentionally missing
+    }
+    path = tmp_path / 'model.pth'
+    torch.save(state, path)
+    with pytest.raises(KeyError):
+        load_surrogate_model(torch.device('cpu'), path=str(path), use_jit=False)
+
+
+def test_missing_tank_params_raises(tmp_path):
+    state = {
+        'layers.0.lin.weight': torch.zeros(1, 1),
+        'layers.0.bias': torch.zeros(1),
+        'decoder.weight': torch.zeros(1, 1),
+        'decoder.bias': torch.zeros(1),
+        'tank_indices': torch.tensor([0]),
+        'tank_edges': torch.tensor([0]),
+        'tank_signs': torch.tensor([1.0]),
+        # 'tank_areas' intentionally missing
+    }
+    path = tmp_path / 'model.pth'
+    torch.save(state, path)
+    with pytest.raises(KeyError):
+        load_surrogate_model(torch.device('cpu'), path=str(path), use_jit=False)


### PR DESCRIPTION
## Summary
- test that normalization stats are loaded from checkpoints and used consistently
- ensure model loading fails if decoder weights or tank parameters are missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689931fb3a148324b1adc441eec48032