### PR TITLE
fix validation dataloader without neighbor sampling

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1745,26 +1745,32 @@ def main(args: argparse.Namespace):
 
     if not seq_mode:
         if args.neighbor_sampling:
-            sample_size = args.cluster_batch_size or max(1, int(0.2 * data_list[0].num_nodes))
-            data_list = NeighborSampleDataset(data_list, edge_index_np, sample_size)
-        loader = DataLoader(
-            data_list,
-            batch_size=args.batch_size,
-            shuffle=True,
-            num_workers=args.workers,
-            pin_memory=torch.cuda.is_available(),
-            persistent_workers=args.workers > 0,
-        )
-        if val_loader is not None:
-            val_loader = DataLoader(
-                NeighborSampleDataset(val_list, edge_index_np, sample_size),
+            sample_size = args.cluster_batch_size or max(
+                1, int(0.2 * data_list[0].num_nodes)
+            )
+            data_list = NeighborSampleDataset(
+                data_list, edge_index_np, sample_size
+            )
+            loader = DataLoader(
+                data_list,
                 batch_size=args.batch_size,
+                shuffle=True,
                 num_workers=args.workers,
                 pin_memory=torch.cuda.is_available(),
                 persistent_workers=args.workers > 0,
             )
+            if val_loader is not None:
+                val_loader = DataLoader(
+                    NeighborSampleDataset(val_list, edge_index_np, sample_size),
+                    batch_size=args.batch_size,
+                    num_workers=args.workers,
+                    pin_memory=torch.cuda.is_available(),
+                    persistent_workers=args.workers > 0,
+                )
         elif args.cluster_batch_size > 0:
-            clusters = partition_graph_greedy(edge_index_np, data_list[0].num_nodes, args.cluster_batch_size)
+            clusters = partition_graph_greedy(
+                edge_index_np, data_list[0].num_nodes, args.cluster_batch_size
+            )
             data_list = ClusterSampleDataset(data_list, clusters)
             loader = DataLoader(
                 data_list,
@@ -1777,6 +1783,23 @@ def main(args: argparse.Namespace):
             if val_loader is not None:
                 val_loader = DataLoader(
                     ClusterSampleDataset(val_list, clusters),
+                    batch_size=args.batch_size,
+                    num_workers=args.workers,
+                    pin_memory=torch.cuda.is_available(),
+                    persistent_workers=args.workers > 0,
+                )
+        else:
+            loader = DataLoader(
+                data_list,
+                batch_size=args.batch_size,
+                shuffle=True,
+                num_workers=args.workers,
+                pin_memory=torch.cuda.is_available(),
+                persistent_workers=args.workers > 0,
+            )
+            if val_loader is not None:
+                val_loader = DataLoader(
+                    val_list,
                     batch_size=args.batch_size,
                     num_workers=args.workers,
                     pin_memory=torch.cuda.is_available(),

--- a/tests/test_val_loader_no_neighbor_sampling.py
+++ b/tests/test_val_loader_no_neighbor_sampling.py
@@ -1,0 +1,73 @@
+import numpy as np
+import subprocess
+from pathlib import Path
+import sys
+import wntr
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import build_edge_attr
+
+
+def test_train_with_val_without_neighbor_sampling(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    data_dir = repo / "data"
+    data_dir.mkdir(exist_ok=True)
+    log_file = data_dir / "training_unit_val.log"
+    if log_file.exists():
+        log_file.unlink()
+
+    wn = wntr.network.WaterNetworkModel(repo / "CTown.inp")
+    node_map = {n: i for i, n in enumerate(wn.node_name_list)}
+    link = wn.get_link(wn.link_name_list[0])
+    edge_index = np.array(
+        [
+            [node_map[link.start_node.name], node_map[link.end_node.name]],
+            [node_map[link.end_node.name], node_map[link.start_node.name]],
+        ],
+        dtype=np.int64,
+    )
+    edge_attr = build_edge_attr(wn, edge_index)
+
+    np.save(tmp_path / "edge_index.npy", edge_index)
+    np.save(tmp_path / "edge_attr.npy", edge_attr)
+
+    F = 4 + len(wn.pump_name_list)
+    N = len(wn.node_name_list)
+    X = np.ones((1, N, F), dtype=np.float32)
+    Y = np.zeros((1, N, 2), dtype=np.float32)
+
+    np.save(tmp_path / "X_train.npy", X)
+    np.save(tmp_path / "Y_train.npy", Y)
+    np.save(tmp_path / "X_val.npy", X)
+    np.save(tmp_path / "Y_val.npy", Y)
+
+    cmd = [
+        "python",
+        str(repo / "scripts/train_gnn.py"),
+        "--x-path",
+        str(tmp_path / "X_train.npy"),
+        "--y-path",
+        str(tmp_path / "Y_train.npy"),
+        "--x-val-path",
+        str(tmp_path / "X_val.npy"),
+        "--y-val-path",
+        str(tmp_path / "Y_val.npy"),
+        "--edge-index-path",
+        str(tmp_path / "edge_index.npy"),
+        "--edge-attr-path",
+        str(tmp_path / "edge_attr.npy"),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--run-name",
+        "unit_val",
+        "--output",
+        str(tmp_path / "model.pth"),
+        "--workers",
+        "0",
+    ]
+
+    subprocess.run(cmd, check=True)
+
+    assert log_file.exists()


### PR DESCRIPTION
## Summary
- prevent unbound `sample_size` when validation set is used without neighbor or cluster sampling
- test `train_gnn.py` runs with validation data and no neighbor sampling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ab43fc5848324b27b17c35db35ca5