### PR TITLE
Add configurable logging to data generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ generated node features and targets. The resulting node features become
 ``[d_t, p_t, elev, pump_speeds...]`` and the targets only contain next-step
 pressure. The training script automatically detects this layout and adjusts
 its output dimension accordingly.
+The script logs to stdout and ``logs/data_generation.log`` by default. Use
+``--log-level`` to control verbosity and ``--log-file`` to change the log
+destination.
 If a particular random configuration causes EPANET to fail to produce results,
 the script now skips it after a few retries so the actual number of generated
 scenarios may be slightly smaller than requested.


### PR DESCRIPTION
## Summary
- add module-level logging to data generation script
- expose `--log-level` and `--log-file` options and log to stdout and file
- document new logging options in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b639e6e9b88324a656b4557013214b