### PR TITLE
Add per-node normalization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ The training script saves feature and target means and standard deviations on
 the model.  ``mpc_control.py`` loads these tensors and checks their shapes so
 inference uses the exact same statistics.  This normalization contract prevents
 silent scaling mismatches; pass ``--skip-normalization`` to operate entirely on
-raw values.
+raw values. Pass ``--per-node-norm`` to compute statistics for each node index
+separately which removes large baseline offsets and often reduces pressure MAE.
 When sequence models are used a component-wise loss curve
 ``loss_components_<run>.png`` is stored alongside ``loss_curve_<run>.png`` and
 the per-component pressure, chlorine and flow losses are recorded each epoch in

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1494,7 +1494,7 @@ def main(args: argparse.Namespace):
     if args.normalize:
         if seq_mode:
             x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(
-                X_raw, Y_raw
+                X_raw, Y_raw, per_node=args.per_node_norm
             )
             apply_sequence_normalization(
                 data_ds,
@@ -1504,6 +1504,7 @@ def main(args: argparse.Namespace):
                 y_std,
                 edge_mean,
                 edge_std,
+                per_node=args.per_node_norm,
             )
             if isinstance(val_list, SequenceDataset):
                 apply_sequence_normalization(
@@ -1514,15 +1515,32 @@ def main(args: argparse.Namespace):
                     y_std,
                     edge_mean,
                     edge_std,
+                    per_node=args.per_node_norm,
                 )
         else:
-            x_mean, x_std, y_mean, y_std = compute_norm_stats(data_list)
+            x_mean, x_std, y_mean, y_std = compute_norm_stats(
+                data_list, per_node=args.per_node_norm
+            )
             apply_normalization(
-                data_list, x_mean, x_std, y_mean, y_std, edge_mean, edge_std
+                data_list,
+                x_mean,
+                x_std,
+                y_mean,
+                y_std,
+                edge_mean,
+                edge_std,
+                per_node=args.per_node_norm,
             )
             if val_list:
                 apply_normalization(
-                    val_list, x_mean, x_std, y_mean, y_std, edge_mean, edge_std
+                    val_list,
+                    x_mean,
+                    x_std,
+                    y_mean,
+                    y_std,
+                    edge_mean,
+                    edge_std,
+                    per_node=args.per_node_norm,
                 )
         print("Target normalization stats:")
         if isinstance(y_mean, dict):
@@ -2184,6 +2202,7 @@ def main(args: argparse.Namespace):
                     y_std,
                     edge_mean,
                     edge_std,
+                    per_node=args.per_node_norm,
                 )
             test_loader = TorchLoader(
                 test_ds,
@@ -2202,7 +2221,16 @@ def main(args: argparse.Namespace):
                 edge_type=edge_types,
             )
             if args.normalize:
