### PR TITLE
Ensure deterministic dataset splits

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -491,10 +491,12 @@ def split_results(
             Dict[str, np.ndarray],
             Dict[str, List[float]],
         ]
-    ]
+    ],
+    seed: Optional[int] = None,
 ) -> Tuple[List, List, List]:
     num_total = len(results)
-    indices = np.random.permutation(num_total)
+    rng = np.random.default_rng(seed)
+    indices = rng.permutation(num_total)
     n_train = int(0.7 * num_total)
     n_val = int(0.15 * num_total)
     train_idx = indices[:n_train]
@@ -926,7 +928,7 @@ def main() -> None:
     plot_dataset_distributions(demand_mults, pump_speeds, run_ts)
     plot_pressure_histogram(all_pressures, base_pressures, run_ts)
     extreme_count = sum(m["min_pressure"] < 10.0 for m in manifest_records)
-    train_res, val_res, test_res = split_results(results)
+    train_res, val_res, test_res = split_results(results, seed=args.seed)
 
     wn_template = wntr.network.WaterNetworkModel(str(inp_file))
     if args.sequence_length > 1:

--- a/tests/test_split_results.py
+++ b/tests/test_split_results.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts.data_generation import split_results
+
+
+def test_split_results_deterministic():
+    results = [(i, {}, {}) for i in range(20)]
+    train1, val1, test1 = split_results(results, seed=123)
+    train2, val2, test2 = split_results(results, seed=123)
+    assert train1 == train2
+    assert val1 == val2
+    assert test1 == test2
+
+
+def test_split_results_different_seed():
+    results = [(i, {}, {}) for i in range(20)]
+    split1 = split_results(results, seed=1)
+    split2 = split_results(results, seed=2)
+    assert split1 != split2


### PR DESCRIPTION
## Summary
- Allow `split_results` to take an optional seed and use `np.random.default_rng` for permutations
- Pass the global seed through to `split_results` in `data_generation.main`
- Add tests verifying that providing the same seed yields identical splits

## Testing
- `python -m pytest tests/test_split_results.py::test_split_results_deterministic -q`
- `python -m pytest tests/test_split_results.py::test_split_results_different_seed -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a664025e188324b169fb41bd3bfc1c