### PR TITLE
Log dataset split counts and include in summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,9 @@ and ``pressure_hist_<timestamp>.png`` are created under ``plots/``. The first
 summarises the sampled demand multipliers and pump speeds, while the latter
 compares the pressure distribution before (normal scenarios) and after the
 augmented extremes. A ``manifest.json`` file in the output directory lists the
-min/median/max pressure for each scenario and counts how many runs fall below
-10 m to verify coverage of extreme low-pressure events.
+min/median/max pressure for each scenario, counts how many runs fall below
+10 m to verify coverage of extreme low-pressure events, and records the number
+of scenarios allocated to the training, validation and test splits.
 
 To create sequence datasets for the recurrent surrogate specify ``--sequence-length``:
 

--- a/tests/test_split_results.py
+++ b/tests/test_split_results.py
@@ -8,11 +8,12 @@ from scripts.data_generation import split_results
 
 def test_split_results_deterministic():
     results = [(i, {}, {}) for i in range(20)]
-    train1, val1, test1 = split_results(results, seed=123)
-    train2, val2, test2 = split_results(results, seed=123)
+    train1, val1, test1, counts1 = split_results(results, seed=123)
+    train2, val2, test2, counts2 = split_results(results, seed=123)
     assert train1 == train2
     assert val1 == val2
     assert test1 == test2
+    assert counts1 == counts2
 
 
 def test_split_results_different_seed():


### PR DESCRIPTION
## Summary
- log split sizes in `split_results`
- report train/val/test counts in `data_generation` and manifest
- document manifest split counts in README

## Testing
- `pytest tests/test_split_results.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63b942350832491af8df98683ff55