### PR TITLE
Log raw physics losses and calibrate loss scales to pressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,10 @@ weights ``--w-press`` (default ``5.0``), ``--w-cl`` (``0.0``) and ``--w-flow``
 relative importance can still be tuned via these flags together with
 ``--w_mass`` and ``--w_head``.  To keep the physics penalties on a comparable
 scale the script estimates baseline magnitudes for the mass, headloss and pump
-curve terms during the first pass over the training data. These values are used
-to normalise the respective losses before applying the user-specified weights.
-The automatically detected scales can be overridden via ``--mass-scale``,
+curve terms relative to the pressure loss during a calibration pass over the
+training data. These ratios are used to normalise the respective losses before
+applying the user-specified weights. The automatically detected scales can be
+overridden via ``--mass-scale``,
 ``--head-scale`` and ``--pump-scale`` if manual tuning or logging is desired.
 Scales below ``1e-3`` are automatically clamped to prevent excessively large
 physics penalties.


### PR DESCRIPTION
## Summary
- Log unscaled mass, head, and pump losses in `train_sequence` and `evaluate_sequence`
- Auto-calibrate mass, head, and pump loss scales relative to baseline pressure loss
- Document automatic calibration in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4c5ab226c8324b9b442f862b6c766