### PR TITLE
Fix mixed precision dtype mismatch in attention

### DIFF
--- a/models/gnn_surrogate.py
+++ b/models/gnn_surrogate.py
@@ -195,7 +195,7 @@ class EnhancedGNNEncoder(nn.Module):
                             xb.unsqueeze(0),
                             need_weights=False,
                         )
-                        out[mask] = xb.squeeze(0)
+                        out[mask] = xb.squeeze(0).to(out.dtype)
                     x = out
             x = self.act_fn(x)
             x = F.dropout(x, p=self.dropout, training=self.training)


### PR DESCRIPTION
## Summary
- avoid dtype mismatch when applying batched multi-head attention under gradient checkpointing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3d189d1d88324907d1aca8c2333ed