### PR TITLE
Fix encoder checkpoint loading and chlorine MAE calculation

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -398,7 +398,7 @@ def validate_surrogate(
                 rmse_p += float((diff_p_masked ** 2).sum())
                 rmse_c += float((diff_c_masked ** 2).sum())
                 mae_p += float(np.abs(diff_p_masked).sum())
-                mae_c += float(np.abs(diff_p_masked).sum())
+                mae_c += float(np.abs(diff_c_masked).sum())
                 rmse_p_all += float((diff_p ** 2).sum())
                 rmse_c_all += float((diff_c ** 2).sum())
                 mae_p_all += float(np.abs(diff_p).sum())


### PR DESCRIPTION
## Summary
- handle `encoder.convs` checkpoints even when metadata is present
- respect attention settings when rebuilding recurrent models
- correct chlorine MAE aggregation in validation metrics
- add regression test for loading checkpoints with `encoder.convs`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a146cfc6f48324ae0b7703037270cf