### PR TITLE
Enable automatic checkpoint fallback on CUDA OOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ The LSTM hidden size can be set with ``--lstm-hidden`` (choices: 64, 128, 256).
 When training larger models that exceed GPU memory, pass ``--checkpoint`` to
 enable gradient checkpointing which recomputes intermediate activations during
 backpropagation to lower peak memory usage at the cost of additional compute.
+If a CUDA out-of-memory error is encountered, the training script now
+automatically retries with gradient checkpointing enabled.
 If training is interrupted with ``Ctrl+C`` a final checkpoint containing the
 model, optimizer, scheduler state and epoch is saved so progress is not lost.
 To continue a previous run pass the checkpoint path via ``--resume``.  All

--- a/tests/test_auto_checkpoint.py
+++ b/tests/test_auto_checkpoint.py
@@ -1,0 +1,24 @@
+import torch
+import pytest
+from scripts.train_gnn import _forward_with_auto_checkpoint
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.use_checkpoint = False
+        self.called = 0
+
+    def forward(self):
+        self.called += 1
+        if self.called == 1 and not self.use_checkpoint:
+            raise RuntimeError("CUDA out of memory")
+        return torch.tensor(1.0)
+
+def test_forward_enables_checkpoint_on_oom():
+    model = DummyModel()
+    def fn():
+        return model()
+    out = _forward_with_auto_checkpoint(model, fn)
+    assert model.use_checkpoint
+    assert out.item() == 1.0
+    assert model.called == 2


### PR DESCRIPTION
## Summary
- Add `_forward_with_auto_checkpoint` helper that retries a forward pass with gradient checkpointing if a CUDA OOM occurs
- Update training pipeline to use the helper across forward calls
- Document automatic fallback in README and add regression test

## Testing
- `pytest` *(fails: Interrupted: 45 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b769ac3150832499e8598de6f0b1ed