### PR TITLE
Clamp small scales in physics loss normalization

### DIFF
--- a/models/losses.py
+++ b/models/losses.py
@@ -183,7 +183,7 @@ def scale_physics_losses(
     head_scale: float = 1.0,
     pump_scale: float = 1.0,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Normalise physics-based losses by baseline magnitudes.
+    """Normalise physics-based losses by baseline magnitudes and clamp small scales.
 
     Parameters
     ----------
@@ -191,17 +191,20 @@ def scale_physics_losses(
         Raw physics loss values.
     mass_scale, head_scale, pump_scale: float, optional
         Baseline magnitudes for each loss. Values ``\le 0`` disable scaling.
+        Very small positive scales are clamped to ``1e-3`` to avoid division
+        by near-zero numbers.
 
     Returns
     -------
     Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
         Scaled ``mass_loss``, ``head_loss`` and ``pump_loss``.
     """
+    eps = 1e-3
     if mass_scale > 0:
-        mass_loss = mass_loss / mass_scale
+        mass_loss = mass_loss / max(mass_scale, eps)
     if head_scale > 0:
-        head_loss = head_loss / head_scale
+        head_loss = head_loss / max(head_scale, eps)
     if pump_scale > 0:
-        pump_loss = pump_loss / pump_scale
+        pump_loss = pump_loss / max(pump_scale, eps)
     return mass_loss, head_loss, pump_loss
 


### PR DESCRIPTION
## Summary
- avoid division by near-zero when scaling physics losses
- document automatic clamping of tiny scaling factors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a395b319b083249cb7fb7a8b958880