-                apply_normalization(test_list, x_mean, x_std, y_mean, y_std, edge_mean, edge_std)
+                apply_normalization(
+                    test_list,
+                    x_mean,
+                    x_std,
+                    y_mean,
+                    y_std,
+                    edge_mean,
+                    edge_std,
+                    per_node=args.per_node_norm,
+                )
             test_loader = DataLoader(
                 test_list,
                 batch_size=args.batch_size,
@@ -2574,6 +2602,11 @@ if __name__ == "__main__":
         action="store_true",
         default=True,
         help="Apply normalization to features and targets",
+    )
+    parser.add_argument(
+        "--per-node-norm",
+        action="store_true",
+        help="Compute normalization statistics for each node index separately",
     )
     parser.add_argument(
         "--physics_loss",

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -5,17 +5,36 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from scripts.train_gnn import compute_norm_stats, apply_normalization
+import pytest
 
-def test_normalization():
-    edge = torch.tensor([[0,1],[1,0]], dtype=torch.long)
-    d1 = Data(x=torch.tensor([[1.0,2.0],[3.0,4.0]]), edge_index=edge, y=torch.tensor([[1.0,2.0],[3.0,4.0]]))
-    d2 = Data(x=torch.tensor([[5.0,6.0],[7.0,8.0]]), edge_index=edge, y=torch.tensor([[5.0,6.0],[7.0,8.0]]))
-    data = [d1,d2]
-    x_mean,x_std,y_mean,y_std = compute_norm_stats(data)
-    apply_normalization(data,x_mean,x_std,y_mean,y_std)
-    all_x = torch.cat([d.x for d in data], dim=0)
-    all_y = torch.cat([d.y for d in data], dim=0)
-    assert torch.allclose(all_x.mean(dim=0), torch.zeros_like(x_mean), atol=1e-6)
-    assert torch.allclose(all_x.std(dim=0), torch.ones_like(x_std), atol=1e-6)
-    assert torch.allclose(all_y.mean(dim=0), torch.zeros_like(y_mean), atol=1e-6)
-    assert torch.allclose(all_y.std(dim=0), torch.ones_like(y_std), atol=1e-6)
+
+@pytest.mark.parametrize("per_node", [False, True])
+def test_normalization(per_node):
+    edge = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    d1 = Data(
+        x=torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+        edge_index=edge,
+        y=torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+    )
+    d2 = Data(
+        x=torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+        edge_index=edge,
+        y=torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+    )
+    data = [d1, d2]
+    x_mean, x_std, y_mean, y_std = compute_norm_stats(data, per_node=per_node)
+    apply_normalization(data, x_mean, x_std, y_mean, y_std, per_node=per_node)
+    if per_node:
+        all_x = torch.stack([d.x for d in data], dim=0)
+        all_y = torch.stack([d.y for d in data], dim=0)
+        assert torch.allclose(all_x.mean(dim=0), torch.zeros_like(x_mean), atol=1e-6)
+        assert torch.allclose(all_x.std(dim=0), torch.ones_like(x_std), atol=1e-6)
+        assert torch.allclose(all_y.mean(dim=0), torch.zeros_like(y_mean), atol=1e-6)
+        assert torch.allclose(all_y.std(dim=0), torch.ones_like(y_std), atol=1e-6)
+    else:
+        all_x = torch.cat([d.x for d in data], dim=0)
+        all_y = torch.cat([d.y for d in data], dim=0)
+        assert torch.allclose(all_x.mean(dim=0), torch.zeros_like(x_mean), atol=1e-6)
+        assert torch.allclose(all_x.std(dim=0), torch.ones_like(x_std), atol=1e-6)
+        assert torch.allclose(all_y.mean(dim=0), torch.zeros_like(y_mean), atol=1e-6)
+        assert torch.allclose(all_y.std(dim=0), torch.ones_like(y_std), atol=1e-6)

--- a/tests/test_sequence_norm_stats.py
+++ b/tests/test_sequence_norm_stats.py
@@ -5,20 +5,31 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from scripts.train_gnn import compute_sequence_norm_stats
+import pytest
 
 
-def test_sequence_norm_stats_edge_vector():
+@pytest.mark.parametrize("per_node", [False, True])
+def test_sequence_norm_stats_edge_vector(per_node):
     X = np.zeros((1, 1, 2, 4), dtype=np.float32)
-    Y = np.array([
-        {
-            "node_outputs": np.zeros((1, 2, 2), dtype=np.float32),
-            "edge_outputs": np.array([[1.0, -1.0]], dtype=np.float32),
-        }
-    ], dtype=object)
-    x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(X, Y)
+    Y = np.array(
+        [
+            {
+                "node_outputs": np.zeros((1, 2, 2), dtype=np.float32),
+                "edge_outputs": np.array([[1.0, -1.0]], dtype=np.float32),
+            }
+        ],
+        dtype=object,
+    )
+    x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(X, Y, per_node=per_node)
     assert isinstance(y_mean, dict)
     assert y_mean["edge_outputs"].shape == torch.Size([2])
     assert y_std["edge_outputs"].shape == torch.Size([2])
+    if per_node:
+        assert x_mean.shape == torch.Size([2, 4])
+        assert y_mean["node_outputs"].shape == torch.Size([2, 2])
+    else:
+        assert x_mean.shape == torch.Size([4])
+        assert y_mean["node_outputs"].shape == torch.Size([2])
     # check normalization broadcast
     Y_tensor = torch.tensor(Y[0]["edge_outputs"], dtype=torch.float32)
     Y_norm = (Y_tensor - y_mean["edge_outputs"]) / y_std["edge_outputs"]


### PR DESCRIPTION
## Summary
- support node-wise mean/std in normalization utilities and sequence variants
- add `--per-node-norm` flag in `train_gnn.py` to toggle node-wise scaling
- document per-node normalization in README and extend tests

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68a3aa887bd08324bbf8985a03377853