### PR TITLE
Save normalization hash in training checkpoints

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1745,6 +1745,8 @@ def main(args: argparse.Namespace):
         "edge_scaler": "MinMax",
         "log_roughness": True,
     }
+    if norm_md5 is not None:
+        model_meta["norm_stats_md5"] = norm_md5
 
     # expose normalization stats on the model for later un-normalisation
     if args.normalize:


### PR DESCRIPTION
## Summary
- Include `norm_stats_md5` in training checkpoint metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a27fa4320c83248ad8a47af1a1023a