### PR TITLE
Ensure debug JSON handles numpy arrays

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -940,8 +940,12 @@ def main() -> None:
                 sample_path = RUNS_DIR / "debug_samples.csv"
                 dbg["sample_df"].to_csv(sample_path, index=False)
                 dbg["sample_df"] = sample_path.name
+            def _to_serializable(obj):
+                if isinstance(obj, np.ndarray):
+                    return obj.tolist()
+                return obj
             with open(debug_path, "w") as f:
-                json.dump(dbg, f, indent=2)
+                json.dump(dbg, f, indent=2, default=_to_serializable)
             print(f"[DEBUG] summary saved to {debug_path}")
         pd.DataFrame([metrics]).to_csv(
             os.path.join(DATA_DIR, "surrogate_validation.csv"), index=False


### PR DESCRIPTION
## Summary
- Add `_to_serializable` helper to convert `numpy` arrays to lists
- Use `json.dump(..., default=_to_serializable)` when writing debug summary

## Testing
- `pytest` *(interrupted: 6 passed, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a21379bd888324b9f93b292a821245