### PR TITLE
Fix object array handling in data generation logging

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -117,8 +117,13 @@ def log_array_stats(name: str, arr: np.ndarray) -> None:
                 values = [item]
             for v in values:
                 v_arr = np.asarray(v)
-                nan_count += int(np.count_nonzero(np.isnan(v_arr)))
-                inf_count += int(np.count_nonzero(np.isinf(v_arr)))
+                # ``np.isnan``/``np.isinf`` error on non-numeric dtypes such as
+                # strings.  Guard the checks so scenario label arrays with
+                # object dtype (e.g. ``["normal", "fire_flow"]``) don't
+                # trigger a ``TypeError``.
+                if np.issubdtype(v_arr.dtype, np.number):
+                    nan_count += int(np.count_nonzero(np.isnan(v_arr)))
+                    inf_count += int(np.count_nonzero(np.isinf(v_arr)))
     else:
         nan_count = int(np.count_nonzero(np.isnan(arr_np)))
         inf_count = int(np.count_nonzero(np.isinf(arr_np)))

--- a/tests/test_flow_denorm.py
+++ b/tests/test_flow_denorm.py
@@ -35,6 +35,7 @@ def test_mass_balance_denorm_per_edge():
             {
                 "node_outputs": np.zeros((T, N, 2), dtype=np.float32),
                 "edge_outputs": np.zeros((T, E), dtype=np.float32),
+                "demand": np.zeros((T, N), dtype=np.float32),
             }
         ],
         dtype=object,

--- a/tests/test_log_array_stats.py
+++ b/tests/test_log_array_stats.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import logging
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.data_generation import log_array_stats  # noqa: E402
+
+
+def test_log_array_stats_handles_strings(caplog):
+    caplog.set_level(logging.INFO)
+    arr = np.array(["normal", "fire_flow"], dtype=object)
+    log_array_stats("scenarios", arr)
+    assert "scenarios: shape" in caplog.text
+
+
+def test_log_array_stats_detects_invalid():
+    arr = np.array([{"α": np.array([1.0, np.nan])}], dtype=object)
+    with pytest.raises(ValueError):
+        log_array_stats("bad", arr)

--- a/tests/test_per_node_demand_denorm.py
+++ b/tests/test_per_node_demand_denorm.py
@@ -29,6 +29,7 @@ def test_evaluate_sequence_per_node_denorm():
         {
             "node_outputs": np.zeros((1, 2, 2), dtype=np.float32),
             "edge_outputs": np.zeros((1, 2), dtype=np.float32),
+            "demand": np.zeros((1, 2), dtype=np.float32),
         }
     ], dtype=object)
     edge_index = np.array([[0, 1], [1, 0]])

--- a/tests/test_physics_training.py
+++ b/tests/test_physics_training.py
@@ -26,6 +26,7 @@ def test_train_sequence_with_physics_losses():
             {
                 "node_outputs": np.zeros((T, N, 2), dtype=np.float32),
                 "edge_outputs": np.zeros((T, E), dtype=np.float32),
+                "demand": np.zeros((T, N), dtype=np.float32),
             }
         ],
         dtype=object,


### PR DESCRIPTION
## Summary
- guard `log_array_stats` against non-numeric object arrays so scenario label logging succeeds
- add regression test for string and dict arrays in `log_array_stats`
- update physics and denormalization tests to include `demand` targets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f78e12c88324848f69ffa9ca4e12