### PR TITLE
Add physics weight annealing schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ Pass ``--no-progress`` to disable the training progress bars or
 Pressure–headloss consistency is now enforced by default with a weight of ``1.0``.
 Pass ``--no-pressure-loss`` if this coupling should be disabled.  To remove the
 mass balance penalty (now weighted ``2.0`` by default) use ``--no-physics-loss``.
+Each physics term can be introduced gradually by specifying an annealing period;
+for example, ``--mass-anneal 10`` linearly ramps the mass conservation weight
+from ``0`` to ``--w_mass`` over the first 10 epochs.  ``--head-anneal`` and
+``--pump-anneal`` behave analogously for their respective penalties.
 The surrogate clamps predicted pressures and chlorine concentrations to
 non-negative values and applies L2 regularization controlled by
 ``--weight-decay`` (default ``1e-5``) to avoid degenerate solutions.

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -196,3 +196,69 @@ def test_cli_loss_scales(tmp_path):
     assert log_file.exists()
     log_text = log_file.read_text()
     assert "scales: mass=0.5, head=0.25, pump=0.75" in log_text
+
+
+def test_cli_anneal(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    data_dir = repo / "data"
+    data_dir.mkdir(exist_ok=True)
+    log_file = data_dir / "training_unit_anneal.log"
+    if log_file.exists():
+        log_file.unlink()
+
+    wn = wntr.network.WaterNetworkModel(repo / "CTown.inp")
+    node_map = {n: i for i, n in enumerate(wn.node_name_list)}
+    link = wn.get_link(wn.link_name_list[0])
+    edge_index = np.array(
+        [
+            [node_map[link.start_node.name], node_map[link.end_node.name]],
+            [node_map[link.end_node.name], node_map[link.start_node.name]],
+        ],
+        dtype=np.int64,
+    )
+    edge_attr = build_edge_attr(wn, edge_index)
+
+    np.save(tmp_path / "edge_index.npy", edge_index)
+    np.save(tmp_path / "edge_attr.npy", edge_attr)
+
+    F = 4 + len(wn.pump_name_list)
+    N = len(wn.node_name_list)
+    X = np.ones((1, N, F), dtype=np.float32)
+    Y = np.zeros((1, N, 2), dtype=np.float32)
+    np.save(tmp_path / "X.npy", X)
+    np.save(tmp_path / "Y.npy", Y)
+
+    cmd = [
+        "python",
+        str(repo / "scripts/train_gnn.py"),
+        "--x-path",
+        str(tmp_path / "X.npy"),
+        "--y-path",
+        str(tmp_path / "Y.npy"),
+        "--edge-index-path",
+        str(tmp_path / "edge_index.npy"),
+        "--edge-attr-path",
+        str(tmp_path / "edge_attr.npy"),
+        "--epochs",
+        "1",
+        "--batch-size",
+        "1",
+        "--run-name",
+        "unit_anneal",
+        "--output",
+        str(tmp_path / "model.pth"),
+        "--mass-anneal",
+        "1",
+        "--head-anneal",
+        "1",
+        "--pump-anneal",
+        "1",
+    ]
+
+    subprocess.run(cmd, check=True)
+
+    assert log_file.exists()
+    log_text = log_file.read_text()
+    assert "'mass_anneal': 1" in log_text
+    assert "'head_anneal': 1" in log_text
+    assert "'pump_anneal': 1" in log_text


### PR DESCRIPTION
## Summary
- ramp mass, head and pump physics loss weights over configurable epochs
- expose --mass-anneal, --head-anneal and --pump-anneal flags in `train_gnn.py`
- document annealing options and test CLI parsing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b67ced46b8832491807d04790c395f