### PR TITLE
Clamp physics loss scales in training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ curve terms during the first pass over the training data. These values are used
 to normalise the respective losses before applying the user-specified weights.
 The automatically detected scales can be overridden via ``--mass-scale``,
 ``--head-scale`` and ``--pump-scale`` if manual tuning or logging is desired.
+Scales below ``1e-3`` are automatically clamped to prevent excessively large
+physics penalties.
 Training logs also report the average mass imbalance per batch and the
 percentage of edges with inconsistent headloss signs.
 

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1826,6 +1826,10 @@ def main(args: argparse.Namespace):
             head_scale = float(base_eval[5]) if base_eval[5] > 0 else 1.0
         if args.pump_loss and pump_scale <= 0:
             pump_scale = float(base_eval[7]) if base_eval[7] > 0 else 1.0
+    MIN_SCALE = 1e-3
+    mass_scale = max(mass_scale, MIN_SCALE)
+    head_scale = max(head_scale, MIN_SCALE)
+    pump_scale = max(pump_scale, MIN_SCALE)
     args.mass_scale = mass_scale
     args.head_scale = head_scale
     args.pump_scale = pump_scale
@@ -2640,19 +2644,19 @@ if __name__ == "__main__":
         "--mass-scale",
         type=float,
         default=0.0,
-        help="Baseline magnitude for mass conservation loss (0 = auto-compute)",
+        help="Baseline magnitude for mass conservation loss (0 = auto-compute; clamped to ≥1e-3)",
     )
     parser.add_argument(
         "--head-scale",
         type=float,
         default=0.0,
-        help="Baseline magnitude for head loss consistency (0 = auto-compute)",
+        help="Baseline magnitude for head loss consistency (0 = auto-compute; clamped to ≥1e-3)",
     )
     parser.add_argument(
         "--pump-scale",
         type=float,
         default=0.0,
-        help="Baseline magnitude for pump curve loss (0 = auto-compute)",
+        help="Baseline magnitude for pump curve loss (0 = auto-compute; clamped to ≥1e-3)",
     )
     parser.add_argument(
         "--cluster-batch-size",


### PR DESCRIPTION
## Summary
- Prevent near-zero physics loss scales by clamping mass, head, and pump scales to a minimum value
- Document minimum scale behavior in CLI help text and README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a392fcc9a883248db0401d31b30e30