### PR TITLE
feat: use global pump speed stats

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2096,10 +2096,11 @@ def main(args: argparse.Namespace):
             f"Dataset provides {sample_dim} features per node but the network has {pump_count} pumps."
         )
     args.output_dim = 2 if has_chlorine else 1
+    pump_cols = list(range(base_dim, base_dim + pump_count))
 
     norm_md5 = None
     if args.normalize:
-        static_cols = [3] if args.per_node_norm else None
+        static_cols = pump_cols if args.per_node_norm else None
         if seq_mode:
             x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(
                 X_raw,
@@ -2132,7 +2133,9 @@ def main(args: argparse.Namespace):
                 )
         else:
             x_mean, x_std, y_mean, y_std = compute_norm_stats(
-                data_list, per_node=args.per_node_norm
+                data_list,
+                per_node=args.per_node_norm,
+                static_cols=static_cols,
             )
             apply_normalization(
                 data_list,

--- a/tests/test_pump_speed_norm.py
+++ b/tests/test_pump_speed_norm.py
@@ -1,0 +1,78 @@
+import numpy as np
+import torch
+from torch_geometric.data import Data
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import (
+    compute_sequence_norm_stats,
+    SequenceDataset,
+    apply_sequence_normalization,
+    compute_norm_stats,
+    apply_normalization,
+)
+
+
+def _sample_inputs():
+    X = np.array(
+        [
+            [
+                [[0, 0, 0, 1, 10], [0, 0, 0, 4, 40]],
+                [[0, 0, 0, 2, 20], [0, 0, 0, 5, 50]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+    Y = np.zeros((1, 2, 2, 1), dtype=np.float32)
+    edge_index = np.zeros((2, 0), dtype=np.int64)
+    pump_cols = [3, 4]
+    return X, Y, edge_index, pump_cols
+
+
+def test_pump_speed_global_stats_sequence():
+    X, Y, edge_index, pump_cols = _sample_inputs()
+    x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(
+        X, Y, per_node=True, static_cols=pump_cols
+    )
+    for col in pump_cols:
+        assert torch.allclose(
+            x_mean[:, col], x_mean[0, col].repeat(x_mean.size(0))
+        )
+        assert torch.allclose(
+            x_std[:, col], x_std[0, col].repeat(x_std.size(0))
+        )
+    ds = SequenceDataset(X, Y, edge_index, None)
+    apply_sequence_normalization(
+        ds, x_mean, x_std, y_mean, y_std, per_node=True, static_cols=pump_cols
+    )
+    col = ds.X[..., pump_cols]
+    assert torch.allclose(col.mean(dim=(0, 1, 2)), torch.zeros(len(pump_cols)), atol=1e-6)
+    assert torch.allclose(
+        col.std(dim=(0, 1, 2), unbiased=False), torch.ones(len(pump_cols)), atol=1e-6
+    )
+
+
+def test_pump_speed_global_stats_data_list():
+    X, Y, _, pump_cols = _sample_inputs()
+    edge = torch.empty((2, 0), dtype=torch.long)
+    data_list = [
+        Data(x=torch.tensor(X[0, 0], dtype=torch.float32), edge_index=edge, y=torch.zeros((2, 1))),
+        Data(x=torch.tensor(X[0, 1], dtype=torch.float32), edge_index=edge, y=torch.zeros((2, 1))),
+    ]
+    x_mean, x_std, y_mean, y_std = compute_norm_stats(
+        data_list, per_node=True, static_cols=pump_cols
+    )
+    for col in pump_cols:
+        assert torch.allclose(
+            x_mean[:, col], x_mean[0, col].repeat(x_mean.size(0))
+        )
+        assert torch.allclose(
+            x_std[:, col], x_std[0, col].repeat(x_std.size(0))
+        )
+    apply_normalization(data_list, x_mean, x_std, y_mean, y_std, per_node=True)
+    cols = torch.stack([d.x for d in data_list], dim=0)[..., pump_cols]
+    assert torch.allclose(cols.mean(dim=(0, 1)), torch.zeros(len(pump_cols)), atol=1e-6)
+    assert torch.allclose(
+        cols.std(dim=(0, 1), unbiased=True), torch.ones(len(pump_cols)), atol=1e-6
+    )


### PR DESCRIPTION
## Summary
- use global statistics for pump speed columns during normalization
- wire pump speed column indices through train script
- add regression tests for global pump speed normalization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1f77dc0988324bc42ae78f5235501