### PR TITLE
Gracefully handle pressure stats write failures

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -1027,11 +1027,15 @@ def append_pressure_stats(
         mean_pressure,
         std_pressure,
     ]
-    with open(stats_path, "a", newline="") as f:
-        writer = csv.writer(f)
-        if write_header:
-            writer.writerow(header)
-        writer.writerow(row)
+    stats_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(stats_path, "a", newline="") as f:
+            writer = csv.writer(f)
+            if write_header:
+                writer.writerow(header)
+            writer.writerow(row)
+    except PermissionError:
+        warnings.warn(f"Could not write to {stats_path}")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_pressure_stats_csv.py
+++ b/tests/test_pressure_stats_csv.py
@@ -3,6 +3,8 @@ from argparse import Namespace
 from pathlib import Path
 import sys
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from scripts.data_generation import append_pressure_stats
 
@@ -43,3 +45,40 @@ def test_append_pressure_stats(tmp_path):
     assert row["seed"] == "123"
     assert row["tank_min"] == "0.2"
     assert row["tank_max"] == "0.8"
+
+
+def test_append_pressure_stats_permission_error(tmp_path, monkeypatch):
+    args = Namespace(
+        seed=123,
+        deterministic=True,
+        num_workers=2,
+        sequence_length=4,
+        fixed_pump_speed=1.0,
+        demand_scale_range=(0.5, 1.5),
+        extreme_rate=0.05,
+        pump_outage_rate=0.1,
+        local_surge_rate=0.2,
+        tank_level_range=(0.2, 0.8),
+        no_demand_scaling=False,
+        show_progress=False,
+        output_dir=tmp_path,
+    )
+
+    stats_path = tmp_path / "pressure_stats.csv"
+
+    def _raise(*args, **kwargs):
+        raise PermissionError
+
+    monkeypatch.setattr("builtins.open", _raise)
+
+    with pytest.warns(UserWarning, match="Could not write"):
+        append_pressure_stats(
+            stats_path,
+            args,
+            num_scenarios=10,
+            mean_pressure=50.0,
+            std_pressure=5.0,
+            timestamp="20240101_000000",
+        )
+
+    assert not stats_path.exists()


### PR DESCRIPTION
## Summary
- add directory creation and permission error handling when appending pressure statistics
- test append_pressure_stats handles PermissionError without crashing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af6ce528048324888461a6c1465674