### PR TITLE
fix: enable gradients for MPC

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -987,6 +987,8 @@ def main() -> None:
     else:
         print(f"{args.test_pkl} not found. Skipping surrogate validation.")
 
+    # Re-enable gradient calculations for MPC optimization
+    torch.set_grad_enabled(True)
     mpc_df = simulate_closed_loop(
         wntr.network.WaterNetworkModel(args.inp),
         model,


### PR DESCRIPTION
## Summary
- re-enable gradient computation after surrogate validation to allow MPC optimization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1552051e48324a0bc2face57d8921