### PR TITLE
feat(train): export pressure predictions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
   - `mpc_control.py` – run gradient-based MPC using the trained surrogate.
   - `feature_utils.py` – shared feature construction and normalization helpers.
   - `ablation_study.py` – run a small grid of model variants and report validation pressure MAE.
-  - `train_gnn.py` – train a graph neural network surrogate on generated data. Pass `--checkpoint` to enable gradient checkpointing when GPU memory is limited.
+  - `train_gnn.py` – train a graph neural network surrogate on generated data. Pass `--checkpoint` to enable gradient checkpointing when GPU memory is limited. The script also writes predicted vs. actual pressures to `data/pressures_<run>.csv` (override with `--pred-csv`).
   - `sweep_training.py` – run hyperparameter sweeps over loss weights and architecture.
   - `plot_sweep.py` – visualise pressure MAE across sweep configurations.
   - `reproducibility.py` – helper utilities for seeding and config logging.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ these plots since their pressures are fixed. In addition,
 both the ground truth and the predictions. ``error_histograms_<run>.png``
 contains histograms and box plots of the prediction errors and the CSV
 ``logs/accuracy_<run>.csv`` records MAE, RMSE, MAPE, maximum error and R^2 for
-pressure and chlorine. Reservoir and tank nodes are excluded from these metrics
+pressure and chlorine. The retained pressure predictions are also written to
+``data/pressures_<run>.csv`` which lists the actual and predicted pressures. Use
+``--pred-csv`` to override the output location. Reservoir and tank nodes are
+excluded from these metrics
 so outliers from fixed heads do not skew the results. Metrics are accumulated
 using running statistics so the full prediction arrays are never stored in
 memory. To limit the number of predictions retained for plotting, pass

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2416,6 +2416,12 @@ def main(args: argparse.Namespace):
         model_path = f"{base}_{run_name}{ext}"
         norm_path = f"{base}_{run_name}_norm.npz"
         log_path = os.path.join(DATA_DIR, f"training_{run_name}.log")
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    pred_csv_path = (
+        Path(args.pred_csv)
+        if args.pred_csv
+        else DATA_DIR / f"pressures_{run_name}.csv"
+    )
     losses = []
     loss_components = []
     grad_norms = []
@@ -3093,6 +3099,15 @@ def main(args: argparse.Namespace):
                 preds_c = true_c = err_c = None
             err_p = preds_p - true_p
 
+            df = pd.DataFrame(
+                {
+                    "actual_pressure": true_p,
+                    "predicted_pressure": preds_p,
+                }
+            )
+            pred_csv_path.parent.mkdir(parents=True, exist_ok=True)
+            df.to_csv(pred_csv_path, index=False)
+
             save_scatter_plots(
                 true_p,
                 preds_p,
@@ -3172,6 +3187,11 @@ if __name__ == "__main__":
         "--y-test-path",
         default=os.path.join(DATA_DIR, "Y_test.npy"),
         help="Test labels",
+    )
+    parser.add_argument(
+        "--pred-csv",
+        default="",
+        help="Path to save pressure predictions CSV",
     )
     parser.add_argument(
         "--epochs",


### PR DESCRIPTION
## Summary
- save pressure vs. prediction CSV during training
- allow overriding CSV path with `--pred-csv`
- document new output in README and AGENTS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbbf3985048324bf2c4601affd9763