### PR TITLE
Remove unused quality parameter from network loader

### DIFF
--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -242,7 +242,6 @@ def load_network(
         simulation.
     """
     wn = wntr.network.WaterNetworkModel(inp_file)
-    wn.options.quality.parameter = "NONE"
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.report_timestep = 3600
 


### PR DESCRIPTION
## Summary
- drop explicit `wn.options.quality.parameter` assignment when loading networks

## Testing
- `python - <<'PY'
from scripts.mpc_control import load_network
wn, node_to_index, pump_names, edge_index, node_types, edge_types = load_network('CTown.inp')
print('n_nodes', len(wn.node_name_list), 'n_pumps', len(pump_names), 'edge_index', tuple(edge_index.shape))
PY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa40dd78188324999c52e82f63f65e