### PR TITLE
Raise minimum physics loss scale to avoid extreme penalties

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ curve terms during the first pass over the training data. These values are used
 to normalise the respective losses before applying the user-specified weights.
 The automatically detected scales can be overridden via ``--mass-scale``,
 ``--head-scale`` and ``--pump-scale`` if manual tuning or logging is desired.
-Scales below ``1e-3`` are automatically clamped to prevent excessively large
+Scales below ``1.0`` are automatically clamped to prevent excessively large
 physics penalties.
 Training logs also report the average mass imbalance per batch and the
 percentage of edges with inconsistent headloss signs.

--- a/models/losses.py
+++ b/models/losses.py
@@ -184,7 +184,7 @@ def scale_physics_losses(
         Raw physics loss values.
     mass_scale, head_scale, pump_scale: float, optional
         Baseline magnitudes for each loss. Values ``\le 0`` disable scaling.
-        Very small positive scales are clamped to ``1e-3`` to avoid division
+        Very small positive scales are clamped to ``1.0`` to avoid division
         by near-zero numbers.
 
     Returns
@@ -192,7 +192,7 @@ def scale_physics_losses(
     Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
         Scaled ``mass_loss``, ``head_loss`` and ``pump_loss``.
     """
-    eps = 1e-3
+    eps = 1.0
     if mass_scale > 0:
         mass_loss = mass_loss / max(mass_scale, eps)
     if head_scale > 0:

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1791,7 +1791,7 @@ def main(args: argparse.Namespace):
                     )
                 else:
                     pump_scale = 1.0
-    MIN_SCALE = 1e-3
+    MIN_SCALE = 1.0
     mass_scale = max(mass_scale, MIN_SCALE)
     head_scale = max(head_scale, MIN_SCALE)
     pump_scale = max(pump_scale, MIN_SCALE)
@@ -2646,19 +2646,19 @@ if __name__ == "__main__":
         "--mass-scale",
         type=float,
         default=0.0,
-        help="Baseline magnitude for mass conservation loss (0 = auto-compute; clamped to ≥1e-3)",
+        help="Baseline magnitude for mass conservation loss (0 = auto-compute; clamped to ≥1.0)",
     )
     parser.add_argument(
         "--head-scale",
         type=float,
         default=0.0,
-        help="Baseline magnitude for head loss consistency (0 = auto-compute; clamped to ≥1e-3)",
+        help="Baseline magnitude for head loss consistency (0 = auto-compute; clamped to ≥1.0)",
     )
     parser.add_argument(
         "--pump-scale",
         type=float,
         default=0.0,
-        help="Baseline magnitude for pump curve loss (0 = auto-compute; clamped to ≥1e-3)",
+        help="Baseline magnitude for pump curve loss (0 = auto-compute; clamped to ≥1.0)",
     )
     parser.add_argument(
         "--cluster-batch-size",


### PR DESCRIPTION
## Summary
- Raise MIN_SCALE in training to 1.0 so auto-computed physics losses stay bounded
- Adjust CLI help and documentation for new minimum
- Clamp physics loss scaling with eps=1.0 in `scale_physics_losses`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2745ae99883248e568156d2826c20