### PR TITLE
Add MPC network animation helper and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
   - `test_validate_surrogate.py`
   - `test_rollout_eval.py`
   - `test_visualizations.py`
+  - `test_mpc_animation.py`
   - `test_workers.py`
 - `data/` – ignored by git; used for generated datasets and temporary simulation outputs.
 - `plots/` – ignored by git; stores figures generated during training, validation and MPC runs.

--- a/README.md
+++ b/README.md
@@ -342,6 +342,18 @@ python scripts/experiments_validation.py \
     --run-name baseline
 ```
 
+The validation run also exports an animated view of network pressures,
+chlorine and pump speeds:
+
+```bash
+python scripts/experiments_validation.py \
+    --model models/gnn_surrogate.pth --inp CTown.inp \
+    --run-name demo
+```
+
+This saves `plots/mpc_animation_demo.gif` and an HTML viewer alongside other
+figures.
+
 To benchmark architectural variants, run ``scripts/ablation_study.py`` which trains four configurations (baseline, residual, deep and attention) and reports validation pressure MAE along with training time.
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas
 matplotlib
 networkx
 epyt
+imageio

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -1743,6 +1743,9 @@ def simulate_closed_loop(
                 "controls": first_speeds.cpu().numpy().tolist(),
                 "bias_min": bias_min,
                 "bias_max": bias_max,
+                # Store full network state for optional animations
+                "pressures": dict(pressures),
+                "chlorine": dict(chlorine),
             }
         )
         if run_name:

--- a/tests/test_mpc_animation.py
+++ b/tests/test_mpc_animation.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+import wntr
+
+from scripts.experiments_validation import animate_mpc_network
+
+
+def test_animate_mpc_network(tmp_path: Path):
+    wn = wntr.network.WaterNetworkModel('CTown.inp')
+    pump_names = wn.pump_name_list
+    node_names = wn.node_name_list
+    pressures = {n: 50.0 for n in node_names}
+    chlorine = {n: 0.3 for n in node_names}
+    df = pd.DataFrame([
+        {
+            'time': 0,
+            'pressures': pressures,
+            'chlorine': chlorine,
+            'controls': [0.5] * len(pump_names),
+        }
+    ])
+    gif_path, html_path = animate_mpc_network(df, pump_names, 'unit', inp_path='CTown.inp', plots_dir=tmp_path)
+    assert gif_path.exists()
+    assert html_path.exists()


### PR DESCRIPTION
## Summary
- add `animate_mpc_network` helper to create GIF/HTML animations of MPC runs
- log full network state from MPC and call animation after simulation
- document animation usage in README and add regression test

## Testing
- `pytest tests/test_mpc_animation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8fc3584ec832481e8d25c68b9f787