### PR TITLE
Disable water quality simulation in MPC controller

### DIFF
--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -242,9 +242,8 @@ def load_network(
         simulation.
     """
     wn = wntr.network.WaterNetworkModel(inp_file)
-    wn.options.quality.parameter = "CHEMICAL"
+    wn.options.quality.parameter = "NONE"
     wn.options.time.hydraulic_timestep = 3600
-    wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
 
     node_to_index = {n: i for i, n in enumerate(wn.node_name_list)}


### PR DESCRIPTION
## Summary
- Disable water-quality simulation by setting `wn.options.quality.parameter` to `"NONE"`
- Remove unused `quality_timestep` option

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa3dbbf2dc8324a5b7a553346f559d