### PR TITLE
Add forecast uncertainty visualization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
   - `train_gnn.py` – train a graph neural network surrogate on generated data. Pass `--checkpoint` to enable gradient checkpointing when GPU memory is limited.
   - `sweep_training.py` – run hyperparameter sweeps over loss weights and architecture.
   - `plot_sweep.py` – visualise pressure MAE across sweep configurations.
+  - `forecast_uncertainty.py` – compute hourly forecast errors and plot forecast vs actual demand with confidence intervals.
   - `reproducibility.py` – helper utilities for seeding and config logging.
 - `notebooks/` – quickstart notebooks visualising common analyses.
   - `00_validate_surrogate_rollout.ipynb` – compare 1-step and multi-step surrogate errors.

--- a/README.md
+++ b/README.md
@@ -477,6 +477,22 @@ energy–pressure trade-off charts and convergence curves.  All images are
 written to the `plots/` directory so they can be included in reports or
 presentations easily.
 
+For demand forecasts the helper `scripts/forecast_uncertainty.py` computes
+hourly forecast errors and 95% confidence intervals.  It overlays the mean
+forecast and actual demand with shaded error bands and saves the figure to
+`figures/forecast_uncertainty.png` by default:
+
+```python
+from scripts.forecast_uncertainty import plot_forecast_uncertainty
+import pandas as pd
+
+# 48 hourly samples covering two days
+timestamps = pd.date_range("2021-01-01", periods=len(actual), freq="H")
+plot_forecast_uncertainty(actual, forecast, timestamps)
+```
+
+The plot helps visualize how forecast accuracy varies throughout the day.
+
 ## Hyperparameter sweep
 
 Use `scripts/sweep_training.py` to evaluate different loss weights and model

--- a/scripts/forecast_uncertainty.py
+++ b/scripts/forecast_uncertainty.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+from typing import Sequence, Union
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIGURES_DIR = REPO_ROOT / "figures"
+
+
+def plot_forecast_uncertainty(
+    actual: Sequence[float],
+    forecast: Sequence[float],
+    timestamps: Sequence[Union[str, pd.Timestamp]],
+    output_path: Union[str, Path, None] = None,
+) -> pd.DataFrame:
+    """Plot forecast vs. actual demand with hourly error bands.
+
+    Parameters
+    ----------
+    actual, forecast : sequence of floats
+        Actual and forecast demand values.
+    timestamps : sequence of datetime-like
+        Timestamps corresponding to each demand observation.
+    output_path : str or Path, optional
+        Where to save the plot. Defaults to
+        ``figures/forecast_uncertainty.png`` relative to the repository root.
+
+    Returns
+    -------
+    pd.DataFrame
+        Hourly statistics with columns ``actual``, ``forecast``, ``error`` and
+        ``error_ci``.
+    """
+    ts = pd.to_datetime(timestamps)
+    df = pd.DataFrame({"actual": actual, "forecast": forecast}, index=ts)
+    df["hour"] = df.index.hour
+
+    def _stats(group: pd.DataFrame) -> pd.Series:
+        err = group["forecast"] - group["actual"]
+        mean_err = err.mean()
+        std_err = err.std(ddof=1)
+        n = len(err)
+        ci = 1.96 * std_err / np.sqrt(n) if n > 0 else 0.0
+        return pd.Series(
+            {
+                "actual": group["actual"].mean(),
+                "forecast": group["forecast"].mean(),
+                "error": mean_err,
+                "error_ci": ci,
+            }
+        )
+
+    stats = df.groupby("hour").apply(_stats)
+    hours = stats.index.to_numpy()
+
+    plt.figure(figsize=(8, 4))
+    plt.plot(hours, stats["actual"], label="Actual")
+    plt.plot(hours, stats["forecast"], label="Forecast")
+    plt.fill_between(
+        hours,
+        stats["forecast"] - stats["error_ci"],
+        stats["forecast"] + stats["error_ci"],
+        color="gray",
+        alpha=0.3,
+        label="95% CI",
+    )
+    plt.xlabel("Hour of Day")
+    plt.ylabel("Demand")
+    plt.legend()
+    plt.tight_layout()
+
+    if output_path is None:
+        output_path = FIGURES_DIR / "forecast_uncertainty.png"
+    else:
+        output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(output_path)
+    plt.close()
+
+    return stats

--- a/tests/test_forecast_uncertainty.py
+++ b/tests/test_forecast_uncertainty.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import numpy as np
+import pandas as pd
+
+from scripts.forecast_uncertainty import plot_forecast_uncertainty
+
+
+def test_plot_forecast_uncertainty(tmp_path: Path):
+    ts = pd.date_range("2021-01-01", periods=48, freq="H")
+    actual = np.tile(np.arange(24), 2)
+    forecast = actual + np.tile([1, -1], 24)
+    output = tmp_path / "fu.png"
+    stats = plot_forecast_uncertainty(actual, forecast, ts, output)
+    assert output.exists()
+    assert "error_ci" in stats.columns


### PR DESCRIPTION
## Summary
- add `plot_forecast_uncertainty` to compute hourly forecast errors with 95% confidence bands
- document forecast uncertainty plotting and usage
- test generation of forecast uncertainty plot

## Testing
- `PYTHONPATH=. pytest tests/test_forecast_uncertainty.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa4653ea948324b4c691063e8267f5