### PR TITLE
Print device used by training script

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1929,6 +1929,7 @@ def main(args: argparse.Namespace):
     configure_seeds(args.seed, args.deterministic)
     signal.signal(signal.SIGINT, _signal_handler)
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print(device)
     edge_index_np = np.load(args.edge_index_path)
     wn = wntr.network.WaterNetworkModel(args.inp_path)
     # Always compute the physical edge attributes from the network


### PR DESCRIPTION
## Summary
- Emit the selected `torch.device` in `train_gnn.py` so runs show whether CPU or GPU is used.

## Testing
- `pytest tests/test_cli_args.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc152dcd483248b0eb350efe33345