### PR TITLE
Trim demand normalization stats for mass balance

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1112,6 +1112,9 @@ def train_sequence(
                     if model.x_mean.ndim == 2:
                         dem_mean = model.x_mean[:, 0].to(device).unsqueeze(1)
                         dem_std = model.x_std[:, 0].to(device).unsqueeze(1)
+                        dem_mean, dem_std = _trim_norm_stats(
+                            dem_mean, dem_std, demand_mb.size(0)
+                        )
                     else:
                         dem_mean = model.x_mean[0].to(device)
                         dem_std = model.x_std[0].to(device)
@@ -1412,6 +1415,9 @@ def evaluate_sequence(
                             if model.x_mean.ndim == 2:
                                 dem_mean = model.x_mean[:, 0].to(device).unsqueeze(1)
                                 dem_std = model.x_std[:, 0].to(device).unsqueeze(1)
+                                dem_mean, dem_std = _trim_norm_stats(
+                                    dem_mean, dem_std, demand_mb.size(0)
+                                )
                             else:
                                 dem_mean = model.x_mean[0].to(device)
                                 dem_std = model.x_std[0].to(device)


### PR DESCRIPTION
## Summary
- prevent dimension mismatch in physics loss by trimming per-node demand normalization stats to match dataset size
- apply trimming during training and evaluation paths

## Testing
- `pip install imageio`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46642120083249ec9df1ac6efddce