### PR TITLE
Remove water quality parameter assignment

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -122,7 +122,8 @@ def _build_randomized_network(
     wn.options.time.duration = 24 * 3600
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.report_timestep = 3600
-    wn.options.quality.parameter = "NONE"
+    # Water quality is not modeled; leave defaults untouched
+    # wn.options.quality.parameter = "NONE"
 
     # Randomize initial tank levels uniformly across the provided range
     for tname in wn.tank_name_list:


### PR DESCRIPTION
## Summary
- avoid setting water quality parameter in data generation
- leave wntr defaults since water quality features are unused

## Testing
- `pytest` *(fails: No module named 'imageio')*
- `python scripts/data_generation.py --num-scenarios 1 --output-dir data/test`


------
https://chatgpt.com/codex/tasks/task_e_68aa40d8c0fc83249b01c4e9ff3a6123