### PR TITLE
Normalize physics losses with automatic scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,12 @@ the headloss term uses ``1.0``. Node pressure, chlorine and flow terms use
 weights ``--w-press`` (default ``5.0``), ``--w-cl`` (``0.0``) and ``--w-flow``
 (``3.0``). Chlorine is thus ignored unless a positive weight is provided. The
 relative importance can still be tuned via these flags together with
-``--w_mass`` and ``--w_head``.
+``--w_mass`` and ``--w_head``.  To keep the physics penalties on a comparable
+scale the script estimates baseline magnitudes for the mass, headloss and pump
+curve terms during the first pass over the training data. These values are used
+to normalise the respective losses before applying the user-specified weights.
+The automatically detected scales can be overridden via ``--mass-scale``,
+``--head-scale`` and ``--pump-scale`` if manual tuning or logging is desired.
 Training logs also report the average mass imbalance per batch and the
 percentage of edges with inconsistent headloss signs.
 

--- a/models/losses.py
+++ b/models/losses.py
@@ -170,3 +170,35 @@ def pressure_headloss_consistency_loss(
 
     return loss
 
+
+def scale_physics_losses(
+    mass_loss: torch.Tensor,
+    head_loss: torch.Tensor,
+    pump_loss: torch.Tensor,
+    *,
+    mass_scale: float = 1.0,
+    head_scale: float = 1.0,
+    pump_scale: float = 1.0,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Normalise physics-based losses by baseline magnitudes.
+
+    Parameters
+    ----------
+    mass_loss, head_loss, pump_loss: torch.Tensor
+        Raw physics loss values.
+    mass_scale, head_scale, pump_scale: float, optional
+        Baseline magnitudes for each loss. Values ``\le 0`` disable scaling.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+        Scaled ``mass_loss``, ``head_loss`` and ``pump_loss``.
+    """
+    if mass_scale > 0:
+        mass_loss = mass_loss / mass_scale
+    if head_scale > 0:
+        head_loss = head_loss / head_scale
+    if pump_scale > 0:
+        pump_loss = pump_loss / pump_scale
+    return mass_loss, head_loss, pump_loss
+


### PR DESCRIPTION
## Summary
- add `scale_physics_losses` helper to normalise mass, head and pump penalties
- automatically estimate physics loss scales on initial pass of training data and apply during training/validation
- expose `--mass-scale`, `--head-scale` and `--pump-scale` options and log chosen values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a8a2826508324a812062da4c5be5a