### PR TITLE
Fix per-node normalization clamp in GNN surrogate

### DIFF
--- a/models/gnn_surrogate.py
+++ b/models/gnn_surrogate.py
@@ -430,18 +430,20 @@ class MultiTaskGNNSurrogate(nn.Module):
         min_p = min_c = 0.0
         if getattr(self, "y_mean", None) is not None:
             if isinstance(self.y_mean, dict):
-                p_mean = self.y_mean["node_outputs"][0].to(node_pred.device)
-                p_std = self.y_std["node_outputs"][0].to(node_pred.device)
-                if self.y_mean["node_outputs"].numel() > 1:
-                    c_mean = self.y_mean["node_outputs"][1].to(node_pred.device)
-                    c_std = self.y_std["node_outputs"][1].to(node_pred.device)
+                node_mean = self.y_mean["node_outputs"]
+                node_std = self.y_std["node_outputs"]
+                p_mean = node_mean[..., 0].to(node_pred.device)
+                p_std = node_std[..., 0].to(node_pred.device)
+                if node_mean.shape[-1] > 1:
+                    c_mean = node_mean[..., 1].to(node_pred.device)
+                    c_std = node_std[..., 1].to(node_pred.device)
                 else:
                     c_mean = torch.tensor(0.0, device=node_pred.device)
                     c_std = torch.tensor(1.0, device=node_pred.device)
             else:
                 p_mean = self.y_mean[0].to(node_pred.device)
                 p_std = self.y_std[0].to(node_pred.device)
-                if self.y_mean.numel() > 1:
+                if self.y_mean.shape[0] > 1:
                     c_mean = self.y_mean[1].to(node_pred.device)
                     c_std = self.y_std[1].to(node_pred.device)
                 else:

--- a/tests/test_output_clamp.py
+++ b/tests/test_output_clamp.py
@@ -52,3 +52,28 @@ def test_multitask_output_clamp_and_tank_level():
     out = model(X, edge_index, edge_attr)
     assert torch.all(out['node_outputs'] >= 0)
     assert torch.all(model.tank_levels >= 0)
+
+
+def test_output_clamp_with_per_node_norm():
+    edge_index = torch.tensor([[0], [1]], dtype=torch.long)
+    edge_attr = torch.ones(1, 3)
+    model = MultiTaskGNNSurrogate(
+        in_channels=2,
+        hidden_channels=4,
+        edge_dim=3,
+        node_output_dim=2,
+        edge_output_dim=1,
+        num_layers=1,
+        use_attention=False,
+        gat_heads=1,
+        dropout=0.0,
+        residual=False,
+        rnn_hidden_dim=4,
+    )
+    model.node_decoder.weight.data.zero_()
+    model.node_decoder.bias.data.fill_(-1.0)
+    model.y_mean = {"node_outputs": torch.zeros(2, 2)}
+    model.y_std = {"node_outputs": torch.ones(2, 2)}
+    X = torch.zeros(1, 1, 2, 2)
+    out = model(X, edge_index, edge_attr)
+    assert out["node_outputs"].shape == (1, 1, 2, 2)


### PR DESCRIPTION
## Summary
- Correct clamping logic in `gnn_surrogate` to handle per-node normalization stats
- Add regression test ensuring per-node stats clamp without shape mismatch

## Testing
- `PYTHONPATH=. pytest tests/test_output_clamp.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3b1ba98cc8324af64201d8c6e36b8