### PR TITLE
Support pressure-only datasets in validation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,10 @@ python scripts/experiments_validation.py \
     --run-name baseline
 ```
 
+The validation script automatically detects whether the surrogate was trained
+with chlorine targets. Models trained without chlorine (pressure-only) are
+also supported and skip chlorine-related metrics and MPC experiments.
+
 The validation run also exports an animated view of network pressures,
 chlorine and pump speeds:
 


### PR DESCRIPTION
## Summary
- allow feature utilities to drop chlorine fields when the model lacks chlorine outputs
- auto-detect chlorine targets in `experiments_validation.py` and skip MPC when absent
- document pressure-only support in README and add a regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8edaab7808324a7bfad09e5cefe13