### PR TITLE
Remove chlorine handling from MPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,8 +372,8 @@ Once the surrogate model is trained you can run gradient-based MPC using
 ```bash
 python scripts/mpc_control.py \
     --horizon 6 --iterations 50 --feedback-interval 24 \
-    --Pmin 20.0 --Cmin 0.2 --energy-scale 1e-9 \
-    --w_p 100 --w_c 100 --w_e 1.0 --bias-correction --bias-window 24 --profile
+    --Pmin 20.0 --energy-scale 1e-9 \
+    --w_p 100 --w_e 1.0 --bias-correction --bias-window 24 --profile
 ```
 
 Pass ``--profile`` to print the runtime of each MPC optimisation step. The
@@ -399,10 +399,8 @@ logged each hour.
 megawatt-hours via ``--energy-scale 1e-9`` before applying the cost.  This keeps
 energy magnitudes comparable to pressure penalties and lets ``w_e`` remain near
 unity while ``w_p`` defaults to 100 so constraint violations dominate.
-``--barrier`` selects how violations are penalised: ``softplus``
-applies a smooth barrier (default), ``exp`` uses an exponential barrier and
-``cubic`` reverts to the previous hinge. Gradients on the control variables are
-clipped to ``[-gmax, gmax]`` with ``--gmax`` to improve numerical robustness.
+Gradients on the control variables are clipped to ``[-gmax, gmax]`` with
+``--gmax`` to improve numerical robustness.
 
 Pump energy usage in the MPC cost function is computed from predicted flows and
 head gains using the EPANET power equations. This removes the need for a

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -1020,10 +1020,8 @@ def main() -> None:
         pump_names,
         device,
         args.Pmin,
-        0.0,
         args.feedback_interval,
         w_p=args.w_p,
-        w_c=0.0,
         w_e=args.w_e,
     )
 

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 import warnings
 import inspect
 from collections import deque
@@ -75,12 +74,11 @@ MAX_PUMP_SPEED = 1.8
 def plot_mpc_time_series(
     df,  # pandas.DataFrame
     Pmin: float,
-    Cmin: float,
     run_name: str,
     plots_dir: Optional[Path] = None,
     return_fig: bool = False,
 ) -> Optional[plt.Figure]:
-    """Time series of minimum pressure/chlorine and pump actions."""
+    """Time series of minimum pressure, energy and pump actions."""
     if plots_dir is None:
         plots_dir = PLOTS_DIR
     plots_dir.mkdir(parents=True, exist_ok=True)
