### PR TITLE
Track gradient norms during training

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ separately which removes large baseline offsets and often reduces pressure MAE.
 When sequence models are used a component-wise loss curve
 ``loss_components_<run>.png`` is stored alongside ``loss_curve_<run>.png`` and
 the per-component pressure, chlorine and flow losses are recorded each epoch in
-``training_<run>.log`` as well as TensorBoard summaries.
+``training_<run>.log`` as well as TensorBoard summaries. The gradient norm is
+logged to the same files and its trajectory is saved as ``grad_norm_<run>.png``
+under ``plots/`` to highlight potential optimisation instability.
 For sequence datasets a time-series example ``time_series_example_<run>.png``
 plots predicted and actual pressure and chlorine for one node across all steps.
 


### PR DESCRIPTION
## Summary
- capture gradient norms during `train` and `train_sequence`
- log gradient norms to training logs, TensorBoard, and plot their evolution
- document gradient norm logging in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6fee0fa1883248ed82da6052a27b7