### PR TITLE
Use current timestep demand for mass balance

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -828,8 +828,6 @@ def train_sequence(
                     .reshape(edge_index.size(1), -1)
                 )
                 dem_seq = X_seq[..., 0]
-                if dem_seq.size(1) > 1:
-                    dem_seq = torch.cat([dem_seq[:, 1:], dem_seq[:, -1:]], dim=1)
                 demand_mb = dem_seq.permute(2, 0, 1).reshape(node_count, -1)
                 if hasattr(model, "x_mean") and model.x_mean is not None:
                     if model.x_mean.ndim == 2:
@@ -1062,8 +1060,6 @@ def evaluate_sequence(
                             .reshape(edge_index.size(1), -1)
                         )
                         dem_seq = X_seq[..., 0]
-                        if dem_seq.size(1) > 1:
-                            dem_seq = torch.cat([dem_seq[:, 1:], dem_seq[:, -1:]], dim=1)
                         demand_mb = dem_seq.permute(2, 0, 1).reshape(node_count, -1)
                         if hasattr(model, "x_mean") and model.x_mean is not None:
                             if model.x_mean.ndim == 2:


### PR DESCRIPTION
## Summary
- remove time-shifted demand handling in train_sequence and evaluate_sequence
- use current timestep demand directly when computing mass balance

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'imageio')*


------
https://chatgpt.com/codex/tasks/task_e_68afcb89aeac832490a0b8dcbe253cca