@@ -93,9 +91,8 @@ def plot_mpc_time_series(
     axes[0].set_title("Operational Performance Under MPC Control")
     axes[0].legend()
 
-    axes[1].plot(df["time"], df["min_chlorine"], label="Min Chlorine", color="tab:orange")
-    axes[1].axhline(Cmin, color="red", linestyle="--", label="C_min")
-    axes[1].set_ylabel("Chlorine (mg/L)")
+    axes[1].plot(df["time"], df["energy"], label="Energy", color="tab:orange")
+    axes[1].set_ylabel("Energy (J)")
     axes[1].legend()
 
     controls = np.stack(df["controls"].to_list())
@@ -952,38 +949,30 @@ def compute_mpc_cost(
     edge_types: torch.Tensor,
     feature_template: torch.Tensor,
     pressures: torch.Tensor,
-    chlorine: torch.Tensor,
     horizon: int,
     device: torch.device,
     Pmin: float,
-    Cmin: float,
     demands: Optional[torch.Tensor] = None,
     pump_info: Optional[List[Tuple[int, int, int]]] = None,
     return_energy: bool = False,
     init_tank_levels: Optional[torch.Tensor] = None,
     skip_normalization: bool = False,
     w_p: float = 100.0,
-    w_c: float = 100.0,
     w_e: float = 1.0,
     energy_scale: float = 1e-9,
-    barrier: str = "softplus",
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     """Return the MPC cost for a sequence of pump speeds.
 
-    The cost combines pressure and chlorine constraint violations, pump
+    The cost combines pressure constraint violations, pump
     energy use and a smoothness term on control differences. ``demands`` can be
     used to provide per-node demand values for each step which keeps the
     surrogate inputs consistent with training.  The energy term is scaled by
     ``energy_scale`` which defaults to converting Joules to megawatt-hours
-    (``1e-9``).  ``w_p``, ``w_c`` and ``w_e`` weight the respective cost
+    (``1e-9``).  ``w_p`` and ``w_e`` weight the respective cost
     components. Pressure violations are always penalised with a squared hinge
-    which softly enforces ``Pmin``. ``barrier`` selects how chlorine
-    violations are penalised: ``"softplus"`` (default) applies a smooth
-    softplus barrier, ``"exp"`` uses an exponential barrier and
-    ``"cubic"`` falls back to the previous cubic hinge.
+    which softly enforces ``Pmin``.
     """
     cur_p = pressures.to(device)
-    cur_c = chlorine.to(device)
 
     if hasattr(model, "reset_tank_levels") and hasattr(model, "tank_indices"):
         if init_tank_levels is None:
@@ -1068,28 +1057,14 @@ def compute_mpc_cost(
                     )
         assert not torch.isnan(pred).any(), "NaN prediction"
         pred_p = pred[:, 0]
-        if pred.shape[1] > 1:
-            pred_c = torch.expm1(pred[:, 1]) * 1000.0
-        else:
-            pred_c = torch.zeros_like(pred_p)
 
         # ------------------------------------------------------------------
         # Cost terms
         # ------------------------------------------------------------------
         w_s = 0.01
 
-        Cmin_safe = Cmin + 0.05
-
         psf = torch.relu(Pmin - pred_p)
         pressure_penalty = torch.sum(psf ** 2)
-
-        csf = torch.clamp(Cmin_safe - pred_c, min=0.0)
-        if barrier == "exp":
-            chlorine_penalty = torch.sum(torch.expm1(csf))
-        elif barrier == "cubic":
-            chlorine_penalty = torch.sum(csf ** 3)
-        else:
-            chlorine_penalty = torch.sum(F.softplus(csf) ** 2)
 
         if flows is not None and pump_info is not None:
             head = pred_p + feature_template[:, 2]
@@ -1114,11 +1089,7 @@ def compute_mpc_cost(
 
         energy_term = energy_term_j * energy_scale
 
-        step_cost = (
-            w_p * pressure_penalty
-            + w_c * chlorine_penalty
-            + w_e * energy_term
-        )
+        step_cost = w_p * pressure_penalty + w_e * energy_term
 
         total_cost = total_cost + step_cost
 
@@ -1130,9 +1101,8 @@ def compute_mpc_cost(
             prev_speed = prev_raw + (prev_clamped - prev_raw).detach()
             smoothness_penalty = smoothness_penalty + torch.sum((speed - prev_speed) ** 2)
 
-        # update dictionaries for next step
+        # update pressures for next step
         cur_p = pred_p
-        cur_c = pred_c
 
     total_cost = total_cost + w_s * smoothness_penalty
 
@@ -1150,22 +1120,18 @@ def run_mpc_step(
     edge_types: torch.Tensor,
     feature_template: torch.Tensor,
     pressures: torch.Tensor,
-    chlorine: torch.Tensor,
     horizon: int,
     iterations: int,
     device: torch.device,
     Pmin: float,
-    Cmin: float,
     demands: Optional[torch.Tensor] = None,
     u_warm: Optional[torch.Tensor] = None,
     pump_info: Optional[List[Tuple[int, int, int]]] = None,
     profile: bool = False,
     skip_normalization: bool = False,
     w_p: float = 100.0,
-    w_c: float = 100.0,
     w_e: float = 1.0,
     energy_scale: float = 1e-9,
-    barrier: str = "softplus",
     gmax: float = 1.0,
 ) -> Tuple[torch.Tensor, List[float], float]:
     """Optimize pump speeds for one hour using gradient-based MPC.
@@ -1188,7 +1154,6 @@ def run_mpc_step(
     cost_history: List[float] = []
     start_time = time.time() if profile else None
     pressures = pressures.to(device)
-    chlorine = chlorine.to(device)
     init_levels = None
     if hasattr(model, "reset_tank_levels") and hasattr(model, "tank_indices"):
         init_press = pressures[model.tank_indices].unsqueeze(0)
@@ -1226,21 +1191,17 @@ def run_mpc_step(
             edge_types,
             feature_template,
             pressures,
-            chlorine,
             horizon,
             device,
             Pmin,
-            Cmin,
             demands,
             pump_info,
             False,
             init_levels,
             skip_normalization,
             w_p,
-            w_c,
             w_e,
             energy_scale,
-            barrier,
         )
         cost.backward()
         if gmax is not None:
@@ -1267,21 +1228,17 @@ def run_mpc_step(
             edge_types,
             feature_template,
             pressures,
-            chlorine,
             horizon,
             device,
             Pmin,
-            Cmin,
             demands,
             pump_info,
             False,
             init_levels,
             skip_normalization,
             w_p,
-            w_c,
             w_e,
             energy_scale,
-            barrier,
         )
         c.backward()
         if gmax is not None:
@@ -1300,21 +1257,17 @@ def run_mpc_step(
         edge_types,
         feature_template,
         pressures,
-        chlorine,
         1,
         device,
         Pmin,
-        Cmin,
         demands[:1] if demands is not None else None,
         pump_info,
         True,
         init_levels,
         skip_normalization,
         w_p,
-        w_c,
         w_e,
         energy_scale,
-        barrier,
     )
     with torch.no_grad():
         pump_speeds.copy_(pump_speeds.clamp(0.0, MAX_PUMP_SPEED))
@@ -1338,23 +1291,20 @@ def propagate_with_surrogate(
     edge_types: torch.Tensor,
     feature_template: torch.Tensor,
     pressures: Dict[str, float],
-    chlorine: Dict[str, float],
     speed_seq: torch.Tensor,
     device: torch.device,
     demands: Optional[torch.Tensor] = None,
     skip_normalization: bool = False,
-) -> Tuple[Dict[str, float], Dict[str, float]]:
+) -> Dict[str, float]:
     """Propagate the network state using the surrogate model.
 
-    The current state ``pressures``/``chlorine`` is advanced through the
-    sequence of pump speeds ``speed_seq`` without running EPANET.  The
-    function returns dictionaries for the next pressures and chlorine levels
-    after applying the entire sequence.  ``pressures`` and ``chlorine`` can be
-    either dictionaries for a single scenario or lists of dictionaries for
-    batched evaluation:
+    The current state ``pressures`` is advanced through the
+    sequence of pump speeds ``speed_seq`` without running EPANET. The
+    function returns a dictionary for the next pressures after applying the
+    entire sequence. ``pressures`` can be either a dictionary for a single
+    scenario or a list of dictionaries for batched evaluation:
 
     ``pressures = [dict(...), dict(...)]``
-    ``chlorine = [dict(...), dict(...)]``
     """
 
     if edge_attr is not None and getattr(model, "edge_mean", None) is not None and not skip_normalization:
@@ -1363,7 +1313,6 @@ def propagate_with_surrogate(
     single = isinstance(pressures, dict)
     if single:
         cur_p = torch.tensor([pressures[n] for n in wn.node_name_list], device=device)
-        cur_c = torch.tensor([chlorine[n] for n in wn.node_name_list], device=device)
         b_edge_index = edge_index
         b_edge_attr = edge_attr
         b_node_type = node_types
@@ -1374,10 +1323,6 @@ def propagate_with_surrogate(
         cur_p = torch.stack([
             torch.tensor([p[n] for n in wn.node_name_list], device=device)
             for p in pressures
-        ])
-        cur_c = torch.stack([
-            torch.tensor([c[n] for n in wn.node_name_list], device=device)
-            for c in chlorine
         ])
         num_nodes = feature_template.size(0)
         E = edge_index.size(1)
@@ -1436,19 +1381,14 @@ def propagate_with_surrogate(
                         pred = pred * (y_std + EPS) + y_mean
             assert not torch.isnan(pred).any(), "NaN prediction"
             cur_p = pred[:, :, 0]
-            cur_c = torch.expm1(pred[:, :, 1]) * 1000.0
 
     if single:
-        out_p = {n: float(cur_p[0, i]) for i, n in enumerate(wn.node_name_list)}
-        out_c = {n: float(cur_c[0, i]) for i, n in enumerate(wn.node_name_list)}
-        return out_p, out_c
+        return {n: float(cur_p[0, i]) for i, n in enumerate(wn.node_name_list)}
 
     out_ps = []
-    out_cs = []
     for b in range(batch_size):
         out_ps.append({n: float(cur_p[b, i]) for i, n in enumerate(wn.node_name_list)})
-        out_cs.append({n: float(cur_c[b, i]) for i, n in enumerate(wn.node_name_list)})
-    return out_ps, out_cs
+    return out_ps
 
 
 class PressureBiasCorrector:
@@ -1490,16 +1430,13 @@ def simulate_closed_loop(
     pump_names: List[str],
     device: torch.device,
     Pmin: float,
-    Cmin: float,
     feedback_interval: int = 1,
     run_name: str = "",
     profile: bool = False,
     skip_normalization: bool = False,
     w_p: float = 100.0,
-    w_c: float = 100.0,
     w_e: float = 1.0,
     energy_scale: float = 1e-9,
-    barrier: str = "softplus",
     gmax: float = 1.0,
     bias_correction: bool = False,
     bias_window: int = 1,
@@ -1507,8 +1444,8 @@ def simulate_closed_loop(
     """Run 24-hour closed-loop MPC using the surrogate for fast updates.
 
     EPANET is invoked only every ``feedback_interval`` hours (default once per
-    hour) to obtain ground-truth measurements.  All intermediate steps update
-    the pressures and chlorine levels using the GNN surrogate which allows the
+    hour) to obtain ground-truth measurements. All intermediate steps update
+    the pressures using the GNN surrogate which allows the
     loop to run nearly instantly.
     """
     if feedback_interval > 1:
@@ -1533,7 +1470,6 @@ def simulate_closed_loop(
 
     log = []
     pressure_violations = 0
-    chlorine_violations = 0
     total_energy = 0.0
     pump_info = []
     node_idx = node_to_index
@@ -1554,9 +1490,7 @@ def simulate_closed_loop(
     sim = wntr.sim.EpanetSimulator(wn)
     results = sim.run_sim(str(TEMP_DIR / "temp"))
     p_arr = results.node["pressure"].iloc[0].to_numpy(dtype=np.float32)
-    c_arr = results.node["quality"].iloc[0].to_numpy(dtype=np.float32)
     pressures = dict(zip(wn.node_name_list, p_arr))
-    chlorine = dict(zip(wn.node_name_list, c_arr))
     for res_name in wn.reservoir_name_list:
         idx = node_idx[res_name]
         head = wn.get_node(res_name).base_head
@@ -1568,11 +1502,6 @@ def simulate_closed_loop(
         .pin_memory() if torch.cuda.is_available() else torch.from_numpy(p_arr)
     )
     cur_p = cur_p.to(device, non_blocking=True)
-    cur_c = (
-        torch.from_numpy(c_arr)
-        .pin_memory() if torch.cuda.is_available() else torch.from_numpy(c_arr)
-    )
-    cur_c = cur_c.to(device, non_blocking=True)
 
     if hasattr(model, "reset_tank_levels") and hasattr(model, "tank_indices"):
         init_press = cur_p[model.tank_indices].unsqueeze(0)
@@ -1600,22 +1529,18 @@ def simulate_closed_loop(
             edge_types,
             feature_template,
             cur_p,
-            cur_c,
             horizon,
             iterations,
             device,
             Pmin,
-            Cmin,
             demands,
             prev_speed,
             pump_info,
             profile,
             skip_normalization,
             w_p,
-            w_c,
             w_e,
             energy_scale,
-            barrier,
             gmax,
         )
         all_costs.extend(costs)
@@ -1646,7 +1571,7 @@ def simulate_closed_loop(
         if feedback_interval > 0 and hour % feedback_interval == 0:
             pred_pressures = None
             if bias_corrector is not None:
-                pred_pressures, _ = propagate_with_surrogate(
+                pred_pressures = propagate_with_surrogate(
                     wn,
                     model,
                     edge_index,
@@ -1655,7 +1580,6 @@ def simulate_closed_loop(
                     edge_types,
                     feature_template,
                     pressures,
-                    chlorine,
                     speed_opt,
                     device,
                     demands,
@@ -1669,9 +1593,7 @@ def simulate_closed_loop(
             sim = wntr.sim.EpanetSimulator(wn)
             results = sim.run_sim(str(TEMP_DIR / "temp"))
             p_arr = results.node["pressure"].iloc[-1].to_numpy(dtype=np.float32)
-            c_arr = results.node["quality"].iloc[-1].to_numpy(dtype=np.float32)
             pressures = dict(zip(wn.node_name_list, p_arr))
-            chlorine = dict(zip(wn.node_name_list, c_arr))
             for res_name in wn.reservoir_name_list:
                 idx = node_idx[res_name]
                 head = wn.get_node(res_name).base_head
@@ -1687,11 +1609,6 @@ def simulate_closed_loop(
                 .pin_memory() if torch.cuda.is_available() else torch.from_numpy(p_arr)
             )
             cur_p = cur_p.to(device, non_blocking=True)
-            cur_c = (
-                torch.from_numpy(c_arr)
-                .pin_memory() if torch.cuda.is_available() else torch.from_numpy(c_arr)
-            )
-            cur_c = cur_c.to(device, non_blocking=True)
             energy_df = pump_energy(
                 results.link["flowrate"][pump_names], results.node["head"], wn
             )
@@ -1700,7 +1617,7 @@ def simulate_closed_loop(
             end = time.time()
         else:
             # Fast surrogate-based propagation
-            pressures, chlorine = propagate_with_surrogate(
+            pressures = propagate_with_surrogate(
                 wn,
                 model,
                 edge_index,
@@ -1709,7 +1626,6 @@ def simulate_closed_loop(
                 edge_types,
                 feature_template,
                 pressures,
-                chlorine,
                 speed_opt,
                 device,
                 demands,
@@ -1718,7 +1634,6 @@ def simulate_closed_loop(
             if bias_corrector is not None:
                 pressures = bias_corrector.apply(pressures, node_idx)
             cur_p = torch.tensor([pressures[n] for n in wn.node_name_list], dtype=torch.float32, device=device)
-            cur_c = torch.tensor([chlorine[n] for n in wn.node_name_list], dtype=torch.float32, device=device)
             end = time.time()
             energy = energy_first
         bias_min = bias_max = 0.0
@@ -1727,17 +1642,13 @@ def simulate_closed_loop(
             bias_min = float(b_abs.min())
             bias_max = float(b_abs.max())
         min_p = max(min(pressures[n] for n in wn.junction_name_list), 0.0)
-        min_c = max(min(chlorine[n] for n in wn.junction_name_list), 0.0)
         if min_p < Pmin:
             pressure_violations += 1
-        if min_c < Cmin:
-            chlorine_violations += 1
         total_energy += energy
         log.append(
             {
                 "time": hour,
                 "min_pressure": min_p,
-                "min_chlorine": min_c,
                 "energy": energy,
                 "runtime_sec": end - start,
                 "controls": first_speeds.cpu().numpy().tolist(),
@@ -1745,7 +1656,6 @@ def simulate_closed_loop(
                 "bias_max": bias_max,
                 # Store full network state for optional animations
                 "pressures": dict(pressures),
-                "chlorine": dict(chlorine),
             }
         )
         if run_name:
@@ -1758,29 +1668,23 @@ def simulate_closed_loop(
             except Exception as exc:
                 warnings.warn(f"plot_network_state_epyt failed: {exc}")
         print(
-            f"Hour {hour}: minP={min_p:.2f}, minC={min_c:.3f}, energy={energy:.2f}, runtime={end-start:.2f}s, bias=[{bias_min:.3f},{bias_max:.3f}]"
+            f"Hour {hour}: minP={min_p:.2f}, energy={energy:.2f}, runtime={end-start:.2f}s, bias=[{bias_min:.3f},{bias_max:.3f}]"
         )
     df = pd.DataFrame(log)
     os.makedirs(DATA_DIR, exist_ok=True)
     df.to_csv(os.path.join(DATA_DIR, "mpc_history.csv"), index=False)
     summary = {
         "pressure_violations": pressure_violations,
-        "chlorine_violations": chlorine_violations,
         "total_energy": float(total_energy),
         "hours": len(log),
     }
-    print(
-        f"[MPC Summary] Pressure violations: {pressure_violations}/{len(log)}h"
-    )
-    print(
-        f"[MPC Summary] Chlorine violations: {chlorine_violations}/{len(log)}h"
-    )
+    print(f"[MPC Summary] Pressure violations: {pressure_violations}/{len(log)}h")
     print(f"[MPC Summary] Total pump energy used: {total_energy:.2f} J")
     os.makedirs(REPO_ROOT / "logs", exist_ok=True)
     with open(REPO_ROOT / "logs" / "mpc_summary.json", "w") as f:
         json.dump(summary, f, indent=2)
     if run_name:
-        plot_mpc_time_series(df, Pmin, Cmin, run_name)
+        plot_mpc_time_series(df, Pmin, run_name)
         plot_convergence_curve(all_costs, run_name)
     return df
 
@@ -1792,7 +1696,6 @@ def main():
         "--iterations", type=int, default=50, help="Gradient descent iterations"
     )
     parser.add_argument("--Pmin", type=float, default=20.0, help="Pressure threshold")
-    parser.add_argument("--Cmin", type=float, default=0.2, help="Chlorine threshold")
     parser.add_argument(
         "--feedback-interval",
         type=int,
@@ -1821,14 +1724,7 @@ def main():
         help="Scale factor applied to pump energy (e.g., 1e-9 converts J to MWh)",
     )
     parser.add_argument("--w_p", type=float, default=100.0, help="Weight on pressure violations")
-    parser.add_argument("--w_c", type=float, default=100.0, help="Weight on chlorine violations")
     parser.add_argument("--w_e", type=float, default=1.0, help="Weight on energy usage")
-    parser.add_argument(
-        "--barrier",
-        choices=["softplus", "exp", "cubic"],
-        default="softplus",
-        help="Penalty type for chlorine violations (pressure uses squared hinge)",
-    )
     parser.add_argument(
         "--gmax",
         type=float,
@@ -1913,16 +1809,13 @@ def main():
         pump_names,
         device,
         args.Pmin,
-        args.Cmin,
         args.feedback_interval,
         run_name,
         args.profile,
         args.skip_normalization,
         args.w_p,
-        args.w_c,
         args.w_e,
         args.energy_scale,
-        args.barrier,
         args.gmax,
         args.bias_correction,
         args.bias_window,

--- a/tests/test_barrier_and_clipping.py
+++ b/tests/test_barrier_and_clipping.py
@@ -18,7 +18,6 @@ def _setup():
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 4))
     pressures = torch.zeros(2)
-    chlorine = torch.zeros(2)
 
     class DummyModel(torch.nn.Module):
         def forward(self, x, edge_index, edge_attr, node_types, edge_types):
@@ -36,11 +35,10 @@ def _setup():
         edge_types,
         feature_template,
         pressures,
-        chlorine,
     )
 
 
-def test_barrier_variants_and_ste_gradient():
+def test_ste_gradient():
     (
         wn,
         speeds,
@@ -51,7 +49,6 @@ def test_barrier_variants_and_ste_gradient():
         edge_types,
         feature_template,
         pressures,
-        chlorine,
     ) = _setup()
     cost, _ = compute_mpc_cost(
         speeds,
@@ -63,40 +60,17 @@ def test_barrier_variants_and_ste_gradient():
         edge_types,
         feature_template,
         pressures,
-        chlorine,
         horizon=1,
         device=torch.device('cpu'),
         Pmin=1.0,
-        Cmin=0.1,
-        barrier='softplus',
     )
     cost.backward()
     assert torch.isfinite(cost)
     assert speeds.grad.abs().max() > 0  # STE keeps gradient
-    speeds.grad.zero_()
-    cost_exp, _ = compute_mpc_cost(
-        speeds,
-        wn,
-        model,
-        edge_index,
-        edge_attr,
-        node_types,
-        edge_types,
-        feature_template,
-        pressures,
-        chlorine,
-        horizon=1,
-        device=torch.device('cpu'),
-        Pmin=1.0,
-        Cmin=0.1,
-        barrier='exp',
-    )
-    cost_exp.backward()
-    assert torch.isfinite(cost_exp)
 
 
 def test_gradient_clipping_stub():
-    wn, speeds, model, edge_index, edge_attr, node_types, edge_types, template, pressures, chlorine = _setup()
+    wn, speeds, model, edge_index, edge_attr, node_types, edge_types, template, pressures = _setup()
     cost, _ = compute_mpc_cost(
         speeds,
         wn,
@@ -107,11 +81,9 @@ def test_gradient_clipping_stub():
         edge_types,
         template,
         pressures,
-        chlorine,
         horizon=1,
         device=torch.device('cpu'),
         Pmin=1.0,
-        Cmin=0.1,
     )
     cost.backward()
     speeds.grad.fill_(1.0)

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,7 +1,4 @@
 def test_min_clip():
     pressures = {'A': -1e-6, 'B': 10.0}
-    chlorine = {'A': -0.5, 'B': 0.3}
     min_p = max(min(pressures.values()), 0.0)
-    min_c = max(min(chlorine.values()), 0.0)
     assert min_p >= 0
-    assert min_c >= 0

--- a/tests/test_energy_clamp.py
+++ b/tests/test_energy_clamp.py
@@ -15,7 +15,6 @@ def test_negative_flow_headloss_clamped():
     feature_template = torch.zeros((2, 4))
     feature_template[:, 2] = torch.tensor([10.0, 0.0])
     pressures = torch.zeros(2)
-    chlorine = torch.zeros(2)
 
     class DummyModel(torch.nn.Module):
         def forward(self, x, edge_index, edge_attr, node_types, edge_types):
@@ -37,11 +36,9 @@ def test_negative_flow_headloss_clamped():
             edge_types,
             feature_template,
             pressures,
-            chlorine,
             horizon=1,
             device=torch.device('cpu'),
             Pmin=0.0,
-            Cmin=0.0,
             pump_info=pump_info,
             return_energy=True,
         )

--- a/tests/test_max_pump_speed.py
+++ b/tests/test_max_pump_speed.py
@@ -17,7 +17,6 @@ def _setup():
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 4))
     pressures = torch.zeros(2)
-    chlorine = torch.zeros(2)
 
     class DummyModel(torch.nn.Module):
         def forward(self, x, edge_index, edge_attr, node_types, edge_types):
@@ -34,7 +33,6 @@ def _setup():
         edge_types,
         feature_template,
         pressures,
-        chlorine,
     )
 
 
@@ -48,7 +46,6 @@ def test_run_mpc_step_respects_max_speed():
         edge_types,
         template,
         pressures,
-        chlorine,
     ) = _setup()
     device = torch.device("cpu")
     u_warm = torch.full((1, 1), MAX_PUMP_SPEED + 0.5)
@@ -61,12 +58,10 @@ def test_run_mpc_step_respects_max_speed():
         edge_types,
         template,
         pressures,
-        chlorine,
         horizon=1,
         iterations=1,
         device=device,
         Pmin=1.0,
-        Cmin=0.1,
         u_warm=u_warm,
     )
 

--- a/tests/test_mpc_cost_extra_outputs.py
+++ b/tests/test_mpc_cost_extra_outputs.py
@@ -22,9 +22,8 @@ class DummyModel(torch.nn.Module):
     def forward(self, x, edge_index, edge_attr=None, node_types=None, edge_types=None):
         n = x.size(0)
         base = torch.full((n, 1), 30.0, device=x.device)
-        chlorine = torch.zeros((n, 1), device=x.device)
         extra = torch.full((n, 1), 123.0, device=x.device)
-        return torch.cat([base, chlorine, extra], dim=1)
+        return torch.cat([base, extra], dim=1)
 
 
 def test_compute_mpc_cost_handles_extra_outputs():
@@ -39,7 +38,6 @@ def test_compute_mpc_cost_handles_extra_outputs():
     edge_types = torch.zeros(0, dtype=torch.long)
     template = torch.zeros(1, 4)
     pressures = torch.tensor([10.0])
-    chlorine = torch.tensor([0.0])
 
     cost, _ = compute_mpc_cost(
         pump_speeds,
@@ -51,11 +49,9 @@ def test_compute_mpc_cost_handles_extra_outputs():
         edge_types,
         template,
         pressures,
-        chlorine,
         horizon=1,
         device=device,
         Pmin=5.0,
-        Cmin=0.0,
         skip_normalization=True,
     )
     assert torch.isfinite(cost)

--- a/tests/test_mpc_cost_per_node_norm.py
+++ b/tests/test_mpc_cost_per_node_norm.py
@@ -39,7 +39,6 @@ def test_compute_mpc_cost_handles_per_node_norm():
     edge_types = torch.zeros(0, dtype=torch.long)
     template = torch.zeros(num_nodes, 3 + num_pumps)
     pressures = torch.full((num_nodes,), 50.0)
-    chlorine = torch.zeros(num_nodes)
 
     cost, _ = compute_mpc_cost(
         pump_speeds,
@@ -51,11 +50,9 @@ def test_compute_mpc_cost_handles_per_node_norm():
         edge_types,
         template,
         pressures,
-        chlorine,
         horizon=1,
         device=device,
         Pmin=20.0,
-        Cmin=0.2,
     )
 
     assert torch.isfinite(cost)

--- a/tests/test_mpc_input_check.py
+++ b/tests/test_mpc_input_check.py
@@ -49,7 +49,6 @@ def test_simulate_closed_loop_requires_pump_inputs():
             pump_names=pump_names,
             device=device,
             Pmin=20.0,
-            Cmin=0.2,
             feedback_interval=0,
         )
 
@@ -92,6 +91,5 @@ def test_simulate_closed_loop_checks_edge_dim():
             pump_names=pump_names,
             device=device,
             Pmin=20.0,
-            Cmin=0.2,
             feedback_interval=0,
         )

--- a/tests/test_per_node_pressure_denorm.py
+++ b/tests/test_per_node_pressure_denorm.py
@@ -9,7 +9,7 @@ from scripts.train_gnn import evaluate_sequence
 class DummyModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        # two nodes with per-node pressure/chlorine stats
+        # two nodes with per-node pressure stats
         self.y_mean = {
             "node_outputs": torch.tensor([[1.0, 0.0], [2.0, 0.0]], dtype=torch.float32),
             "edge_outputs": torch.zeros(2, dtype=torch.float32),


### PR DESCRIPTION
## Summary
- drop chlorine penalties and parameters from MPC cost and surrogate propagation
- report only pressure and energy in MPC plots and logs
- simplify CLI and docs to remove chlorine-related options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa35a1806c8324990d9da8df2f35af