### PR TITLE
Handle Path objects in reproducibility save_config

### DIFF
--- a/tests/test_save_config_path.py
+++ b/tests/test_save_config_path.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import yaml
+
+# Ensure repository root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts.reproducibility import save_config
+
+
+def test_save_config_converts_path(tmp_path):
+    cfg_file = tmp_path / "cfg.yaml"
+    some_path = tmp_path / "subdir" / "file.txt"
+
+    save_config(cfg_file, {"my_path": some_path})
+
+    data = yaml.safe_load(cfg_file.read_text())
+    assert data["my_path"] == some_path.as_posix()
+    assert isinstance(data["my_path"], str)


### PR DESCRIPTION
## Summary
- allow `save_config` to accept `argparse.Namespace`
- recursively convert `pathlib.Path` values to strings before YAML dump
- test that `save_config` writes plain string paths

## Testing
- `python -m pytest tests/test_save_config_path.py -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc0c36a6083248fef13a864e4d3bb