### PR TITLE
Handle per-node pressure stats when de-normalizing

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1064,12 +1064,15 @@ def train_sequence(
                 flow = edge_preds.squeeze(-1)
                 if hasattr(model, 'y_mean') and model.y_mean is not None:
                     if isinstance(model.y_mean, dict):
-                        p_mean = model.y_mean['node_outputs'][0].to(device)
-                        p_std = model.y_std['node_outputs'][0].to(device)
+                        p_mean = model.y_mean['node_outputs'].to(device)
+                        p_std = model.y_std['node_outputs'].to(device)
+                        if p_mean.ndim == 2:
+                            p_mean = p_mean[..., 0]
+                            p_std = p_std[..., 0]
+                        press = press * p_std.view(1, 1, -1) + p_mean.view(1, 1, -1)
                         q_mean = model.y_mean['edge_outputs'].to(device)
                         q_std = model.y_std['edge_outputs'].to(device)
-                        press = press * p_std + p_mean
-                        flow = flow * q_std + q_mean
+                        flow = flow * q_std.view(1, 1, -1) + q_mean.view(1, 1, -1)
                     else:
                         press = press * model.y_std[0].to(device) + model.y_mean[0].to(device)
                 head_loss, head_violation = pressure_headloss_consistency_loss(
@@ -1299,12 +1302,15 @@ def evaluate_sequence(
                         flow = edge_preds.squeeze(-1)
                         if hasattr(model, 'y_mean') and model.y_mean is not None:
                             if isinstance(model.y_mean, dict):
-                                p_mean = model.y_mean['node_outputs'][0].to(device)
-                                p_std = model.y_std['node_outputs'][0].to(device)
+                                p_mean = model.y_mean['node_outputs'].to(device)
+                                p_std = model.y_std['node_outputs'].to(device)
+                                if p_mean.ndim == 2:
+                                    p_mean = p_mean[..., 0]
+                                    p_std = p_std[..., 0]
+                                press = press * p_std.view(1, 1, -1) + p_mean.view(1, 1, -1)
                                 q_mean = model.y_mean['edge_outputs'].to(device)
                                 q_std = model.y_std['edge_outputs'].to(device)
-                                press = press * p_std + p_mean
-                                flow = flow * q_std + q_mean
+                                flow = flow * q_std.view(1, 1, -1) + q_mean.view(1, 1, -1)
                             else:
                                 press = press * model.y_std[0].to(device) + model.y_mean[0].to(device)
                         head_loss, head_violation = pressure_headloss_consistency_loss(

--- a/tests/test_per_node_pressure_denorm.py
+++ b/tests/test_per_node_pressure_denorm.py
@@ -1,0 +1,61 @@
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from scripts.feature_utils import SequenceDataset
+from scripts.train_gnn import evaluate_sequence
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        # two nodes with per-node pressure/chlorine stats
+        self.y_mean = {
+            "node_outputs": torch.tensor([[1.0, 0.0], [2.0, 0.0]], dtype=torch.float32),
+            "edge_outputs": torch.zeros(2, dtype=torch.float32),
+        }
+        self.y_std = {
+            "node_outputs": torch.ones((2, 2), dtype=torch.float32),
+            "edge_outputs": torch.ones(2, dtype=torch.float32),
+        }
+
+    def forward(self, X_seq, edge_index, edge_attr, node_type, edge_type):
+        batch_size, T, num_nodes, _ = X_seq.shape
+        edge_count = edge_index.size(1)
+        node_out = torch.zeros(batch_size, T, num_nodes, 2, device=X_seq.device)
+        edge_out = torch.zeros(batch_size, T, edge_count, 1, device=X_seq.device)
+        return {"node_outputs": node_out, "edge_outputs": edge_out}
+
+
+def test_evaluate_sequence_per_node_pressure_denorm():
+    X = np.zeros((1, 1, 2, 2), dtype=np.float32)
+    Y = np.array([
+        {
+            "node_outputs": np.zeros((1, 2, 2), dtype=np.float32),
+            "edge_outputs": np.zeros((1, 2), dtype=np.float32),
+        }
+    ], dtype=object)
+    edge_index = np.array([[0, 1], [1, 0]])
+    edge_attr = np.zeros((2, 3), dtype=np.float32)
+    dataset = SequenceDataset(X, Y, edge_index=edge_index, edge_attr=edge_attr)
+    loader = DataLoader(dataset, batch_size=1)
+
+    model = DummyModel()
+    device = torch.device("cpu")
+    edge_attr_phys = torch.ones_like(dataset.edge_attr)
+
+    # Should run without raising despite per-node normalization stats
+    result = evaluate_sequence(
+        model,
+        loader,
+        dataset.edge_index,
+        dataset.edge_attr,
+        edge_attr_phys,
+        None,
+        None,
+        [],
+        device,
+        pressure_loss=True,
+        progress=False,
+    )
+    assert isinstance(result, tuple)


### PR DESCRIPTION
## Summary
- Fix pressure de-normalization in `evaluate_sequence` to properly broadcast per-node statistics
- Add regression test covering per-node pressure normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3b90138548324b45c60d371c58ead