### PR TITLE
Add norm-stats option to validation and enforce output normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ diverging over long horizons.  It now also reports mean absolute error (MAE)
 distribution.  All metrics are written to
 ``logs/surrogate_metrics.json`` for reproducibility.
 
+If your surrogate weights were saved separately from their normalization
+statistics, provide the path to the ``*.npz`` file via ``--norm-stats`` so the
+script can correctly de-normalize predictions.  The validation script aborts if
+``y_mean``/``y_std`` are missing to avoid evaluating normalized outputs.
+
 If the dimension of ``edge_attr.npy`` does not match the value stored in the
 surrogate checkpoint, ``validate_surrogate`` now raises a ``ValueError``.
 Regenerate the dataset or retrain the surrogate when this occurs.
@@ -317,7 +322,8 @@ Typical validation command:
 
 ```bash
 python scripts/experiments_validation.py \
-    --model models/gnn_surrogate.pth --inp CTown.inp \
+    --model models/gnn_surrogate.pth --norm-stats models/gnn_surrogate_norm.npz \
+    --inp CTown.inp \
     --horizon 6 --iterations 50 \
     --run-name baseline
 ```

--- a/tests/test_validation_norm_stats.py
+++ b/tests/test_validation_norm_stats.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import subprocess
+import torch
+import numpy as np
+
+repo = Path(__file__).resolve().parents[1]
+
+def test_experiments_validation_requires_output_norm(tmp_path):
+    state = {
+        'layers.0.weight': torch.zeros(1, 1),
+        'layers.0.bias': torch.zeros(1),
+    }
+    model_path = tmp_path / 'model.pth'
+    torch.save(state, model_path)
+
+    stats_path = tmp_path / 'stats.npz'
+    np.savez(stats_path, x_mean=np.zeros(1), x_std=np.ones(1))
+
+    cmd = [
+        'python', str(repo / 'scripts/experiments_validation.py'),
+        '--model', str(model_path),
+        '--norm-stats', str(stats_path),
+        '--inp', str(repo / 'CTown.inp'),
+        '--test-pkl', str(tmp_path / 'missing.pkl'),
+        '--no-jit',
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode != 0
+    assert 'output normalization statistics' in result.stderr.lower()


### PR DESCRIPTION
## Summary
- allow specifying normalization stats file in `experiments_validation.py`
- extend `load_surrogate_model` to load stats from an explicit path
- document and test failure when output normalization is missing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml' and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f93e471808324b421fde700c72199