### PR TITLE
Handle static columns in sequence normalization

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2040,9 +2040,13 @@ def main(args: argparse.Namespace):
 
     norm_md5 = None
     if args.normalize:
+        static_cols = [3] if args.per_node_norm else None
         if seq_mode:
             x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(
-                X_raw, Y_raw, per_node=args.per_node_norm
+                X_raw,
+                Y_raw,
+                per_node=args.per_node_norm,
+                static_cols=static_cols,
             )
             apply_sequence_normalization(
                 data_ds,
@@ -2053,6 +2057,7 @@ def main(args: argparse.Namespace):
                 edge_mean,
                 edge_std,
                 per_node=args.per_node_norm,
+                static_cols=static_cols,
             )
             if isinstance(val_list, SequenceDataset):
                 apply_sequence_normalization(
@@ -2064,6 +2069,7 @@ def main(args: argparse.Namespace):
                     edge_mean,
                     edge_std,
                     per_node=args.per_node_norm,
+                    static_cols=static_cols,
                 )
         else:
             x_mean, x_std, y_mean, y_std = compute_norm_stats(
@@ -2844,6 +2850,7 @@ def main(args: argparse.Namespace):
                     edge_mean,
                     edge_std,
                     per_node=args.per_node_norm,
+                    static_cols=static_cols,
                 )
             test_loader = TorchLoader(
                 test_ds,

--- a/tests/test_sequence_norm_stats.py
+++ b/tests/test_sequence_norm_stats.py
@@ -4,7 +4,11 @@ from pathlib import Path
 import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from scripts.train_gnn import compute_sequence_norm_stats
+from scripts.train_gnn import (
+    compute_sequence_norm_stats,
+    SequenceDataset,
+    apply_sequence_normalization,
+)
 import pytest
 
 
@@ -35,3 +39,23 @@ def test_sequence_norm_stats_edge_vector(per_node):
     Y_norm = (Y_tensor - y_mean["edge_outputs"]) / y_std["edge_outputs"]
     assert abs(float(Y_norm.mean())) < 1e-6
     assert abs(float(Y_norm.std(unbiased=False))) < 1e-6
+
+
+def test_static_cols_global_stats():
+    X = np.array([[[[0, 0, 0, 10], [0, 0, 0, 20]]]], dtype=np.float32)
+    Y = np.zeros((1, 1, 2, 1), dtype=np.float32)
+    edge_index = np.zeros((2, 0), dtype=np.int64)
+
+    x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(
+        X, Y, per_node=True, static_cols=[3]
+    )
+    assert torch.allclose(x_mean[:, 3], torch.tensor([15.0, 15.0]))
+    assert torch.allclose(x_std[:, 3], torch.tensor([5.0, 5.0]))
+
+    ds = SequenceDataset(X, Y, edge_index, None)
+    apply_sequence_normalization(
+        ds, x_mean, x_std, y_mean, y_std, per_node=True, static_cols=[3]
+    )
+    col = ds.X[..., 3]
+    assert torch.allclose(col.mean(), torch.tensor(0.0), atol=1e-6)
+    assert torch.allclose(col.std(unbiased=False), torch.tensor(1.0), atol=1e-6)


### PR DESCRIPTION
## Summary
- add `static_cols` support to sequence normalization helpers
- normalize static features globally and pass elevation index from `train_gnn`
- test static column normalization

## Testing
- `pytest tests/test_sequence_norm_stats.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'imageio')*


------
https://chatgpt.com/codex/tasks/task_e_68b8b944c6488324a4388a481a03389b