### PR TITLE
Use cubic meters per second for flows

### DIFF
--- a/models/gnn_surrogate.py
+++ b/models/gnn_surrogate.py
@@ -419,7 +419,7 @@ class MultiTaskGNNSurrogate(nn.Module):
                     else:
                         net.append((flows[:, t, edges] * signs).sum(dim=1))
                 net_flow = torch.stack(net, dim=1)
-                delta_vol = net_flow * 3600.0 * 0.001
+                delta_vol = net_flow * 3600.0  # flows already in m^3/s
                 self.tank_levels += delta_vol
                 self.tank_levels = self.tank_levels.clamp(min=0.0)
                 delta_h = delta_vol / self.tank_areas

--- a/models/losses.py
+++ b/models/losses.py
@@ -132,8 +132,9 @@ def pressure_headloss_consistency_loss(
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """Return MSE between predicted and Hazen--Williams head losses.
 
-    When ``return_violation`` is ``True`` the percentage of edges where the
-    predicted head loss has the wrong sign is also returned.
+    Parameters are expected to use edge flows in ``m^3/s``. When
+    ``return_violation`` is ``True`` the percentage of edges where the predicted
+    head loss has the wrong sign is also returned.
     """
     # Un-normalise edge attributes if statistics are available
     if edge_attr_mean is not None and edge_attr_std is not None:
@@ -166,7 +167,7 @@ def pressure_headloss_consistency_loss(
     diam = diam[pipe_mask]
     rough = rough[pipe_mask]
     q_pipe = q[:, pipe_mask]
-    q_m3 = q_pipe * 0.001
+    q_m3 = q_pipe  # flows already in m^3/s
     flow_sign = torch.sign(q_pipe)
     denom = (rough.pow(1.852) * diam.pow(4.87)).clamp(min=epsilon)
     hw_hl = const * length * q_m3.abs().pow(1.852) / denom

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -223,10 +223,10 @@ def compute_loss_scales(
 ) -> Tuple[float, float, float]:
     """Determine physics loss scales from the dataset.
 
-    Scales are estimated from robust dataset statistics (95th percentile).
-    When the dataset lacks the required information (e.g., no edge flow labels
-    or all-zero flows), the corresponding physics loss is disabled with a
-    warning.
+    Flows are assumed to be provided in ``m^3/s``. Scales are estimated from
+    robust dataset statistics (95th percentile). When the dataset lacks the
+    required information (e.g., no edge flow labels or all-zero flows), the
+    corresponding physics loss is disabled with a warning.
     """
     mass_scale = args.mass_scale
     head_scale = args.head_scale
@@ -287,7 +287,7 @@ def compute_loss_scales(
                         rough = np.clip(
                             edge_attr_phys_np[pipe_mask, 2][active_edges], 1e-6, None
                         )
-                        q_m3 = np.abs(q_pipe) * 0.001
+                        q_m3 = np.abs(q_pipe)  # flows already in m^3/s
                         denom = np.clip(rough ** 1.852 * diam ** 4.87, 1e-6, None)
                         hw_hl = 10.67 * length * (q_m3 ** 1.852) / denom
                         if hw_hl.size > 0:

--- a/tests/test_headloss_loss.py
+++ b/tests/test_headloss_loss.py
@@ -6,7 +6,7 @@ def test_headloss_consistency_zero():
     edge_attr = torch.tensor([[1000.0, 0.5, 100.0]], dtype=torch.float32)
     flow = torch.tensor([0.1], dtype=torch.float32)
     const = 10.67
-    q_m3 = flow * 0.001
+    q_m3 = flow  # flows already in m^3/s
     hl = const * edge_attr[0,0] * q_m3.abs().pow(1.852) / (
         edge_attr[0,2].pow(1.852) * edge_attr[0,1].pow(4.87)
     )

--- a/tests/test_tank_dynamics.py
+++ b/tests/test_tank_dynamics.py
@@ -28,4 +28,5 @@ def test_tank_pressure_update():
     model.tank_signs = [torch.tensor([1.0])]
     X = torch.zeros(1,1,2,2)
     out = model(X, edge_index, edge_attr)
-    assert torch.isclose(out['node_outputs'][0,0,0,0], torch.tensor(3.6))
+    # Flow is 1 m^3/s over an hour with unit area -> 3600 m level rise
+    assert torch.isclose(out['node_outputs'][0,0,0,0], torch.tensor(3600.0))


### PR DESCRIPTION
## Summary
- Treat flow values as cubic meters per second across training and losses
- Drop litre-to-cubic-meter conversions in headloss loss and loss scaling
- Update tank volume integration and unit tests for m³/s flows

## Testing
- `pip install imageio -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b39a6a0da08324ad57270cabded7a9