### PR TITLE
feat: support attention after HydroConv

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ Physics-based losses (mass conservation, pressure–headloss consistency and pum
 Use `--auto-w-flow` to automatically scale the flow loss weight based on dataset flow variance so that its gradient magnitude matches that of the pressure loss.
 
 GNN depth and width are controlled via ``--num-layers`` (choose from {4,6,8}) and ``--hidden-dim`` ({128,256}).
-Use ``--residual`` to enable skip connections and ``--use-attention`` for graph attention on node updates.
+Use ``--residual`` to enable skip connections and ``--use-attention`` for graph attention on node updates. Set
+``--attention-after-hydro`` to apply self-attention after the mass-conserving ``HydroConv`` layers instead of replacing them.
 The LSTM hidden size can be set with ``--lstm-hidden`` (64 or 128).
 When training larger models that exceed GPU memory, pass ``--checkpoint`` to
 enable gradient checkpointing which recomputes intermediate activations during

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1786,6 +1786,7 @@ def main(args: argparse.Namespace):
                 edge_output_dim=1,
                 num_layers=args.num_layers,
                 use_attention=args.use_attention,
+                attention_after_hydro=args.attention_after_hydro,
                 gat_heads=args.gat_heads,
                 dropout=args.dropout,
                 residual=args.residual,
@@ -1822,6 +1823,7 @@ def main(args: argparse.Namespace):
                 output_dim=args.output_dim,
                 num_layers=args.num_layers,
                 use_attention=args.use_attention,
+                attention_after_hydro=args.attention_after_hydro,
                 gat_heads=args.gat_heads,
                 dropout=args.dropout,
                 residual=args.residual,
@@ -1868,6 +1870,7 @@ def main(args: argparse.Namespace):
             residual=args.residual,
             edge_dim=edge_attr.shape[1],
             use_attention=args.use_attention,
+            attention_after_hydro=args.attention_after_hydro,
             gat_heads=args.gat_heads,
             share_weights=args.share_weights,
             num_node_types=num_node_types,
@@ -1880,6 +1883,7 @@ def main(args: argparse.Namespace):
         "hidden_dim": args.hidden_dim,
         "num_layers": args.num_layers,
         "use_attention": args.use_attention,
+        "attention_after_hydro": args.attention_after_hydro,
         "gat_heads": args.gat_heads,
         "residual": args.residual,
         "dropout": args.dropout,
@@ -2627,6 +2631,11 @@ if __name__ == "__main__":
     )
     parser.add_argument("--use-attention", action="store_true",
                         help="Use GATConv instead of HydroConv for graph convolution")
+    parser.add_argument(
+        "--attention-after-hydro",
+        action="store_true",
+        help="Apply self-attention after HydroConv instead of replacing it",
+    )
     parser.add_argument("--gat-heads", type=int, default=4,
                         help="Number of attention heads for GATConv (if attention is enabled)")
     parser.add_argument("--dropout", type=float, default=0.1,

--- a/tests/test_attention_after_hydro.py
+++ b/tests/test_attention_after_hydro.py
@@ -1,0 +1,38 @@
+import warnings
+import torch
+from torch.nn import MultiheadAttention
+from torch_geometric.nn import GATConv
+
+from models.gnn_surrogate import EnhancedGNNEncoder, HydroConv
+
+
+def test_attention_keeps_hydroconv():
+    model = EnhancedGNNEncoder(
+        in_channels=3,
+        hidden_channels=4,
+        out_channels=2,
+        num_layers=1,
+        edge_dim=2,
+        use_attention=True,
+        attention_after_hydro=True,
+        gat_heads=1,
+    )
+    assert isinstance(model.convs[0], HydroConv)
+    assert isinstance(model.attentions[0], MultiheadAttention)
+
+
+def test_attention_warns_when_disabling_hydro():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        model = EnhancedGNNEncoder(
+            in_channels=3,
+            hidden_channels=4,
+            out_channels=2,
+            num_layers=1,
+            edge_dim=2,
+            use_attention=True,
+            attention_after_hydro=False,
+            gat_heads=1,
+        )
+        assert any("HydroConv disabled" in str(wi.message) for wi in w)
+        assert isinstance(model.convs[0], GATConv)


### PR DESCRIPTION
## Summary
- add `attention_after_hydro` option to keep HydroConv layers and append self-attention
- expose flag in `train_gnn.py` and document usage in README
- test that HydroConv remains active when attention is requested

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3a3f46f388324ac5d13f7dfcf5749