### PR TITLE
Add EPyT network state plotting for MPC runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,9 @@ interval exceeds one hour to highlight potential drift. Results are written to
 `data/mpc_history.csv`.  A summary listing constraint violations and total
 energy consumption (in Joules) is printed at the end of the run and saved to
 ``logs/mpc_summary.json``.
+Each simulated hour also produces a network snapshot coloured by pressure with
+pump links scaled by their control inputs, saved under
+``plots/mpc_network_state_<run>_t<hour>.png``.
 The ``--feedback-interval`` flag controls how often EPANET provides ground
 truth. ``1`` (default) refreshes the state each hour, ``0`` disables feedback
 entirely for a fully surrogate rollout, and larger values propagate the

--- a/tests/test_network_state_plot.py
+++ b/tests/test_network_state_plot.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts.mpc_control import plot_network_state_epyt
+
+
+def test_plot_network_state_epyt_creates_png(tmp_path):
+    pressures = {"J511": 30.0, "J411": 25.0}
+    pump_controls = {"P1": 0.7}
+    out_path = plot_network_state_epyt(pressures, pump_controls, "test", 0, plots_dir=tmp_path)
+    assert out_path.exists()
+    assert out_path.suffix == ".png"


### PR DESCRIPTION
## Summary
- Add `plot_network_state_epyt` to visualize network pressures and pump controls using EPyT
- Generate network snapshots during MPC simulation
- Document and test the new plotting functionality

## Testing
- `pytest tests/test_network_state_plot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8fa61cdf88324b94e21161d9a0ca6