### PR TITLE
Normalize edge attributes during validation

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -267,6 +267,8 @@ def validate_surrogate(
     edge_index = edge_index.to(device)
     if edge_attr is not None:
         edge_attr = edge_attr.to(device)
+        if getattr(model, "edge_mean", None) is not None:
+            edge_attr = (edge_attr - model.edge_mean) / (model.edge_std + 1e-8)
 
     with torch.no_grad():
         first = True
@@ -523,6 +525,8 @@ def rollout_surrogate(
     edge_index = edge_index.to(device)
     if edge_attr is not None:
         edge_attr = edge_attr.to(device)
+        if getattr(model, "edge_mean", None) is not None:
+            edge_attr = (edge_attr - model.edge_mean) / (model.edge_std + 1e-8)
 
     sq_p = np.zeros(steps, dtype=float)
     sq_c = np.zeros(steps, dtype=float)

--- a/tests/test_validate_surrogate.py
+++ b/tests/test_validate_surrogate.py
@@ -224,7 +224,7 @@ def test_validate_surrogate_edge_dim_check():
         )
 
 
-def test_validate_surrogate_passes_edge_attr_unchanged():
+def test_validate_surrogate_normalizes_edge_attr():
     device = torch.device('cpu')
     (
         wn,
@@ -266,7 +266,7 @@ def test_validate_surrogate_passes_edge_attr_unchanged():
         torch.tensor(node_types, dtype=torch.long),
         torch.tensor(edge_types, dtype=torch.long),
     )
-    expected = edge_attr.to(device)
+    expected = (edge_attr.to(device) - model.edge_mean) / (model.edge_std + 1e-8)
     assert model.seen is not None
     assert torch.allclose(model.seen, expected)
 


### PR DESCRIPTION
## Summary
- normalize edge features in `validate_surrogate` and `rollout_surrogate`
- update unit test to expect normalized edge attributes

## Testing
- `pytest`
- `python scripts/experiments_validation.py --model models/gnn_surrogate.pth --inp CTown.inp --force-arch-mismatch` *(fails: KeyError: 'layers.0.lin.weight')*


------
https://chatgpt.com/codex/tasks/task_e_68a2573eca1083249a746dd546ab25f5