### PR TITLE
Use running statistics for evaluation metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,16 @@ these plots since their pressures are fixed. ``error_histograms_<run>.png``
 contains histograms and box plots of the prediction errors and the CSV
 ``logs/accuracy_<run>.csv`` records MAE, RMSE, MAPE and maximum error for
 pressure and chlorine. Reservoir and tank nodes are excluded from these metrics
-so outliers from fixed heads do not skew the results. Finally ``correlation_heatmap_<run>.png``
-visualises pairwise correlations between the unnormalised training features.
-When normalization is enabled (the default) the test data is scaled using the
-training statistics. During evaluation both predictions **and** the
-corresponding ground truth labels are transformed back to physical units before
-plotting.
+so outliers from fixed heads do not skew the results. Metrics are accumulated
+using running statistics so the full prediction arrays are never stored in
+memory. To limit the number of predictions retained for plotting, pass
+``--eval-sample N`` (default ``1000``) which keeps only the first ``N``
+predictions for the scatter and error plots. Set ``N=0`` to skip these
+figures entirely. Finally ``correlation_heatmap_<run>.png`` visualises pairwise
+correlations between the unnormalised training features. When normalization is
+enabled (the default) the test data is scaled using the training statistics.
+During evaluation both predictions **and** the corresponding ground truth
+labels are transformed back to physical units before plotting.
 The training script saves feature and target means and standard deviations on
 the model.  ``mpc_control.py`` loads these tensors and checks their shapes so
 inference uses the exact same statistics.  This normalization contract prevents
@@ -138,7 +142,7 @@ python scripts/train_gnn.py \
     --edge-index-path data/edge_index.npy --edge-attr-path data/edge_attr.npy \
     --inp-path CTown.inp \
     --epochs 100 --batch-size 32 --hidden-dim 128 --num-layers 4 \
-    --lstm-hidden 64 --workers 8 \
+    --lstm-hidden 64 --workers 8 --eval-sample 1000 \
     --dropout 0.1 --residual --early-stop-patience 10 \
     --weight-decay 1e-5 --w-press 5.0 --w-flow 3.0 --w-cl 0.0
 ```

--- a/tests/test_accuracy_export.py
+++ b/tests/test_accuracy_export.py
@@ -4,15 +4,21 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from scripts.train_gnn import save_accuracy_metrics
+from scripts.train_gnn import RunningStats, save_accuracy_metrics
+
 
 def test_save_accuracy_metrics(tmp_path):
     true_p = np.array([10.0, 12.0])
     pred_p = np.array([9.5, 12.5])
     true_c = np.log1p(np.array([0.5, 0.4]) / 1000.0)
     pred_c = np.log1p(np.array([0.45, 0.6]) / 1000.0)
-    mask = [True, False]
-    save_accuracy_metrics(true_p, pred_p, true_c, pred_c, "unit", logs_dir=tmp_path, mask=mask)
+
+    p_stats = RunningStats()
+    p_stats.update(pred_p, true_p)
+    c_stats = RunningStats()
+    c_stats.update(pred_c, true_c)
+
+    save_accuracy_metrics(p_stats, "unit", logs_dir=tmp_path, chlorine_stats=c_stats)
     f = tmp_path / "accuracy_unit.csv"
     assert f.exists()
     df = pd.read_csv(f, index_col=0)


### PR DESCRIPTION
## Summary
- accumulate MAE/RMSE statistics without storing full prediction arrays
- allow limiting evaluation plots to first N predictions via `--eval-sample`
- document evaluation sampling in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a368e5a7c88324811ab975d2714216