### PR TITLE
Record data generation parameters in pressure stats CSV

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
   - `test_output_clamp.py`
   - `test_physics_training.py`
   - `test_pump_controls.py`
+  - `test_pressure_stats_csv.py`
   - `test_recurrent_forward.py`
   - `test_reservoir_feature.py`
   - `test_reservoir_mask.py`

--- a/README.md
+++ b/README.md
@@ -267,7 +267,9 @@ generates a clean batch to inspect mean pressures.
 After each run the script prints the mean and standard deviation of all
 simulated pressures and appends these values along with the key flags to
 `pressure_stats.csv` inside the chosen `--output-dir` so repeated runs can be
-compared.
+compared. The CSV now records all command line parameters such as
+`--sequence-length`, `--deterministic`, `--num-workers` and others for easier
+reproducibility.
 If a particular random configuration causes EPANET to fail to produce results,
 the script now skips it after a few retries so the actual number of generated
 scenarios may be slightly smaller than requested.

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -964,28 +964,66 @@ def main() -> None:
     print(f"Std pressure: {std_pressure:.2f} m")
 
     stats_path = out_dir / "pressure_stats.csv"
+    append_pressure_stats(
+        stats_path,
+        args,
+        N,
+        mean_pressure,
+        std_pressure,
+        run_ts,
+    )
+
+
+def append_pressure_stats(
+    stats_path: Path,
+    args: argparse.Namespace,
+    num_scenarios: int,
+    mean_pressure: float,
+    std_pressure: float,
+    timestamp: str,
+) -> None:
+    """Append a row of run parameters and pressure statistics to ``stats_path``."""
+
     write_header = not stats_path.exists()
     header = [
         "timestamp",
         "num_scenarios",
+        "seed",
+        "deterministic",
+        "num_workers",
+        "sequence_length",
         "fixed_pump_speed",
         "demand_min",
         "demand_max",
         "extreme_rate",
         "pump_outage_rate",
         "local_surge_rate",
+        "tank_min",
+        "tank_max",
+        "no_demand_scaling",
+        "show_progress",
+        "output_dir",
         "mean_pressure",
         "std_pressure",
     ]
     row = [
-        run_ts,
-        N,
+        timestamp,
+        num_scenarios,
+        args.seed if args.seed is not None else "",
+        bool(args.deterministic),
+        args.num_workers if args.num_workers is not None else "",
+        args.sequence_length,
         args.fixed_pump_speed if args.fixed_pump_speed is not None else "",
         args.demand_scale_range[0],
         args.demand_scale_range[1],
         args.extreme_rate,
         args.pump_outage_rate,
         args.local_surge_rate,
+        args.tank_level_range[0],
+        args.tank_level_range[1],
+        getattr(args, "no_demand_scaling", False),
+        bool(getattr(args, "show_progress", False)),
+        str(args.output_dir),
         mean_pressure,
         std_pressure,
     ]

--- a/tests/test_pressure_stats_csv.py
+++ b/tests/test_pressure_stats_csv.py
@@ -1,0 +1,45 @@
+import csv
+from argparse import Namespace
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.data_generation import append_pressure_stats
+
+
+def test_append_pressure_stats(tmp_path):
+    args = Namespace(
+        seed=123,
+        deterministic=True,
+        num_workers=2,
+        sequence_length=4,
+        fixed_pump_speed=1.0,
+        demand_scale_range=(0.5, 1.5),
+        extreme_rate=0.05,
+        pump_outage_rate=0.1,
+        local_surge_rate=0.2,
+        tank_level_range=(0.2, 0.8),
+        no_demand_scaling=False,
+        show_progress=False,
+        output_dir=tmp_path,
+    )
+
+    stats_path = tmp_path / "pressure_stats.csv"
+    append_pressure_stats(
+        stats_path,
+        args,
+        num_scenarios=10,
+        mean_pressure=50.0,
+        std_pressure=5.0,
+        timestamp="20240101_000000",
+    )
+
+    with open(stats_path) as f:
+        row = list(csv.DictReader(f))[0]
+
+    assert row["sequence_length"] == "4"
+    assert row["deterministic"] == "True"
+    assert row["num_workers"] == "2"
+    assert row["seed"] == "123"
+    assert row["tank_min"] == "0.2"
+    assert row["tank_max"] == "0.8"


### PR DESCRIPTION
## Summary
- log all data_generation.py arguments in pressure_stats.csv via new helper
- document new logging behavior in README
- add unit test for pressure stats column coverage

## Testing
- `pytest tests/test_pressure_stats_csv.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af6a4183188324b52745bd6a64d0f3