### PR TITLE
Log split counts and include in dataset summary

### DIFF
--- a/tests/test_split_results.py
+++ b/tests/test_split_results.py
@@ -8,11 +8,15 @@ from scripts.data_generation import split_results
 
 def test_split_results_deterministic():
     results = [(i, {}, {}) for i in range(20)]
-    train1, val1, test1 = split_results(results, seed=123)
-    train2, val2, test2 = split_results(results, seed=123)
+    train1, val1, test1, counts1 = split_results(results, seed=123)
+    train2, val2, test2, counts2 = split_results(results, seed=123)
     assert train1 == train2
     assert val1 == val2
     assert test1 == test2
+    assert counts1 == counts2
+    assert counts1["train"] == len(train1)
+    assert counts1["val"] == len(val1)
+    assert counts1["test"] == len(test1)
 
 
 def test_split_results_different_seed():


### PR DESCRIPTION
## Summary
- log split sizes and return counts from `split_results`
- report scenario counts when splitting results in `main`
- embed train/val/test counts in generated dataset summary JSON

## Testing
- `pytest tests/test_split_results.py`


------
https://chatgpt.com/codex/tasks/task_e_68b63e3af5d48324afe1bb1ac04ec3b0