### PR TITLE
Update default loss weights and training docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,11 @@ python scripts/train_gnn.py \
     --epochs 100 --batch-size 32 --hidden-dim 128 --num-layers 4 \
     --lstm-hidden 64 --workers 8 \
     --dropout 0.1 --residual --early-stop-patience 10 \
-    --weight-decay 1e-5
+    --weight-decay 1e-5 --w-press 5.0 --w-flow 3.0 --w-cl 0.0
 ```
+Chlorine supervision is disabled by default. Pass a positive weight such as
+``--w-cl 1.0`` to train on chlorine again.
+
 GNN depth and width are controlled via ``--num-layers`` (choose from {4,6,8}) and ``--hidden-dim`` ({128,256}).
 Use ``--residual`` to enable skip connections and ``--use-attention`` for graph attention on node updates.
 The LSTM hidden size can be set with ``--lstm-hidden`` (64 or 128).
@@ -195,10 +198,11 @@ pressures are no longer part of the direct MSE loss.  Disable the physics terms
 with ``--no-physics-loss`` if necessary. ``--pressure_loss`` is enabled by
 default to enforce pressure–headloss consistency via the Hazen--Williams
 equation.  The mass penalty uses a default weight of ``2.0`` while
-the headloss term uses ``1.0``. Node pressure and chlorine terms now have
-independent weights ``--w-press`` (default ``3.0``) and ``--w-cl`` (``1.0``),
-and pipe flows are scaled by ``--w-flow`` (``1.0``). The relative importance can
-still be tuned via these flags together with ``--w_mass`` and ``--w_head``.
+the headloss term uses ``1.0``. Node pressure, chlorine and flow terms use
+weights ``--w-press`` (default ``5.0``), ``--w-cl`` (``0.0``) and ``--w-flow``
+(``3.0``). Chlorine is thus ignored unless a positive weight is provided. The
+relative importance can still be tuned via these flags together with
+``--w_mass`` and ``--w_head``.
 Training logs also report the average mass imbalance per batch and the
 percentage of edges with inconsistent headloss signs.
 

--- a/models/losses.py
+++ b/models/losses.py
@@ -21,9 +21,9 @@ def weighted_mtl_loss(
     edge_target: torch.Tensor,
     *,
     loss_fn: str = "mae",
-    w_press: float = 3.0,
-    w_cl: float = 1.0,
-    w_flow: float = 1.0,
+    w_press: float = 5.0,
+    w_cl: float = 0.0,
+    w_flow: float = 3.0,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Return total and component losses for pressure, chlorine and flow.
 
@@ -41,7 +41,9 @@ def weighted_mtl_loss(
     loss_fn: {"mae", "mse", "huber"}
         Base loss applied per component.
     w_press, w_cl, w_flow: float
-        Weights for pressure, chlorine and flow losses respectively.
+        Weights for pressure, chlorine and flow losses respectively. The
+        defaults emphasise pressure and flow (``5.0`` and ``3.0``) while
+        chlorine is disabled (``0.0``).
     """
     press_loss = _apply_loss(pred_nodes[..., 0], target_nodes[..., 0], loss_fn)
     cl_loss = _apply_loss(pred_nodes[..., 1], target_nodes[..., 1], loss_fn)

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2388,19 +2388,19 @@ if __name__ == "__main__":
     parser.add_argument(
         "--w-press",
         type=float,
-        default=3.0,
+        default=5.0,
         help="Weight of the node pressure loss term",
     )
     parser.add_argument(
         "--w-cl",
         type=float,
-        default=1.0,
+        default=0.0,
         help="Weight of the node chlorine loss term",
     )
     parser.add_argument(
         "--w-flow",
         type=float,
-        default=1.0,
+        default=3.0,
         help="Weight of the edge (flow) loss term",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- Emphasise pressure and flow in `weighted_mtl_loss` defaults
- Match training script CLI defaults to new loss weights
- Document new defaults and how to re-enable chlorine training

## Testing
- `pytest` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6899f37adcc883249ed9f437f2df02af