### PR TITLE
Handle mismatched sequence lengths in dataset

### DIFF
--- a/scripts/feature_utils.py
+++ b/scripts/feature_utils.py
@@ -118,8 +118,21 @@ class SequenceDataset(torch.utils.data.Dataset):
             self.multi = False
             self.Y = torch.tensor(Y, dtype=torch.float32)
 
+        # Truncate to the shortest target length to avoid out-of-bounds access
+        self.length = self.X.shape[0]
+        if self.multi:
+            for v in self.Y.values():
+                self.length = min(self.length, v.shape[0])
+            self.X = self.X[: self.length]
+            for k in list(self.Y.keys()):
+                self.Y[k] = self.Y[k][: self.length]
+        else:
+            self.length = min(self.length, self.Y.shape[0])
+            self.X = self.X[: self.length]
+            self.Y = self.Y[: self.length]
+
     def __len__(self) -> int:  # type: ignore[override]
-        return self.X.shape[0]
+        return self.length
 
     def __getitem__(self, idx: int):  # type: ignore[override]
         if self.multi:

--- a/tests/test_sequence_dataset_length.py
+++ b/tests/test_sequence_dataset_length.py
@@ -1,0 +1,17 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.feature_utils import SequenceDataset
+
+def test_sequence_dataset_truncates_to_shortest_length():
+    X = np.zeros((10, 2, 3), dtype=np.float32)
+    Y = np.zeros((7, 2), dtype=np.float32)
+    edge_index = np.zeros((2,0), dtype=np.int64)
+    dataset = SequenceDataset(X, Y, edge_index, None)
+    assert len(dataset) == 7
+    # last index should be accessible without error
+    x, y = dataset[6]
+    assert x.shape[0] == 2 and x.shape[1] == 3
+    assert y.shape[0] == 2


### PR DESCRIPTION
## Summary
- Prevent out-of-bounds access in `SequenceDataset` by truncating to the shortest input/target length and storing dataset length explicitly
- Add regression test covering truncated sequence handling

## Testing
- `pytest tests/test_sequence_dataset_length.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b64d80413c83249550ec3df9766992