### PR TITLE
Align normalization hash ordering

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1733,15 +1733,23 @@ def main(args: argparse.Namespace):
         import hashlib
 
         md5 = hashlib.md5()
-        arrays = [x_mean, x_std, y_mean, y_std, edge_mean, edge_std]
+        if isinstance(y_mean, dict):
+            arrays = [
+                x_mean,
+                x_std,
+                y_mean.get("node_outputs"),
+                y_std.get("node_outputs"),
+                y_mean.get("edge_outputs"),
+                y_std.get("edge_outputs"),
+                edge_mean,
+                edge_std,
+            ]
+        else:
+            arrays = [x_mean, x_std, y_mean, y_std, edge_mean, edge_std]
         for arr in arrays:
             if arr is None:
                 continue
-            if isinstance(arr, dict):
-                for v in arr.values():
-                    md5.update(v.to(torch.float32).cpu().numpy().tobytes())
-            else:
-                md5.update(arr.to(torch.float32).cpu().numpy().tobytes())
+            md5.update(arr.to(torch.float32).cpu().numpy().tobytes())
         norm_md5 = md5.hexdigest()
         norm_stats = {
             "x_mean": x_mean.to(torch.float32).cpu().numpy(),


### PR DESCRIPTION
## Summary
- Ensure train_gnn computes MD5 hashes in the same order as _norm.npz saving, including node and edge outputs
- Retain edge output normalization stats in mpc_control and hash arrays in identical order

## Testing
- `pytest tests/test_norm_stats_checkpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689bd947bda083248f979d2e9cfb5078