### PR TITLE
Include run name in validation config path

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -901,7 +901,11 @@ def main() -> None:
         "model_layers": model_layers,
         "model_hidden_dim": model_hidden,
     }
-    save_config(REPO_ROOT / "logs" / "config.yaml", vars(args), cfg_extra)
+    save_config(
+        REPO_ROOT / "logs" / f"config_validation_{run_name}.yaml",
+        vars(args),
+        cfg_extra,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `scripts/experiments_validation.py` writes run-specific config files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f90a19ac0832491d2913a2f4a5fc3