### PR TITLE
Handle extra surrogate outputs in MPC cost

### DIFF
--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -921,8 +921,15 @@ def compute_mpc_cost(
                 pred = pred.unsqueeze(-1)
             if pred.dim() == 2 and pred.shape[1] != y_mean.shape[0] and pred.shape[0] == y_mean.shape[0]:
                 pred = pred.t()
-            out_dim = pred.shape[1]
-            pred = pred * (y_std[:out_dim].view(1, -1) + EPS) + y_mean[:out_dim].view(1, -1)
+            target_dim = min(pred.shape[1], y_mean.shape[0])
+            pred = torch.cat(
+                [
+                    pred[:, :target_dim] * (y_std[:target_dim].view(1, -1) + EPS)
+                    + y_mean[:target_dim].view(1, -1),
+                    pred[:, target_dim:],
+                ],
+                dim=1,
+            )
         assert not torch.isnan(pred).any(), "NaN prediction"
         pred_p = pred[:, 0]
         if pred.shape[1] > 1:

--- a/tests/test_mpc_cost_extra_outputs.py
+++ b/tests/test_mpc_cost_extra_outputs.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+
+import torch
+import wntr
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(REPO_ROOT))
+
+from scripts.mpc_control import compute_mpc_cost
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.x_mean = torch.zeros(5)
+        self.x_std = torch.ones(5)
+        self.y_mean = torch.zeros(2)
+        self.y_std = torch.ones(2)
+
+    def forward(self, x, edge_index, edge_attr=None, node_types=None, edge_types=None):
+        n = x.size(0)
+        base = torch.stack(
+            [
+                torch.full((n,), 30.0, device=x.device),
+                torch.full((n,), 1.0, device=x.device),
+            ],
+            dim=1,
+        )
+        extra = torch.full((n, 1), 123.0, device=x.device)
+        return torch.cat([base, extra], dim=1)
+
+
+def test_compute_mpc_cost_handles_extra_outputs():
+    device = torch.device("cpu")
+    model = DummyModel()
+    wn = wntr.network.WaterNetworkModel()
+
+    pump_speeds = torch.zeros(1, 1, dtype=torch.float32)
+    edge_index = torch.zeros((2, 0), dtype=torch.long)
+    edge_attr = torch.zeros((0, 0))
+    node_types = torch.zeros(1, dtype=torch.long)
+    edge_types = torch.zeros(0, dtype=torch.long)
+    template = torch.zeros(1, 5)
+    pressures = torch.tensor([10.0])
+    chlorine = torch.tensor([0.0])
+
+    cost, _ = compute_mpc_cost(
+        pump_speeds,
+        wn,
+        model,
+        edge_index,
+        edge_attr,
+        node_types,
+        edge_types,
+        template,
+        pressures,
+        chlorine,
+        horizon=1,
+        device=device,
+        Pmin=5.0,
+        Cmin=0.0,
+        skip_normalization=True,
+    )
+    assert torch.isfinite(cost)


### PR DESCRIPTION
## Summary
- Avoid dimension mismatches when denormalising MPC predictions
- Add regression test for MPC cost with surplus surrogate outputs

## Testing
- `pytest tests/test_mpc_cost_extra_outputs.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689fb4088b5c832499bea2bbbca7262f