### PR TITLE
Add residual residual scatter plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ create this folder if it does not yet exist. After each training run
 ``train_gnn.py`` saves two scatter plots comparing model predictions to
 EPANET results: ``pred_vs_actual_pressure_<run>.png`` and
 ``pred_vs_actual_chlorine_<run>.png``. Reservoirs and tanks are excluded from
-these plots since their pressures are fixed. ``error_histograms_<run>.png``
+these plots since their pressures are fixed. In addition,
+``residual_scatter_pressure_<run>.png`` and
+``residual_scatter_chlorine_<run>.png`` show the prediction residuals versus
+both the ground truth and the predictions. ``error_histograms_<run>.png``
 contains histograms and box plots of the prediction errors and the CSV
 ``logs/accuracy_<run>.csv`` records MAE, RMSE, MAPE, maximum error and R^2 for
 pressure and chlorine. Reservoir and tank nodes are excluded from these metrics

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -14,6 +14,8 @@ def test_save_scatter_plots(tmp_path):
     save_scatter_plots(p_true, p_pred, c_true, c_pred, "unit", plots_dir=tmp_path)
     assert (tmp_path / "pred_vs_actual_pressure_unit.png").exists()
     assert (tmp_path / "pred_vs_actual_chlorine_unit.png").exists()
+    assert (tmp_path / "residual_scatter_pressure_unit.png").exists()
+    assert (tmp_path / "residual_scatter_chlorine_unit.png").exists()
 
 
 def test_save_scatter_plots_mask(tmp_path):
@@ -33,3 +35,5 @@ def test_save_scatter_plots_mask(tmp_path):
     )
     assert (tmp_path / "pred_vs_actual_pressure_unit.png").exists()
     assert (tmp_path / "pred_vs_actual_chlorine_unit.png").exists()
+    assert (tmp_path / "residual_scatter_pressure_unit.png").exists()
+    assert (tmp_path / "residual_scatter_chlorine_unit.png").exists()

--- a/tests/test_scatter_interrupt.py
+++ b/tests/test_scatter_interrupt.py
@@ -16,5 +16,7 @@ def test_scatter_plots_generated_when_interrupted(tmp_path):
         train_gnn.save_scatter_plots(p_true, p_pred, c_true, c_pred, "unit", plots_dir=tmp_path)
         assert (tmp_path / "pred_vs_actual_pressure_unit.png").exists()
         assert (tmp_path / "pred_vs_actual_chlorine_unit.png").exists()
+        assert (tmp_path / "residual_scatter_pressure_unit.png").exists()
+        assert (tmp_path / "residual_scatter_chlorine_unit.png").exists()
     finally:
         train_gnn.interrupted = False

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -4,6 +4,7 @@ import torch
 
 from scripts.train_gnn import (
     predicted_vs_actual_scatter,
+    plot_residual_scatter,
     plot_loss_components,
     plot_error_histograms,
     SequenceDataset,
@@ -44,6 +45,22 @@ def test_predicted_vs_actual_scatter_mask(tmp_path: Path):
     assert (tmp_path / "pred_vs_actual_unit.png").exists()
     ax0 = fig.axes[0]
     assert ax0.collections[0].get_offsets().shape[0] == 2
+
+
+def test_plot_residual_scatter(tmp_path: Path):
+    fig = plot_residual_scatter(
+        [1.0, 2.0, 3.0],
+        [1.1, 2.1, 2.9],
+        "unit",
+        "pressure",
+        plots_dir=tmp_path,
+        return_fig=True,
+        density="hex",
+    )
+    assert (tmp_path / "residual_scatter_pressure_unit.png").exists()
+    ax0 = fig.axes[0]
+    assert ax0.get_ylabel() == "Residual"
+    plt = None
 
 
 def test_convergence_curve(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add `plot_residual_scatter` to visualize prediction residuals against truth and predictions with optional KDE/hexbin overlays
- save residual scatter plots alongside existing scatter outputs after evaluation
- document new residual plots and test plotting utilities

## Testing
- `pytest tests/test_scatter.py tests/test_scatter_interrupt.py tests/test_visualizations.py`

------
https://chatgpt.com/codex/tasks/task_e_68b704ac76048324817737eb17d900e4