### PR TITLE
Ensure pressure stats output is writable

### DIFF
--- a/tests/test_pressure_stats_csv.py
+++ b/tests/test_pressure_stats_csv.py
@@ -132,7 +132,7 @@ def test_append_pressure_stats_permission_error(tmp_path, monkeypatch):
 
     monkeypatch.setattr("builtins.open", _raise)
 
-    with pytest.warns(UserWarning, match="Could not write"):
+    with pytest.raises(RuntimeError):
         append_pressure_stats(
             stats_path,
             args,
@@ -142,4 +142,4 @@ def test_append_pressure_stats_permission_error(tmp_path, monkeypatch):
             timestamp="20240101_000000",
         )
 
-    assert not stats_path.exists()
+    assert stats_path.exists()


### PR DESCRIPTION
## Summary
- touch pressure stats CSV before writing to ensure it exists
- retry writing pressure stats CSV after adjusting permissions and raise RuntimeError on repeated failure
- update pressure stats tests for new error handling

## Testing
- `pip install imageio`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af7e3dc3dc832484ec8fa027f30acd