### PR TITLE
Warn when physics losses used without flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ python scripts/train_gnn.py \
     --checkpoint
 ```
 
+Physics-based losses (mass conservation, pressure–headloss consistency and pump curve penalties) require a non-zero `--w-flow` because they operate on flow predictions. If `--w-flow` is set to `0`, these physics terms are automatically disabled.
+
 GNN depth and width are controlled via ``--num-layers`` (choose from {4,6,8}) and ``--hidden-dim`` ({128,256}).
 Use ``--residual`` to enable skip connections and ``--use-attention`` for graph attention on node updates.
 The LSTM hidden size can be set with ``--lstm-hidden`` (64 or 128).
@@ -206,6 +208,7 @@ default to enforce pressure–headloss consistency via the Hazen--Williams
 equation.  The mass penalty uses a default weight of ``2.0`` while
 the headloss term uses ``1.0``. Node pressure and flow terms use
 weights ``--w-press`` (default ``5.0``) and ``--w-flow`` (``3.0``).
+Physics losses are ignored if ``--w-flow`` is set to ``0``.
 The relative importance can still be tuned via these flags together with
 ``--w_mass`` and ``--w_head``.  To keep the physics penalties on a comparable
 scale the script estimates baseline magnitudes for the mass, headloss and pump

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1285,6 +1285,16 @@ PLOTS_DIR = REPO_ROOT / "plots"
 
 def main(args: argparse.Namespace):
     configure_seeds(args.seed, args.deterministic)
+    if args.w_flow == 0 and (
+        args.physics_loss or args.pressure_loss or args.pump_loss
+    ):
+        warnings.warn(
+            "Physics-based losses require a non-zero --w-flow; disabling physics-related losses.",
+            RuntimeWarning,
+        )
+        args.physics_loss = False
+        args.pressure_loss = False
+        args.pump_loss = False
     signal.signal(signal.SIGINT, _signal_handler)
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     edge_index_np = np.load(args.edge_index_path)

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -187,3 +187,65 @@ def test_cli_loss_weights(tmp_path):
     log_text = log_file.read_text()
     assert "'w_press': 2.5" in log_text
     assert "'w_flow': 1.5" in log_text
+
+
+def test_cli_zero_w_flow_disables_physics(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    data_dir = repo / "data"
+    data_dir.mkdir(exist_ok=True)
+    log_file = data_dir / "training_zero_w_flow.log"
+    if log_file.exists():
+        log_file.unlink()
+
+    wn = wntr.network.WaterNetworkModel(repo / "CTown.inp")
+    node_map = {n: i for i, n in enumerate(wn.node_name_list)}
+    link = wn.get_link(wn.link_name_list[0])
+    edge_index = np.array(
+        [
+            [node_map[link.start_node.name], node_map[link.end_node.name]],
+            [node_map[link.end_node.name], node_map[link.start_node.name]],
+        ],
+        dtype=np.int64,
+    )
+    edge_attr = build_edge_attr(wn, edge_index)
+
+    np.save(tmp_path / "edge_index.npy", edge_index)
+    np.save(tmp_path / "edge_attr.npy", edge_attr)
+
+    F = 3 + len(wn.pump_name_list)
+    N = len(wn.node_name_list)
+    X = np.ones((1, N, F), dtype=np.float32)
+    Y = np.zeros((1, N, 1), dtype=np.float32)
+    np.save(tmp_path / "X.npy", X)
+    np.save(tmp_path / "Y.npy", Y)
+
+    cmd = [
+        "python",
+        str(repo / "scripts/train_gnn.py"),
+        "--x-path",
+        str(tmp_path / "X.npy"),
+        "--y-path",
+        str(tmp_path / "Y.npy"),
+        "--edge-index-path",
+        str(tmp_path / "edge_index.npy"),
+        "--edge-attr-path",
+        str(tmp_path / "edge_attr.npy"),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--run-name",
+        "zero_w_flow",
+        "--output",
+        str(tmp_path / "model.pth"),
+        "--w-flow",
+        "0",
+    ]
+
+    subprocess.run(cmd, check=True)
+
+    assert log_file.exists()
+    log_text = log_file.read_text()
+    assert "'physics_loss': False" in log_text
+    assert "'pressure_loss': False" in log_text
+    assert "'pump_loss': False" in log_text


### PR DESCRIPTION
## Summary
- disable physics-based losses when --w-flow is zero
- document that physics losses require a non-zero --w-flow
- add regression test for zero flow weight

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b27b0fc2e483249e8b72596e08f7ba