### PR TITLE
Log mean pressure statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ python scripts/data_generation.py --fixed-pump-speed 1.0 \
 ```
 
 generates a clean batch to inspect mean pressures.
+After each run the script prints the mean and standard deviation of all
+simulated pressures and appends these values along with the key flags to
+`pressure_stats.csv` inside the chosen `--output-dir` so repeated runs can be
+compared.
 If a particular random configuration causes EPANET to fail to produce results,
 the script now skips it after a few retries so the actual number of generated
 scenarios may be slightly smaller than requested.

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -73,6 +73,7 @@ from wntr.network.base import LinkStatus
 from wntr.metrics.economic import pump_energy
 import networkx as nx
 import json
+import csv
 
 
 def simulate_extreme_event(
@@ -957,6 +958,42 @@ def main() -> None:
     with open(os.path.join(out_dir, "test_results_list.pkl"), "wb") as f:
         pickle.dump(test_res, f)
 
+    mean_pressure = float(np.mean(all_pressures))
+    std_pressure = float(np.std(all_pressures))
+    print(f"Mean pressure: {mean_pressure:.2f} m")
+    print(f"Std pressure: {std_pressure:.2f} m")
+
+    stats_path = out_dir / "pressure_stats.csv"
+    write_header = not stats_path.exists()
+    header = [
+        "timestamp",
+        "num_scenarios",
+        "fixed_pump_speed",
+        "demand_min",
+        "demand_max",
+        "extreme_rate",
+        "pump_outage_rate",
+        "local_surge_rate",
+        "mean_pressure",
+        "std_pressure",
+    ]
+    row = [
+        run_ts,
+        N,
+        args.fixed_pump_speed if args.fixed_pump_speed is not None else "",
+        args.demand_scale_range[0],
+        args.demand_scale_range[1],
+        args.extreme_rate,
+        args.pump_outage_rate,
+        args.local_surge_rate,
+        mean_pressure,
+        std_pressure,
+    ]
+    with open(stats_path, "a", newline="") as f:
+        writer = csv.writer(f)
+        if write_header:
+            writer.writerow(header)
+        writer.writerow(row)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- log dataset mean and standard deviation after data generation
- append pressure statistics to `pressure_stats.csv`
- document pressure statistics logging in README

## Testing
- `python scripts/data_generation.py --fixed-pump-speed 1.0 --extreme-rate 0 --pump-outage-rate 0 --local-surge-rate 0 --num-scenarios 100 --seed 42 --deterministic --sequence-length 24 --show-progress --demand-scale-range 1.0 1.01 --output-dir data`
- `pytest` *(fails: tests/test_cli_args.py::test_cli_no_pressure_loss, tests/test_cli_args.py::test_cli_pump_loss_alias, tests/test_cli_args.py::test_cli_loss_weights, tests/test_val_loader_no_neighbor_sampling.py::test_train_with_val_without_neighbor_sampling)*

------
https://chatgpt.com/codex/tasks/task_e_68af60d34f8c83249799bde16b153bdc