### PR TITLE
Add option to disable demand scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ scenarios may be slightly smaller than requested.
 
 Use ``--demand-scale-range MIN MAX`` to adjust the spread of hourly demand
 multipliers. The default ``0.8 1.2`` keeps demands centered around their
-original values while introducing modest variability.
+original values while introducing modest variability. Pass ``--no-demand-scaling``
+to disable random demand multipliers altogether (equivalent to ``--demand-scale-range 1 1``).
 
 ``--pump-outage-rate`` randomly shuts off one pump for 2–4 hours while
 ``--local-surge-rate`` applies ±80% demand changes to a small subnetwork for a

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -804,6 +804,11 @@ def main() -> None:
         help="Uniform range for randomized demand scaling multipliers",
     )
     parser.add_argument(
+        "--no-demand-scaling",
+        action="store_true",
+        help="Disable randomized demand scaling and use base demands",
+    )
+    parser.add_argument(
         "--output-dir",
         default=DATA_DIR,
         help="Directory to store generated datasets",
@@ -826,6 +831,9 @@ def main() -> None:
         help="Display a progress bar during scenario simulation",
     )
     args = parser.parse_args()
+
+    if args.no_demand_scaling:
+        args.demand_scale_range = (1.0, 1.0)
 
     if args.seed is not None:
         configure_seeds(args.seed, args.deterministic)

--- a/tests/test_demand_scaling.py
+++ b/tests/test_demand_scaling.py
@@ -5,7 +5,7 @@ import numpy as np
 import wntr
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from scripts.data_generation import _build_randomized_network
+import scripts.data_generation as dg
 
 
 def test_demand_multiplier_range():
@@ -23,11 +23,52 @@ def test_demand_multiplier_range():
 
     random.seed(42)
     np.random.seed(42)
-    _, scale_dict, _ = _build_randomized_network(str(inp), idx=0)
+    _, scale_dict, _ = dg._build_randomized_network(str(inp), idx=0)
 
     for jname, scaled in scale_dict.items():
         base_mult = base_patterns[jname][: len(scaled)]
         ratio = scaled * base_mult.mean() / base_mult
         assert np.all(ratio >= 0.8)
         assert np.all(ratio <= 1.2)
+
+
+def test_no_demand_scaling_arg(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run_scenarios(*args, **kwargs):
+        captured["demand_scale_range"] = kwargs["demand_scale_range"]
+        return []
+
+    monkeypatch.setattr(dg, "run_scenarios", fake_run_scenarios)
+    monkeypatch.setattr(dg, "plot_dataset_distributions", lambda *a, **k: None)
+    monkeypatch.setattr(dg, "plot_pressure_histogram", lambda *a, **k: None)
+    monkeypatch.setattr(dg, "split_results", lambda *a, **k: ([], [], []))
+    monkeypatch.setattr(
+        dg,
+        "build_dataset",
+        lambda *a, **k: (np.zeros((1, 1, 1)), np.zeros((1, 1, 1))),
+    )
+    monkeypatch.setattr(
+        dg,
+        "build_edge_index",
+        lambda wn: (
+            np.zeros((2, 0), dtype=np.int64),
+            np.zeros((0,)),
+            np.zeros((0,)),
+            np.zeros((0,)),
+        ),
+    )
+
+    argv = [
+        "prog",
+        "--num-scenarios",
+        "1",
+        "--no-demand-scaling",
+        "--output-dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    dg.main()
+
+    assert captured["demand_scale_range"] == (1.0, 1.0)
 


### PR DESCRIPTION
## Summary
- allow `scripts/data_generation.py` to disable demand scaling via `--no-demand-scaling`
- document new flag in README
- test that flag overrides demand scaling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5a345ed8832493f89e0881d45816