### PR TITLE
Handle read-only pressure stats files

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -1028,13 +1028,19 @@ def append_pressure_stats(
         std_pressure,
     ]
     stats_path.parent.mkdir(parents=True, exist_ok=True)
+    if stats_path.exists():
+        try:
+            current_mode = stats_path.stat().st_mode
+            stats_path.chmod(current_mode | 0o666)
+        except OSError:
+            pass
     try:
         with open(stats_path, "a", newline="") as f:
             writer = csv.writer(f)
             if write_header:
                 writer.writerow(header)
             writer.writerow(row)
-    except PermissionError:
+    except OSError:
         warnings.warn(f"Could not write to {stats_path}")
 
 if __name__ == "__main__":

--- a/tests/test_pressure_stats_csv.py
+++ b/tests/test_pressure_stats_csv.py
@@ -47,6 +47,67 @@ def test_append_pressure_stats(tmp_path):
     assert row["tank_max"] == "0.8"
 
 
+def test_append_pressure_stats_readonly_file(tmp_path):
+    args = Namespace(
+        seed=123,
+        deterministic=True,
+        num_workers=2,
+        sequence_length=4,
+        fixed_pump_speed=1.0,
+        demand_scale_range=(0.5, 1.5),
+        extreme_rate=0.05,
+        pump_outage_rate=0.1,
+        local_surge_rate=0.2,
+        tank_level_range=(0.2, 0.8),
+        no_demand_scaling=False,
+        show_progress=False,
+        output_dir=tmp_path,
+    )
+
+    stats_path = tmp_path / "pressure_stats.csv"
+    stats_path.write_text(
+        ",".join(
+            [
+                "timestamp",
+                "num_scenarios",
+                "seed",
+                "deterministic",
+                "num_workers",
+                "sequence_length",
+                "fixed_pump_speed",
+                "demand_min",
+                "demand_max",
+                "extreme_rate",
+                "pump_outage_rate",
+                "local_surge_rate",
+                "tank_min",
+                "tank_max",
+                "no_demand_scaling",
+                "show_progress",
+                "output_dir",
+                "mean_pressure",
+                "std_pressure",
+            ]
+        )
+        + "\n"
+    )
+    stats_path.chmod(0o444)
+
+    append_pressure_stats(
+        stats_path,
+        args,
+        num_scenarios=10,
+        mean_pressure=50.0,
+        std_pressure=5.0,
+        timestamp="20240101_000000",
+    )
+
+    with open(stats_path) as f:
+        rows = list(csv.DictReader(f))
+
+    assert len(rows) == 1
+
+
 def test_append_pressure_stats_permission_error(tmp_path, monkeypatch):
     args = Namespace(
         seed=123,


### PR DESCRIPTION
## Summary
- ensure `pressure_stats.csv` is writable by resetting permissions before appending
- expand `append_pressure_stats` error handling and test read-only file scenario

## Testing
- `pytest tests/test_pressure_stats_csv.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af76cf0ad88324a202f76c148766eb