### PR TITLE
Add edge flow regularization to mass balance loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ terms with data losses to keep predictions physically plausible. These
 regularisers operate independently of the flow mean absolute error weight so
 they may be enabled even when ``--w-flow 0`` is used to disable the flow MAE
 term.
+Pass ``--flow-reg-weight`` to add a small L2 penalty on predicted edge flows,
+ensuring zero-flow solutions with non-zero demand still incur loss.
 
 Training performs node-wise regression and by default optimizes the mean
 absolute error (MAE).  Specify ``--loss-fn`` to switch between MAE (``mae``),

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1047,6 +1047,7 @@ def train_sequence(
                     node_count,
                     demand=demand_mb,
                     node_type=nt,
+                    flow_reg_weight=args.flow_reg_weight,
                     return_imbalance=True,
                 )
                 sym_errors = []
@@ -1308,6 +1309,7 @@ def evaluate_sequence(
                             node_count,
                             demand=demand_mb,
                             node_type=nt,
+                            flow_reg_weight=args.flow_reg_weight,
                             return_imbalance=True,
                         )
                         sym_errors = []
@@ -2737,6 +2739,12 @@ if __name__ == "__main__":
         type=float,
         default=3.0,
         help="Weight of the edge (flow) loss term",
+    )
+    parser.add_argument(
+        "--flow-reg-weight",
+        type=float,
+        default=0.0,
+        help="Weight of L2 regularization on predicted edge flows in the mass balance loss",
     )
     parser.add_argument(
         "--mass-scale",

--- a/tests/test_mass_balance.py
+++ b/tests/test_mass_balance.py
@@ -48,3 +48,12 @@ def test_mass_balance_ignore_reservoir_nodes():
         flows, edge_index, 2, node_type=node_type
     )
     assert torch.allclose(loss, torch.tensor(0.5))
+
+
+def test_zero_flow_with_demand_positive_loss():
+    """Zero edge flows with demand should incur a positive loss."""
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    flows = torch.zeros(2)
+    demand = torch.tensor([1.0, 0.0])
+    loss = compute_mass_balance_loss(flows, edge_index, 2, demand=demand)
+    assert loss > 0


### PR DESCRIPTION
## Summary
- allow `compute_mass_balance_loss` to apply optional L2 regularization on edge flows
- expose `--flow-reg-weight` in `train_gnn.py` to weight this penalty
- test that zero flows with demand incur positive mass balance loss

## Testing
- `PYTHONPATH=. pytest tests/test_mass_balance.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b38a6595e88324b6ae3ae6c943ad42