### PR TITLE
Validate node ordering when loading datasets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,13 +14,13 @@ for EPANET water distribution models. The main example network is `CTown.inp`.
   - `losses.py` – weighted multi-task loss utilities.
   - `gnn_surrogate.pth` – trained weights saved here after running the training script.
 - `scripts/`
-  - `data_generation.py` – create randomized simulation scenarios and produce training datasets.
+  - `data_generation.py` – create randomized simulation scenarios and produce training datasets. It also stores the node order in `node_names.npy`.
   - `experiments_validation.py` – validate the surrogate, compare baselines and aggregate results.
   - `metrics.py` – report surrogate accuracy, MPC control and runtime metrics.
   - `mpc_control.py` – run gradient-based MPC using the trained surrogate.
   - `feature_utils.py` – shared feature construction and normalization helpers.
   - `ablation_study.py` – run a small grid of model variants and report validation pressure MAE.
-  - `train_gnn.py` – train a graph neural network surrogate on generated data. Pass `--checkpoint` to enable gradient checkpointing when GPU memory is limited. The script also writes predicted vs. actual pressures to `data/pressures_<run>.csv` (override with `--pred-csv`).
+  - `train_gnn.py` – train a graph neural network surrogate on generated data. Pass `--checkpoint` to enable gradient checkpointing when GPU memory is limited. The script also writes predicted vs. actual pressures to `data/pressures_<run>.csv` (override with `--pred-csv`). The loader verifies that feature matrices follow the node order saved as `node_names.npy` during data generation.
   - `sweep_training.py` – run hyperparameter sweeps over loss weights and architecture.
   - `plot_sweep.py` – visualise pressure MAE across sweep configurations.
   - `reproducibility.py` – helper utilities for seeding and config logging.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ the ``"demand"`` key.  ``train_gnn.py`` relies on this field for mass balance
 checks and will error out if it is missing.  Ensure datasets are generated with
 the current ``data_generation.py`` so demands are recorded.
 
+``scripts/data_generation.py`` also writes a ``node_names.npy`` file capturing
+the node ordering used to build the feature matrices.  ``train_gnn.py`` verifies
+that the loaded features align with this reference list and raises an error if
+any nodes are missing or out of order.
+
 All plots generated during training, validation and MPC experiments are
 saved under the top-level ``plots/`` directory.  The scripts automatically
 create this folder if it does not yet exist. After each training run

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -1228,6 +1228,10 @@ def main() -> None:
     np.save(os.path.join(out_dir, "edge_type.npy"), edge_type)
     log_array_stats("pump_coeffs", pump_coeffs)
     np.save(os.path.join(out_dir, "pump_coeffs.npy"), pump_coeffs)
+    # Persist node ordering so training can validate feature alignment
+    node_names = np.array(wn_template.node_name_list)
+    log_array_stats("node_names", node_names)
+    np.save(os.path.join(out_dir, "node_names.npy"), node_names)
 
     manifest = {
         "num_extreme": int(extreme_count),

--- a/tests/test_node_order_mismatch.py
+++ b/tests/test_node_order_mismatch.py
@@ -1,0 +1,49 @@
+import numpy as np
+import wntr
+import pytest
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import load_dataset
+
+
+def test_load_dataset_detects_node_order_mismatch(tmp_path):
+    repo = Path(__file__).resolve().parents[1]
+    wn = wntr.network.WaterNetworkModel(repo / "CTown.inp")
+
+    # Build a minimal edge index
+    node_map = {n: i for i, n in enumerate(wn.node_name_list)}
+    link = wn.get_link(wn.link_name_list[0])
+    edge_index = np.array(
+        [
+            [node_map[link.start_node.name], node_map[link.end_node.name]],
+            [node_map[link.end_node.name], node_map[link.start_node.name]],
+        ],
+        dtype=np.int64,
+    )
+    np.save(tmp_path / "edge_index.npy", edge_index)
+
+    F = 4 + len(wn.pump_name_list)
+    N = len(wn.node_name_list)
+    X = np.ones((1, N, F), dtype=np.float32)
+    Y = np.zeros((1, N, 1), dtype=np.float32)
+
+    # Permute node order and save the mismatching list
+    perm = np.arange(N)
+    perm[[0, 1]] = perm[[1, 0]]
+    X = X[:, perm, :]
+    node_names = np.array(wn.node_name_list)[perm]
+
+    np.save(tmp_path / "X.npy", X)
+    np.save(tmp_path / "Y.npy", Y)
+    np.save(tmp_path / "node_names.npy", node_names)
+
+    with pytest.raises(ValueError):
+        load_dataset(
+            str(tmp_path / "X.npy"),
+            str(tmp_path / "Y.npy"),
+            str(tmp_path / "edge_index.npy"),
+            expected_node_names=wn.node_name_list,
+            node_names_path=str(tmp_path / "node_names.npy"),
+        )


### PR DESCRIPTION
## Summary
- ensure `load_dataset` checks node features against `node_names.npy` and `wn.node_name_list`
- save `node_names.npy` during data generation for downstream validation
- add unit test covering node order mismatches and document new behaviour

## Testing
- `pytest tests/test_node_order_mismatch.py -q`
- `pytest -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68c1d304c9548324996a29fd963ca23e