### PR TITLE
Fix node mask normalization in train_gnn

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1032,6 +1032,9 @@ def train_sequence(
                     if p_mean.ndim == 2:
                         p_mean = p_mean[..., 0]
                         p_std = p_std[..., 0]
+                    if node_mask is not None:
+                        p_mean = p_mean[node_mask]
+                        p_std = p_std[node_mask]
                     press_pred = press_pred * p_std.view(1, 1, -1) + p_mean.view(1, 1, -1)
                     press_true = press_true * p_std.view(1, 1, -1) + p_mean.view(1, 1, -1)
                 elif not isinstance(model.y_mean, dict):


### PR DESCRIPTION
## Summary
- handle node_mask when denormalizing pressures during training

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b65f386abc8324bdd061e608ac5138