### PR TITLE
feat: make demand scaling range configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ The generation step writes ``edge_index.npy``, ``edge_attr.npy``, ``edge_type.np
 ``--num-workers`` to override the number of parallel workers if needed.
 Pass ``--show-progress`` to display a live progress bar during simulation
 when ``tqdm`` is installed.
+Base demands are scaled by random factors drawn uniformly from ``[0.8, 1.2]``.
+Customize this range via ``--demand-scale-min`` and ``--demand-scale-max``.
 The pump speed random walk can be adjusted using ``--pump-speed-min``,
 ``--pump-speed-max`` and ``--pump-step`` to set the minimum/maximum
 relative speeds and the maximum hourly change (defaults 0.6, 1.2 and

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -187,6 +187,8 @@ def _build_randomized_network(
     pump_speed_min: float = DEFAULT_PUMP_SPEED_MIN,
     pump_speed_max: float = DEFAULT_PUMP_SPEED_MAX,
     pump_step: float = DEFAULT_PUMP_STEP,
+    demand_scale_min: float = 0.8,
+    demand_scale_max: float = 1.2,
 ) -> Tuple[wntr.network.WaterNetworkModel, Dict[str, np.ndarray], Dict[str, List[float]]]:
     """Create a network with randomized demand patterns and pump controls.
 
@@ -226,7 +228,9 @@ def _build_randomized_network(
         else:
             base_mult = np.array(ts.pattern.multipliers, dtype=float)
         multipliers = base_mult.copy()
-        scale_factors = np.random.uniform(0.8, 1.2, size=len(multipliers))
+        scale_factors = np.random.uniform(
+            demand_scale_min, demand_scale_max, size=len(multipliers)
+        )
         multipliers = multipliers * scale_factors
         multipliers = np.clip(multipliers, a_min=0.0, a_max=None)
         pat_name = f"{jname}_pat_{idx}"
@@ -353,6 +357,8 @@ def _run_single_scenario(
     pump_speed_min: float = DEFAULT_PUMP_SPEED_MIN,
     pump_speed_max: float = DEFAULT_PUMP_SPEED_MAX,
     pump_step: float = DEFAULT_PUMP_STEP,
+    demand_scale_min: float = 0.8,
+    demand_scale_max: float = 1.2,
 ) -> Optional[
     Tuple[wntr.sim.results.SimulationResults, Dict[str, np.ndarray], Dict[str, List[float]]]
 ]:
@@ -389,6 +395,8 @@ def _run_single_scenario(
             pump_speed_min=pump_speed_min,
             pump_speed_max=pump_speed_max,
             pump_step=pump_step,
+            demand_scale_min=demand_scale_min,
+            demand_scale_max=demand_scale_max,
         )
 
         events = []
@@ -461,6 +469,8 @@ def run_scenarios(
     pump_speed_min: float = DEFAULT_PUMP_SPEED_MIN,
     pump_speed_max: float = DEFAULT_PUMP_SPEED_MAX,
     pump_step: float = DEFAULT_PUMP_STEP,
+    demand_scale_min: float = 0.8,
+    demand_scale_max: float = 1.2,
 ) -> List[
     Tuple[wntr.sim.results.SimulationResults, Dict[str, np.ndarray], Dict[str, List[float]]]
 ]:
@@ -486,6 +496,8 @@ def run_scenarios(
             pump_speed_min=pump_speed_min,
             pump_speed_max=pump_speed_max,
             pump_step=pump_step,
+            demand_scale_min=demand_scale_min,
+            demand_scale_max=demand_scale_max,
         )
         if show_progress and tqdm is not None:
             raw_results = [
@@ -973,6 +985,18 @@ def main() -> None:
         help="Maximum absolute hourly change in pump speed",
     )
     parser.add_argument(
+        "--demand-scale-min",
+        type=float,
+        default=0.8,
+        help="Minimum multiplicative demand scaling factor",
+    )
+    parser.add_argument(
+        "--demand-scale-max",
+        type=float,
+        default=1.2,
+        help="Maximum multiplicative demand scaling factor",
+    )
+    parser.add_argument(
         "--exclude-stress",
         action="store_true",
         help="Drop stress-test scenarios from the saved datasets",
@@ -1063,6 +1087,8 @@ def main() -> None:
         pump_speed_min=args.pump_speed_min,
         pump_speed_max=args.pump_speed_max,
         pump_step=args.pump_step,
+        demand_scale_min=args.demand_scale_min,
+        demand_scale_max=args.demand_scale_max,
     )
 
     if args.exclude_stress:

--- a/tests/test_demand_scaling.py
+++ b/tests/test_demand_scaling.py
@@ -31,3 +31,15 @@ def test_demand_multiplier_range():
         assert np.all(ratio >= 0.8)
         assert np.all(ratio <= 1.2)
 
+    random.seed(123)
+    np.random.seed(123)
+    _, custom_scale_dict, _ = _build_randomized_network(
+        str(inp), idx=0, demand_scale_min=0.5, demand_scale_max=1.5
+    )
+
+    for jname, scaled in custom_scale_dict.items():
+        base_mult = base_patterns[jname][: len(scaled)]
+        ratio = scaled / base_mult
+        assert np.all(ratio >= 0.5)
+        assert np.all(ratio <= 1.5)
+


### PR DESCRIPTION
## Summary
- add `--demand-scale-min` and `--demand-scale-max` to data generation CLI
- draw demand multipliers from provided range instead of fixed 0.8–1.2
- document new options and test custom scaling

## Testing
- `pytest` *(fails: Missing 'demand' in targets; regenerate data with demand outputs)*
- `pytest tests/test_demand_scaling.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6a502668883248430bb9651f29e13