### PR TITLE
Expand GNN architecture options

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ python scripts/train_gnn.py \
     --x-val-path data/X_val.npy --y-val-path data/Y_val.npy \
     --edge-index-path data/edge_index.npy --edge-attr-path data/edge_attr.npy \
     --inp-path CTown.inp \
-    --epochs 100 --batch-size 32 --hidden-dim 128 --num-layers 4 \
+    --epochs 100 --batch-size 32 --hidden-dim 512 --num-layers 10 \
     --lstm-hidden 64 --workers 8 --eval-sample 1000 \
     --dropout 0.1 --residual --early-stop-patience 10 \
     --weight-decay 1e-5 --w-press 5.0 --w-flow 3.0 --w-cl 0.0 \
@@ -161,7 +161,7 @@ python scripts/train_gnn.py \
 Chlorine supervision is disabled by default. Pass a positive weight such as
 ``--w-cl 1.0`` to train on chlorine again.
 
-GNN depth and width are controlled via ``--num-layers`` (choose from {4,6,8}) and ``--hidden-dim`` ({128,256}).
+GNN depth and width are controlled via ``--num-layers`` (choose from {4,6,8,10}) and ``--hidden-dim`` ({128,256,512}).
 Use ``--residual`` to enable skip connections and ``--use-attention`` for graph attention on node updates.
 The LSTM hidden size can be set with ``--lstm-hidden`` (choices: 64, 128, 256).
 When training larger models that exceed GPU memory, pass ``--checkpoint`` to

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -3200,7 +3200,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--hidden-dim",
         type=int,
-        choices=[128, 256],
+        choices=[128, 256, 512],
         default=128,
         help="Hidden dimension",
     )
@@ -3210,7 +3210,7 @@ if __name__ == "__main__":
                         help="Number of attention heads for GATConv (if attention is enabled)")
     parser.add_argument("--dropout", type=float, default=0.1,
                         help="Dropout rate applied after each GNN layer")
-    parser.add_argument("--num-layers", type=int, choices=[4, 6, 8], default=4,
+    parser.add_argument("--num-layers", type=int, choices=[4, 6, 8, 10], default=4,
                         help="Number of convolutional layers in the GNN model")
     parser.add_argument(
         "--activation",


### PR DESCRIPTION
## Summary
- allow selecting 512 hidden units and up to 10 GNN layers in `train_gnn.py`
- document new `--hidden-dim` and `--num-layers` choices in README
- test CLI accepts 512 hidden dim and 10 layers

## Testing
- `pytest tests/test_cli_args.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbc8dc4018832485b8a5c020668429