### PR TITLE
Scale edge attributes like training pipeline

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -257,8 +257,6 @@ def validate_surrogate(
     edge_index = edge_index.to(device)
     if edge_attr is not None:
         edge_attr = edge_attr.to(device)
-        if hasattr(model, "edge_mean") and getattr(model, "edge_mean") is not None:
-            edge_attr = (edge_attr - model.edge_mean) / model.edge_std
 
     with torch.no_grad():
         first = True
@@ -466,8 +464,6 @@ def rollout_surrogate(
     edge_index = edge_index.to(device)
     if edge_attr is not None:
         edge_attr = edge_attr.to(device)
-        if hasattr(model, "edge_mean") and getattr(model, "edge_mean") is not None:
-            edge_attr = (edge_attr - model.edge_mean) / model.edge_std
 
     sq_p = np.zeros(steps, dtype=float)
     sq_c = np.zeros(steps, dtype=float)

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -36,7 +36,6 @@ try:
         RecurrentGNNSurrogate,
         MultiTaskGNNSurrogate,
         build_edge_attr,
-        build_edge_type,
         build_node_type,
     )  # type: ignore
 except ImportError:  # pragma: no cover - executed when run as a script
@@ -45,7 +44,6 @@ except ImportError:  # pragma: no cover - executed when run as a script
         RecurrentGNNSurrogate,
         MultiTaskGNNSurrogate,
         build_edge_attr,
-        build_edge_type,
         build_node_type,
     )
 import wntr
@@ -225,7 +223,9 @@ def load_network(
             static_feats[idx, 3] = float(elev or 0.0)
 
     if return_edge_attr:
-        edge_attr = build_edge_attr(wn, edge_index.numpy())
+        edge_attr = build_edge_attr(wn, edge_index.numpy()).astype(np.float32)
+        edge_attr[:, 2] = np.log1p(edge_attr[:, 2])
+        edge_attr = MinMaxScaler().fit_transform(edge_attr).astype(np.float32)
         edge_attr = torch.tensor(edge_attr, dtype=torch.float32)
         if return_features:
             return (

--- a/tests/test_validate_surrogate.py
+++ b/tests/test_validate_surrogate.py
@@ -144,9 +144,8 @@ def test_validate_surrogate_dict_stats():
         torch.tensor(edge_types, dtype=torch.long),
     )
     p_df = res.node["pressure"].clip(lower=5.0)
-    c_df = res.node["quality"]
+    _ = res.node["quality"]
     true_p = p_df.iloc[1, 0]
-    true_c = c_df.iloc[1, 0]
     expected_diff_p = 1.0 - true_p
     assert arr.shape[0] >= 1
     assert abs(arr[0, 0] - expected_diff_p) < 1e-6
@@ -225,7 +224,7 @@ def test_validate_surrogate_edge_dim_check():
         )
 
 
-def test_validate_surrogate_normalizes_edge_attr():
+def test_validate_surrogate_passes_edge_attr_unchanged():
     device = torch.device('cpu')
     (
         wn,
@@ -267,7 +266,7 @@ def test_validate_surrogate_normalizes_edge_attr():
         torch.tensor(node_types, dtype=torch.long),
         torch.tensor(edge_types, dtype=torch.long),
     )
-    expected = (edge_attr.to(device) - model.edge_mean) / model.edge_std
+    expected = edge_attr.to(device)
     assert model.seen is not None
     assert torch.allclose(model.seen, expected)
 


### PR DESCRIPTION
## Summary
- Preprocess edge attributes in `load_network` using log1p and MinMax scaling to match training
- Stop re-normalizing edge attributes in surrogate validation and rollout
- Update tests to reflect new edge-attribute handling

## Testing
- `python -m pyflakes scripts/mpc_control.py scripts/experiments_validation.py tests/test_validate_surrogate.py`
- `pytest tests/test_validate_surrogate.py tests/test_rollout_eval.py tests/test_mpc_normalization.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d79cb4288324a924345bbb50abaa