### PR TITLE
Ensure demand field present for mass balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ supported:
 2. **Matrix format** – ``X`` is an array of node feature matrices and a shared
    ``edge_index`` array is stored separately.
 
+The accompanying label arrays always include the next-hour node demands under
+the ``"demand"`` key.  ``train_gnn.py`` relies on this field for mass balance
+checks and will error out if it is missing.  Ensure datasets are generated with
+the current ``data_generation.py`` so demands are recorded.
+
 All plots generated during training, validation and MPC experiments are
 saved under the top-level ``plots/`` directory.  The scripts automatically
 create this folder if it does not yet exist. After each training run

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -941,27 +941,16 @@ def _extract_next_demand(
 ) -> torch.Tensor:
     """Return demand at ``t+1`` for mass balance checks.
 
-    ``Y_seq`` may provide the next-step demand directly.  When absent, the
-    demand channel from ``X_seq`` is shifted forward by one step and
-    de-normalised to approximate the same quantity.
+    Raises
+    ------
+    KeyError
+        If ``Y_seq`` does not contain the ``"demand"`` field.
     """
 
-    if isinstance(Y_seq, dict) and "demand" in Y_seq:
-        return Y_seq["demand"].permute(2, 0, 1).reshape(node_count, -1)
+    if not (isinstance(Y_seq, dict) and "demand" in Y_seq):
+        raise KeyError("Missing 'demand' in targets; regenerate data with demand outputs")
 
-    dem_seq = X_seq[..., 0]
-    if dem_seq.size(1) > 1:
-        dem_seq = torch.cat([dem_seq[:, 1:], dem_seq[:, -1:]], dim=1)
-    demand_mb = dem_seq.permute(2, 0, 1).reshape(node_count, -1)
-    if hasattr(model, "x_mean") and model.x_mean is not None:
-        if model.x_mean.ndim == 2:
-            dem_mean = model.x_mean[:, 0].to(device).unsqueeze(1)
-            dem_std = model.x_std[:, 0].to(device).unsqueeze(1)
-        else:
-            dem_mean = model.x_mean[0].to(device)
-            dem_std = model.x_std[0].to(device)
-        demand_mb = demand_mb * dem_std + dem_mean
-    return demand_mb
+    return Y_seq["demand"].permute(2, 0, 1).reshape(node_count, -1)
 
 
 def train_sequence(


### PR DESCRIPTION
## Summary
- require demand outputs during data generation and fail fast when missing
- enforce demand presence in training by removing feature-based fallback
- document demand requirement in README

## Testing
- ⚠️ `pytest` (partial: 9 passed, keyboard interrupt)

------
https://chatgpt.com/codex/tasks/task_e_68b6984172ec8324b8c2dca6ed9aff04