### PR TITLE
Normalize demand scaling and expose range

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ looks like:
 ```bash
 python scripts/data_generation.py \
     --num-scenarios 2000 --output-dir data/ --seed 42 \
-    --extreme-rate 0.03 --pump-outage-rate 0.1 --local-surge-rate 0.1
+    --extreme-rate 0.03 --pump-outage-rate 0.1 --local-surge-rate 0.1 \
+    --demand-scale-range 0.8 1.2
 ```
 Append `--deterministic` to enforce deterministic CUDA kernels.
 The generation step writes ``edge_index.npy``, ``edge_attr.npy``, ``edge_type.npy`` and
@@ -257,6 +258,10 @@ when ``tqdm`` is installed.
 If a particular random configuration causes EPANET to fail to produce results,
 the script now skips it after a few retries so the actual number of generated
 scenarios may be slightly smaller than requested.
+
+Use ``--demand-scale-range MIN MAX`` to adjust the spread of hourly demand
+multipliers. The default ``0.8 1.2`` keeps demands centered around their
+original values while introducing modest variability.
 
 ``--pump-outage-rate`` randomly shuts off one pump for 2–4 hours while
 ``--local-surge-rate`` applies ±80% demand changes to a small subnetwork for a

--- a/tests/test_demand_scaling.py
+++ b/tests/test_demand_scaling.py
@@ -27,7 +27,7 @@ def test_demand_multiplier_range():
 
     for jname, scaled in scale_dict.items():
         base_mult = base_patterns[jname][: len(scaled)]
-        ratio = scaled / base_mult
+        ratio = scaled * base_mult.mean() / base_mult
         assert np.all(ratio >= 0.8)
         assert np.all(ratio <= 1.2)
 


### PR DESCRIPTION
## Summary
- normalize base demand patterns and clip scaled multipliers to non-negative values
- allow `--demand-scale-range` to tune variability of randomized demands
- update demand scaling test to account for normalized base patterns

## Testing
- `python scripts/data_generation.py --num-scenarios 2 --seed 0 --output-dir data/test_small --demand-scale-range 0.8 1.2`
- `python - <<'PY'
import numpy as np
import scripts.data_generation as dg
results = dg.run_scenarios('CTown.inp', 1, seed=0, num_workers=1)
demand_mults = []
for _, scale_dict, _ in results:
    for arr in scale_dict.values():
        demand_mults.extend(arr.ravel())
print('mean', np.mean(demand_mults))
print('min', np.min(demand_mults), 'max', np.max(demand_mults))
PY`
- `pip install imageio`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa4a214c6c83249e97826bd307e21b