### PR TITLE
Support node mask in normalization

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1666,7 +1666,7 @@ def main(args: argparse.Namespace):
     if args.normalize:
         if seq_mode:
             x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(
-                X_raw, Y_raw, per_node=args.per_node_norm
+                X_raw, Y_raw, per_node=args.per_node_norm, node_mask=loss_mask
             )
             apply_sequence_normalization(
                 data_ds,
@@ -1677,6 +1677,7 @@ def main(args: argparse.Namespace):
                 edge_mean,
                 edge_std,
                 per_node=args.per_node_norm,
+                node_mask=loss_mask,
             )
             if isinstance(val_list, SequenceDataset):
                 apply_sequence_normalization(
@@ -1688,10 +1689,11 @@ def main(args: argparse.Namespace):
                     edge_mean,
                     edge_std,
                     per_node=args.per_node_norm,
+                    node_mask=loss_mask,
                 )
         else:
             x_mean, x_std, y_mean, y_std = compute_norm_stats(
-                data_list, per_node=args.per_node_norm
+                data_list, per_node=args.per_node_norm, node_mask=loss_mask
             )
             apply_normalization(
                 data_list,
@@ -1702,6 +1704,7 @@ def main(args: argparse.Namespace):
                 edge_mean,
                 edge_std,
                 per_node=args.per_node_norm,
+                node_mask=loss_mask,
             )
             if val_list:
                 apply_normalization(
@@ -1713,6 +1716,7 @@ def main(args: argparse.Namespace):
                     edge_mean,
                     edge_std,
                     per_node=args.per_node_norm,
+                    node_mask=loss_mask,
                 )
         print("Target normalization stats:")
         pressure_stats = summarize_target_norm_stats(y_mean, y_std)
@@ -1772,11 +1776,11 @@ def main(args: argparse.Namespace):
         if y_std is None:
             if seq_mode:
                 _, _, _, y_std_tmp = compute_sequence_norm_stats(
-                    X_raw, Y_raw, per_node=args.per_node_norm
+                    X_raw, Y_raw, per_node=args.per_node_norm, node_mask=loss_mask
                 )
             else:
                 _, _, _, y_std_tmp = compute_norm_stats(
-                    data_list, per_node=args.per_node_norm
+                    data_list, per_node=args.per_node_norm, node_mask=loss_mask
                 )
         else:
             y_std_tmp = y_std
@@ -2398,6 +2402,7 @@ def main(args: argparse.Namespace):
                     edge_mean,
                     edge_std,
                     per_node=args.per_node_norm,
+                    node_mask=loss_mask,
                 )
             test_loader = TorchLoader(
                 test_ds,
@@ -2425,6 +2430,7 @@ def main(args: argparse.Namespace):
                     edge_mean,
                     edge_std,
                     per_node=args.per_node_norm,
+                    node_mask=loss_mask,
                 )
             test_loader = DataLoader(
                 test_list,

--- a/tests/test_normalization_mask.py
+++ b/tests/test_normalization_mask.py
@@ -1,0 +1,97 @@
+import numpy as np
+import torch
+from torch_geometric.data import Data
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import (
+    compute_norm_stats,
+    apply_normalization,
+    SequenceDataset,
+    compute_sequence_norm_stats,
+    apply_sequence_normalization,
+)
+import pytest
+
+
+@pytest.mark.parametrize("per_node", [False, True])
+def test_node_mask_normalization(per_node):
+    edge = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    d1 = Data(
+        x=torch.tensor([[100.0], [1.0]]),
+        edge_index=edge,
+        y=torch.tensor([[100.0], [1.0]]),
+    )
+    d2 = Data(
+        x=torch.tensor([[100.0], [3.0]]),
+        edge_index=edge,
+        y=torch.tensor([[100.0], [3.0]]),
+    )
+    data = [d1, d2]
+    mask = torch.tensor([False, True])
+    x_mean, x_std, y_mean, y_std = compute_norm_stats(
+        data, per_node=per_node, node_mask=mask
+    )
+    apply_normalization(
+        data, x_mean, x_std, y_mean, y_std, per_node=per_node, node_mask=mask
+    )
+    if per_node:
+        all_x = torch.stack([d.x[mask] for d in data], dim=0)
+        all_y = torch.stack([d.y[mask] for d in data], dim=0)
+    else:
+        all_x = torch.cat([d.x[mask] for d in data], dim=0)
+        all_y = torch.cat([d.y[mask] for d in data], dim=0)
+    assert torch.allclose(all_x.mean(dim=0), torch.zeros_like(x_mean), atol=1e-6)
+    assert torch.allclose(all_x.std(dim=0), torch.ones_like(x_std), atol=1e-6)
+    assert torch.allclose(all_y.mean(dim=0), torch.zeros_like(y_mean), atol=1e-6)
+    assert torch.allclose(all_y.std(dim=0), torch.ones_like(y_std), atol=1e-6)
+    # Unmasked node remains unmodified
+    for d in data:
+        assert torch.allclose(d.x[0], torch.tensor([100.0]))
+        assert torch.allclose(d.y[0], torch.tensor([100.0]))
+
+
+@pytest.mark.parametrize("per_node", [False, True])
+def test_sequence_node_mask_normalization(per_node):
+    edge_index = np.array([[0, 1], [1, 0]], dtype=np.int64)
+    edge_attr = np.zeros((edge_index.shape[1], 3), dtype=np.float32)
+    X = np.array([
+        [[[100.0], [1.0]]],
+        [[[100.0], [3.0]]],
+    ], dtype=np.float32)
+    Y = np.array(
+        [
+            {
+                "node_outputs": np.array([[[100.0], [1.0]]], dtype=np.float32),
+                "edge_outputs": np.zeros((1, edge_index.shape[1]), dtype=np.float32),
+            },
+            {
+                "node_outputs": np.array([[[100.0], [3.0]]], dtype=np.float32),
+                "edge_outputs": np.zeros((1, edge_index.shape[1]), dtype=np.float32),
+            },
+        ],
+        dtype=object,
+    )
+    mask = torch.tensor([False, True])
+    x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(
+        X, Y, per_node=per_node, node_mask=mask
+    )
+    ds = SequenceDataset(X, Y, edge_index, edge_attr)
+    apply_sequence_normalization(
+        ds,
+        x_mean,
+        x_std,
+        y_mean,
+        y_std,
+        per_node=per_node,
+        node_mask=mask,
+    )
+    masked_x = ds.X[:, :, mask, :].reshape(-1)
+    masked_y = ds.Y["node_outputs"][:, :, mask, :].reshape(-1)
+    assert abs(float(masked_x.mean())) < 1e-6
+    assert abs(float(masked_x.std(unbiased=False)) - 1) < 1e-6
+    assert abs(float(masked_y.mean())) < 1e-6
+    assert abs(float(masked_y.std(unbiased=False)) - 1) < 1e-6
+    assert torch.allclose(ds.X[:, :, 0, :], torch.tensor(100.0))
+    assert torch.allclose(ds.Y["node_outputs"][..., 0, :], torch.tensor(100.0))


### PR DESCRIPTION
## Summary
- allow compute/apply normalization utilities to ignore masked nodes
- have training pipeline pass loss_mask so reservoirs and tanks are excluded from stats
- test normalization utilities respect node masks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4601156788324b128bdb2081d10b2