### PR TITLE
Mask reservoir and tank nodes during normalization

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2101,12 +2101,14 @@ def main(args: argparse.Namespace):
     norm_md5 = None
     if args.normalize:
         static_cols = pump_cols if args.per_node_norm else None
+        norm_mask = loss_mask.cpu()
         if seq_mode:
             x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(
                 X_raw,
                 Y_raw,
                 per_node=args.per_node_norm,
                 static_cols=static_cols,
+                node_mask=norm_mask,
             )
             apply_sequence_normalization(
                 data_ds,
@@ -2136,6 +2138,7 @@ def main(args: argparse.Namespace):
                 data_list,
                 per_node=args.per_node_norm,
                 static_cols=static_cols,
+                node_mask=norm_mask,
             )
             apply_normalization(
                 data_list,

--- a/tests/test_normalization_mask.py
+++ b/tests/test_normalization_mask.py
@@ -1,0 +1,35 @@
+import numpy as np
+import torch
+from torch_geometric.data import Data
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.train_gnn import compute_norm_stats, compute_sequence_norm_stats
+
+def test_node_mask_excludes_nodes():
+    edge = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    d = Data(
+        x=torch.tensor([[0.0], [10.0]], dtype=torch.float32),
+        edge_index=edge,
+        y=torch.tensor([[0.0], [10.0]], dtype=torch.float32),
+    )
+    mask = torch.tensor([True, False])
+    x_mean, x_std, y_mean, y_std = compute_norm_stats([d], node_mask=mask)
+    assert torch.allclose(x_mean, torch.tensor([0.0]))
+    assert torch.allclose(y_mean, torch.tensor([0.0]))
+    x_mean_all, _, y_mean_all, _ = compute_norm_stats([d])
+    assert torch.allclose(x_mean_all, torch.tensor([5.0]))
+    assert torch.allclose(y_mean_all, torch.tensor([5.0]))
+
+
+def test_sequence_node_mask_excludes_nodes():
+    X = np.array([[[[0.0], [10.0]]]], dtype=np.float32)
+    Y = np.array([[[[0.0], [10.0]]]], dtype=np.float32)
+    mask = [True, False]
+    x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(X, Y, node_mask=mask)
+    assert torch.allclose(x_mean, torch.tensor([0.0]))
+    assert torch.allclose(y_mean, torch.tensor([0.0]))
+    x_mean_all, _, y_mean_all, _ = compute_sequence_norm_stats(X, Y)
+    assert torch.allclose(x_mean_all, torch.tensor([5.0]))
+    assert torch.allclose(y_mean_all, torch.tensor([5.0]))


### PR DESCRIPTION
## Summary
- allow `compute_norm_stats` and `compute_sequence_norm_stats` to take a node mask and ignore excluded nodes
- omit reservoir and tank indices from normalization in `train_gnn.py`
- add tests verifying masked nodes don't affect normalization statistics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1fb9582bc8324b0adb203b6858fde