### PR TITLE
Add node metadata to training pressure export

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ both the ground truth and the predictions. ``error_histograms_<run>.png``
 contains histograms and box plots of the prediction errors and the CSV
 ``logs/accuracy_<run>.csv`` records MAE, RMSE, MAPE, maximum error and R^2 for
 pressure and chlorine. The retained pressure predictions are also written to
-``data/pressures_<run>.csv`` which lists the actual and predicted pressures. Use
-``--pred-csv`` to override the output location. Reservoir and tank nodes are
+``data/pressures_<run>.csv`` which lists the node index, elevation, demand,
+pump speeds, and the actual and predicted pressures. Use ``--pred-csv`` to
+override the output location. Reservoir and tank nodes are
 excluded from these metrics
 so outliers from fixed heads do not skew the results. Metrics are accumulated
 using running statistics so the full prediction arrays are never stored in


### PR DESCRIPTION
## Summary
- retain raw test features and append node index, elevation, demand, and pump speeds to `pressures_*.csv`
- document extended pressure CSV contents in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c057a217948324b6f05cec76960ebd