### PR TITLE
Remove chlorine features from data pipeline

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -134,9 +134,8 @@ def _build_randomized_network(
     wn = wntr.network.WaterNetworkModel(inp_file)
     wn.options.time.duration = 24 * 3600
     wn.options.time.hydraulic_timestep = 3600
-    wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    wn.options.quality.parameter = "CHEMICAL"
+    wn.options.quality.parameter = "NONE"
 
     # Randomize initial tank levels uniformly across the provided range
     for tname in wn.tank_name_list:
@@ -347,7 +346,7 @@ def _run_single_scenario(
     if energy[wn.pump_name_list].isna().any().any():
         raise ValueError("pump energy contains NaN")
 
-    for df in [flows, heads, sim_results.node["pressure"], sim_results.node["quality"]]:
+    for df in [flows, heads, sim_results.node["pressure"]]:
         if df.isna().any().any() or np.isinf(df.values).any():
             raise ValueError("invalid values detected in simulation results")
 
@@ -519,14 +518,8 @@ def build_sequence_dataset(
     ],
     wn_template: wntr.network.WaterNetworkModel,
     seq_len: int,
-    *,
-    include_chlorine: bool = True,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Construct a dataset of sequences from simulation results.
-
-    When ``include_chlorine`` is ``False`` the node feature vectors exclude
-    chlorine concentrations and the targets only contain next-step pressure.
-    """
+    """Construct a dataset of sequences from simulation results."""
 
     X_list: List[np.ndarray] = []
     Y_list: List[dict] = []
@@ -541,16 +534,6 @@ def build_sequence_dataset(
         # range otherwise.  Enforce a 5 m lower bound to match downstream
         # validation logic.
         pressures = sim_results.node["pressure"].clip(lower=MIN_PRESSURE)
-        if include_chlorine:
-            quality_df = sim_results.node["quality"].clip(lower=0.0, upper=4.0)
-            param = str(wn_template.options.quality.parameter).upper()
-            if "CHEMICAL" in param or "CHLORINE" in param:
-                # convert mg/L to g/L used by CHEMICAL or CHLORINE models before
-                # taking the logarithm so the surrogate sees reasonable scales
-                quality_df = quality_df / 1000.0
-            quality = np.log1p(quality_df)
-        else:
-            quality = None
         demands = sim_results.node.get("demand")
         if demands is not None:
             max_d = float(demands.max().max())
@@ -568,7 +551,6 @@ def build_sequence_dataset(
         # Precompute arrays and mappings for faster indexing
         node_idx = {n: pressures.columns.get_loc(n) for n in node_names}
         p_arr = pressures.to_numpy(dtype=np.float64)
-        q_arr = quality.to_numpy(dtype=np.float64) if quality is not None else None
         d_arr = demands.to_numpy(dtype=np.float64) if demands is not None else None
         pump_ctrl_arr = np.asarray([pump_ctrl[p] for p in pumps], dtype=np.float64)
 
@@ -588,10 +570,6 @@ def build_sequence_dataset(
                     p_t = float(wn_template.get_node(node).base_head)
                 else:
                     p_t = float(p_arr[t, idx])
-                if include_chlorine:
-                    c_t = float(q_arr[t, idx])
-                else:
-                    c_t = None
                 if d_arr is not None and node in wn_template.junction_name_list:
                     d_t = float(d_arr[t, idx])
                 else:
@@ -608,10 +586,7 @@ def build_sequence_dataset(
                         elev = getattr(n, "base_head", 0.0)
                 if elev is None:
                     elev = 0.0
-                feat = [d_t, p_t]
-                if include_chlorine:
-                    feat.append(c_t)
-                feat.append(elev)
+                feat = [d_t, p_t, elev]
                 feat.extend(pump_vector.tolist())
                 feat_nodes.append(feat)
             X_seq.append(np.array(feat_nodes, dtype=np.float64))
@@ -623,11 +598,7 @@ def build_sequence_dataset(
                     p_next = float(wn_template.get_node(node).base_head)
                 else:
                     p_next = float(p_arr[t + 1, idx])
-                if include_chlorine:
-                    c_next = float(q_arr[t + 1, idx])
-                    out_nodes.append([max(p_next, MIN_PRESSURE), max(c_next, 0.0)])
-                else:
-                    out_nodes.append([max(p_next, MIN_PRESSURE)])
+                out_nodes.append([max(p_next, MIN_PRESSURE)])
             node_out_seq.append(np.array(out_nodes, dtype=np.float64))
 
             edge_out_seq.append(flows_arr[t + 1].astype(np.float64))
@@ -658,8 +629,6 @@ def build_dataset(
         ]
     ],
     wn_template: wntr.network.WaterNetworkModel,
-    *,
-    include_chlorine: bool = True,
 ) -> Tuple[np.ndarray, np.ndarray]:
     X_list: List[np.ndarray] = []
     Y_list: List[dict] = []
@@ -671,16 +640,6 @@ def build_dataset(
         # Enforce a 5 m lower bound while keeping the upper range unrestricted
         # to capture extreme pressure values.
         pressures = sim_results.node["pressure"].clip(lower=MIN_PRESSURE)
-        if include_chlorine:
-            quality_df = sim_results.node["quality"].clip(lower=0.0, upper=4.0)
-            param = str(wn_template.options.quality.parameter).upper()
-            if "CHEMICAL" in param or "CHLORINE" in param:
-                # CHEMICAL or CHLORINE quality models return mg/L, scale to g/L
-                # before applying the log transform
-                quality_df = quality_df / 1000.0
-            quality = np.log1p(quality_df)
-        else:
-            quality = None
         demands = sim_results.node.get("demand")
         times = pressures.index
         flows_arr, energy_arr = extract_additional_targets(sim_results, wn_template)
@@ -692,7 +651,6 @@ def build_dataset(
         # Precompute arrays and index mappings for faster lookup
         node_idx = {n: pressures.columns.get_loc(n) for n in node_names}
         p_arr = pressures.to_numpy(dtype=np.float64)
-        q_arr = quality.to_numpy(dtype=np.float64) if quality is not None else None
         d_arr = demands.to_numpy(dtype=np.float64) if demands is not None else None
         pump_ctrl_arr = np.asarray([pump_ctrl[p] for p in pumps], dtype=np.float64)
 
@@ -707,8 +665,6 @@ def build_dataset(
                     p_t = float(wn_template.get_node(node).base_head)
                 else:
                     p_t = max(p_arr[i, idx], MIN_PRESSURE)
-                if include_chlorine:
-                    c_t = max(q_arr[i, idx], 0.0)
                 if d_arr is not None and node in wn_template.junction_name_list:
                     d_t = d_arr[i, idx]
                 else:
@@ -727,10 +683,7 @@ def build_dataset(
                 if elev is None:
                     elev = 0.0
 
-                feat = [d_t, p_t]
-                if include_chlorine:
-                    feat.append(c_t)
-                feat.append(elev)
+                feat = [d_t, p_t, elev]
                 feat.extend(pump_vector.tolist())
                 feat_nodes.append(feat)
             X_list.append(np.array(feat_nodes, dtype=np.float64))
@@ -742,11 +695,7 @@ def build_dataset(
                     p_next = float(wn_template.get_node(node).base_head)
                 else:
                     p_next = max(p_arr[i + 1, idx], MIN_PRESSURE)
-                if include_chlorine:
-                    c_next = max(q_arr[i + 1, idx], 0.0)
-                    out_nodes.append([p_next, c_next])
-                else:
-                    out_nodes.append([p_next])
+                out_nodes.append([p_next])
             Y_list.append({
                 "node_outputs": np.array(out_nodes, dtype=np.float32),
                 "edge_outputs": flows_arr[i + 1].astype(np.float32),
@@ -873,12 +822,6 @@ def main() -> None:
         action="store_true",
         help="Display a progress bar during scenario simulation",
     )
-    parser.add_argument(
-        "--include-chlorine",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Include chlorine concentration features and targets",
-    )
     args = parser.parse_args()
 
     if args.seed is not None:
@@ -933,18 +876,18 @@ def main() -> None:
     wn_template = wntr.network.WaterNetworkModel(str(inp_file))
     if args.sequence_length > 1:
         X_train, Y_train, train_labels = build_sequence_dataset(
-            train_res, wn_template, args.sequence_length, include_chlorine=args.include_chlorine
+            train_res, wn_template, args.sequence_length
         )
         X_val, Y_val, val_labels = build_sequence_dataset(
-            val_res, wn_template, args.sequence_length, include_chlorine=args.include_chlorine
+            val_res, wn_template, args.sequence_length
         )
         X_test, Y_test, test_labels = build_sequence_dataset(
-            test_res, wn_template, args.sequence_length, include_chlorine=args.include_chlorine
+            test_res, wn_template, args.sequence_length
         )
     else:
-        X_train, Y_train = build_dataset(train_res, wn_template, include_chlorine=args.include_chlorine)
-        X_val, Y_val = build_dataset(val_res, wn_template, include_chlorine=args.include_chlorine)
-        X_test, Y_test = build_dataset(test_res, wn_template, include_chlorine=args.include_chlorine)
+        X_train, Y_train = build_dataset(train_res, wn_template)
+        X_val, Y_val = build_dataset(val_res, wn_template)
+        X_test, Y_test = build_dataset(test_res, wn_template)
 
     edge_index, edge_attr, edge_type, pump_coeffs = build_edge_index(wn_template)
 
@@ -969,8 +912,7 @@ def main() -> None:
     manifest = {
         "num_extreme": int(extreme_count),
         "total_scenarios": len(manifest_records),
-        "include_chlorine": bool(args.include_chlorine),
-        "node_target_dim": 2 if args.include_chlorine else 1,
+        "node_target_dim": 1,
         "scenarios": manifest_records,
     }
     with open(os.path.join(out_dir, "manifest.json"), "w") as f:

--- a/scripts/feature_utils.py
+++ b/scripts/feature_utils.py
@@ -224,9 +224,9 @@ def build_node_type(wn: wntr.network.WaterNetworkModel) -> np.ndarray:
 def build_static_node_features(
     wn: wntr.network.WaterNetworkModel, num_pumps: int
 ) -> torch.Tensor:
-    """Return per-node static features [demand, 0, 0, elevation]."""
+    """Return per-node static features [demand, 0, elevation]."""
     num_nodes = len(wn.node_name_list)
-    feats = torch.zeros(num_nodes, 4 + num_pumps, dtype=torch.float32)
+    feats = torch.zeros(num_nodes, 3 + num_pumps, dtype=torch.float32)
     for idx, name in enumerate(wn.node_name_list):
         node = wn.get_node(name)
         if name in wn.junction_name_list:
@@ -240,14 +240,13 @@ def build_static_node_features(
         else:
             elev = node.head
         feats[idx, 0] = float(demand)
-        feats[idx, 3] = float(elev or 0.0)
+        feats[idx, 2] = float(elev or 0.0)
     return feats
 
 
 def prepare_node_features(
     template: torch.Tensor,
     pressures: torch.Tensor,
-    chlorine: torch.Tensor,
     pump_speeds: torch.Tensor,
     model: torch.nn.Module,
     demands: Optional[torch.Tensor] = None,
@@ -264,8 +263,7 @@ def prepare_node_features(
         if demands is not None:
             feats[:, :, 0] = demands
         feats[:, :, 1] = pressures
-        feats[:, :, 2] = torch.log1p(chlorine / 1000.0)
-        feats[:, :, 4 : 4 + num_pumps] = pump_speeds.view(batch_size, 1, -1).expand(
+        feats[:, :, 3 : 3 + num_pumps] = pump_speeds.view(batch_size, 1, -1).expand(
             batch_size, num_nodes, num_pumps
         )
         in_dim = getattr(getattr(model, "layers", [None])[0], "in_channels", None)
@@ -292,8 +290,7 @@ def prepare_node_features(
     if demands is not None:
         feats[:, 0] = demands
     feats[:, 1] = pressures
-    feats[:, 2] = torch.log1p(chlorine / 1000.0)
-    feats[:, 4 : 4 + num_pumps] = pump_speeds.view(1, -1).expand(num_nodes, num_pumps)
+    feats[:, 3 : 3 + num_pumps] = pump_speeds.view(1, -1).expand(num_nodes, num_pumps)
     in_dim = getattr(getattr(model, "layers", [None])[0], "in_channels", None)
     if in_dim is not None:
         feats = feats[:, :in_dim]

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -1007,7 +1007,7 @@ def compute_mpc_cost(
         clamped = torch.clamp(raw_speed, 0.0, MAX_PUMP_SPEED)
         speed = raw_speed + (clamped - raw_speed).detach()
         x = prepare_node_features(
-            feature_template, cur_p, cur_c, speed, model, d, skip_normalization
+            feature_template, cur_p, speed, model, d, skip_normalization
         )
         if hasattr(model, "rnn"):
             seq_in = x.unsqueeze(0).unsqueeze(0)
@@ -1092,7 +1092,7 @@ def compute_mpc_cost(
             chlorine_penalty = torch.sum(F.softplus(csf) ** 2)
 
         if flows is not None and pump_info is not None:
-            head = pred_p + feature_template[:, 3]
+            head = pred_p + feature_template[:, 2]
             energy_term_j = torch.tensor(0.0, device=device)
             eff = wn.options.energy.global_efficiency / 100.0
             for idx, s_idx, e_idx in pump_info:
@@ -1184,7 +1184,7 @@ def run_mpc_step(
     u_warm : torch.Tensor, optional
         Previous speed sequence to warm start the optimization.
     """
-    num_pumps = feature_template.size(1) - 4
+    num_pumps = feature_template.size(1) - 3
     cost_history: List[float] = []
     start_time = time.time() if profile else None
     pressures = pressures.to(device)
@@ -1404,7 +1404,7 @@ def propagate_with_surrogate(
                 speed_in = speed
             d = demands[t] if demands is not None else None
             x = prepare_node_features(
-                feature_template, cur_p, cur_c, speed_in, model, d, skip_normalization
+                feature_template, cur_p, speed_in, model, d, skip_normalization
             )
             if hasattr(model, "rnn"):
                 seq_in = x.view(batch_size, 1, feature_template.size(0), x.size(-1))

--- a/tests/test_barrier_and_clipping.py
+++ b/tests/test_barrier_and_clipping.py
@@ -16,13 +16,13 @@ def _setup():
     edge_attr = torch.zeros((1, 3))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
-    feature_template = torch.zeros((2, 5))
+    feature_template = torch.zeros((2, 4))
     pressures = torch.zeros(2)
     chlorine = torch.zeros(2)
 
     class DummyModel(torch.nn.Module):
         def forward(self, x, edge_index, edge_attr, node_types, edge_types):
-            node_outputs = torch.zeros((x.size(0), 2))
+            node_outputs = torch.zeros((x.size(0), 1))
             edge_outputs = torch.zeros((1, 1))
             return {'node_outputs': node_outputs, 'edge_outputs': edge_outputs}
 

--- a/tests/test_energy_clamp.py
+++ b/tests/test_energy_clamp.py
@@ -12,14 +12,14 @@ def test_negative_flow_headloss_clamped():
     edge_attr = torch.zeros((1, 3))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
-    feature_template = torch.zeros((2, 5))
-    feature_template[:, 3] = torch.tensor([10.0, 0.0])
+    feature_template = torch.zeros((2, 4))
+    feature_template[:, 2] = torch.tensor([10.0, 0.0])
     pressures = torch.zeros(2)
     chlorine = torch.zeros(2)
 
     class DummyModel(torch.nn.Module):
         def forward(self, x, edge_index, edge_attr, node_types, edge_types):
-            node_outputs = torch.zeros((x.size(0), 2))
+            node_outputs = torch.zeros((x.size(0), 1))
             edge_outputs = torch.tensor([[-5.0]])
             return {'node_outputs': node_outputs, 'edge_outputs': edge_outputs}
 

--- a/tests/test_max_pump_speed.py
+++ b/tests/test_max_pump_speed.py
@@ -15,13 +15,13 @@ def _setup():
     edge_attr = torch.zeros((1, 3))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
-    feature_template = torch.zeros((2, 5))
+    feature_template = torch.zeros((2, 4))
     pressures = torch.zeros(2)
     chlorine = torch.zeros(2)
 
     class DummyModel(torch.nn.Module):
         def forward(self, x, edge_index, edge_attr, node_types, edge_types):
-            node_outputs = torch.zeros((x.size(0), 2))
+            node_outputs = torch.zeros((x.size(0), 1))
             edge_outputs = torch.zeros((1, 1))
             return {"node_outputs": node_outputs, "edge_outputs": edge_outputs}
 

--- a/tests/test_mpc_cost_extra_outputs.py
+++ b/tests/test_mpc_cost_extra_outputs.py
@@ -14,22 +14,17 @@ from scripts.mpc_control import compute_mpc_cost
 class DummyModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.x_mean = torch.zeros(5)
-        self.x_std = torch.ones(5)
-        self.y_mean = torch.zeros(2)
-        self.y_std = torch.ones(2)
+        self.x_mean = torch.zeros(4)
+        self.x_std = torch.ones(4)
+        self.y_mean = torch.zeros(1)
+        self.y_std = torch.ones(1)
 
     def forward(self, x, edge_index, edge_attr=None, node_types=None, edge_types=None):
         n = x.size(0)
-        base = torch.stack(
-            [
-                torch.full((n,), 30.0, device=x.device),
-                torch.full((n,), 1.0, device=x.device),
-            ],
-            dim=1,
-        )
+        base = torch.full((n, 1), 30.0, device=x.device)
+        chlorine = torch.zeros((n, 1), device=x.device)
         extra = torch.full((n, 1), 123.0, device=x.device)
-        return torch.cat([base, extra], dim=1)
+        return torch.cat([base, chlorine, extra], dim=1)
 
 
 def test_compute_mpc_cost_handles_extra_outputs():
@@ -42,7 +37,7 @@ def test_compute_mpc_cost_handles_extra_outputs():
     edge_attr = torch.zeros((0, 0))
     node_types = torch.zeros(1, dtype=torch.long)
     edge_types = torch.zeros(0, dtype=torch.long)
-    template = torch.zeros(1, 5)
+    template = torch.zeros(1, 4)
     pressures = torch.tensor([10.0])
     chlorine = torch.tensor([0.0])
 

--- a/tests/test_mpc_cost_per_node_norm.py
+++ b/tests/test_mpc_cost_per_node_norm.py
@@ -13,16 +13,16 @@ from scripts.mpc_control import compute_mpc_cost
 class DummyModel(torch.nn.Module):
     def __init__(self, num_nodes: int):
         super().__init__()
-        # Five node features (pressure, chlorine, etc.)
-        self.x_mean = torch.zeros(5)
-        self.x_std = torch.ones(5)
-        # Per-node normalisation stats for two outputs
-        self.y_mean = torch.zeros(num_nodes, 2)
-        self.y_std = torch.ones(num_nodes, 2)
+        # Four node features (demand, pressure, elevation, pump)
+        self.x_mean = torch.zeros(4)
+        self.x_std = torch.ones(4)
+        # Per-node normalisation stats for one output
+        self.y_mean = torch.zeros(num_nodes, 1)
+        self.y_std = torch.ones(num_nodes, 1)
 
     def forward(self, x, edge_index, edge_attr=None, node_types=None, edge_types=None):
         # Return zeros in normalised space
-        return torch.zeros(x.size(0), 2, device=x.device)
+        return torch.zeros(x.size(0), 1, device=x.device)
 
 
 def test_compute_mpc_cost_handles_per_node_norm():
@@ -37,7 +37,7 @@ def test_compute_mpc_cost_handles_per_node_norm():
     edge_attr = torch.zeros((0, 0))
     node_types = torch.zeros(num_nodes, dtype=torch.long)
     edge_types = torch.zeros(0, dtype=torch.long)
-    template = torch.zeros(num_nodes, 4 + num_pumps)
+    template = torch.zeros(num_nodes, 3 + num_pumps)
     pressures = torch.full((num_nodes,), 50.0)
     chlorine = torch.zeros(num_nodes)
 

--- a/tests/test_mpc_normalization.py
+++ b/tests/test_mpc_normalization.py
@@ -11,25 +11,22 @@ def test_mpc_normalization_round_trip_and_consistency():
     torch.manual_seed(0)
     num_nodes = 2
     num_pumps = 1
-    template = torch.zeros(num_nodes, 4 + num_pumps)
+    template = torch.zeros(num_nodes, 3 + num_pumps)
     pressures = torch.tensor([1.0, 2.0])
-    chlorine = torch.tensor([10.0, 20.0])
     pump_speed = torch.tensor([0.5])
 
-    conv = GCNConv(5, 2)
+    conv = GCNConv(4, 1)
     model = GNNSurrogate([conv]).eval()
-
-    model.x_mean = torch.randn(5)
-    model.x_std = torch.rand(5) + 0.1
-    model.y_mean = torch.randn(2)
-    model.y_std = torch.rand(2) + 0.1
+    model.x_mean = torch.randn(4)
+    model.x_std = torch.rand(4) + 0.1
+    model.y_mean = torch.randn(1)
+    model.y_std = torch.rand(1) + 0.1
 
     feats = template.clone()
     feats[:, 1] = pressures
-    feats[:, 2] = torch.log1p(chlorine / 1000.0)
-    feats[:, 4] = pump_speed
+    feats[:, 3] = pump_speed
 
-    x_norm = prepare_node_features(template, pressures, chlorine, pump_speed, model)
+    x_norm = prepare_node_features(template, pressures, pump_speed, model)
     x_round = x_norm * (model.x_std + EPS) + model.x_mean
     assert torch.allclose(x_round, feats, atol=1e-6)
 
@@ -48,24 +45,22 @@ def test_prepare_node_features_per_node_batch_norm():
     batch_size = 3
     num_nodes = 2
     num_pumps = 1
-    template = torch.zeros(num_nodes, 4 + num_pumps)
+    template = torch.zeros(num_nodes, 3 + num_pumps)
     pressures = torch.randn(batch_size, num_nodes)
-    chlorine = torch.rand(batch_size, num_nodes)
     pump_speed = torch.rand(batch_size, num_pumps)
 
-    conv = GCNConv(5, 2)
+    conv = GCNConv(4, 1)
     model = GNNSurrogate([conv]).eval()
-    model.x_mean = torch.randn(num_nodes, 5)
-    model.x_std = torch.rand(num_nodes, 5) + 0.1
+    model.x_mean = torch.randn(num_nodes, 4)
+    model.x_std = torch.rand(num_nodes, 4) + 0.1
 
     feats = template.expand(batch_size, num_nodes, template.size(1)).clone()
     feats[:, :, 1] = pressures
-    feats[:, :, 2] = torch.log1p(chlorine / 1000.0)
-    feats[:, :, 4:4 + num_pumps] = pump_speed.view(batch_size, 1, -1).expand(
+    feats[:, :, 3:3 + num_pumps] = pump_speed.view(batch_size, 1, -1).expand(
         batch_size, num_nodes, num_pumps
     )
 
-    x_norm = prepare_node_features(template, pressures, chlorine, pump_speed, model)
+    x_norm = prepare_node_features(template, pressures, pump_speed, model)
     x_manual = (feats - model.x_mean.view(1, num_nodes, -1)) / (
         model.x_std.view(1, num_nodes, -1) + EPS
     )
@@ -77,30 +72,28 @@ def test_prepare_node_features_flattened_stats():
     batch_size = 1
     num_nodes = 2
     num_pumps = 1
-    template = torch.zeros(num_nodes, 4 + num_pumps)
+    template = torch.zeros(num_nodes, 3 + num_pumps)
     pressures = torch.randn(batch_size, num_nodes)
-    chlorine = torch.rand(batch_size, num_nodes)
     pump_speed = torch.rand(batch_size, num_pumps)
 
-    conv = GCNConv(5, 2)
+    conv = GCNConv(4, 1)
     model = GNNSurrogate([conv]).eval()
 
-    mean2d = torch.randn(num_nodes, 5)
-    std2d = torch.rand(num_nodes, 5) + 0.1
+    mean2d = torch.randn(num_nodes, 4)
+    std2d = torch.rand(num_nodes, 4) + 0.1
     model.x_mean = mean2d.flatten()
     model.x_std = std2d.flatten()
 
     feats = template.expand(batch_size, num_nodes, template.size(1)).clone()
     feats[:, :, 1] = pressures
-    feats[:, :, 2] = torch.log1p(chlorine / 1000.0)
-    feats[:, :, 4:4 + num_pumps] = pump_speed.view(batch_size, 1, -1).expand(
+    feats[:, :, 3:3 + num_pumps] = pump_speed.view(batch_size, 1, -1).expand(
         batch_size, num_nodes, num_pumps
     )
     expected = (feats - mean2d.view(1, num_nodes, -1)) / (
         std2d.view(1, num_nodes, -1) + EPS
     )
 
-    x_norm = prepare_node_features(template, pressures, chlorine, pump_speed, model)
+    x_norm = prepare_node_features(template, pressures, pump_speed, model)
     assert torch.allclose(
         x_norm.view(batch_size, num_nodes, -1), expected, atol=1e-6
     )


### PR DESCRIPTION
## Summary
- drop chlorine handling from data generation and metadata, leaving pressure-only targets
- trim static node templates and feature assembly to `[demand, pressure, elevation, pump...]`
- update validation and MPC utilities for the new feature layout

## Testing
- `pip install imageio -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa10aff7848324a85ad3a1b8705778