### PR TITLE
Add pump direction flag to edge attributes

### DIFF
--- a/models/gnn_surrogate.py
+++ b/models/gnn_surrogate.py
@@ -67,6 +67,7 @@ class HydroConv(MessagePassing):
         edge_attr: torch.Tensor,
         edge_type: torch.Tensor,
     ) -> torch.Tensor:
+        direction = edge_attr[:, -1:].clone()
         if self.edge_type_emb is not None:
             edge_attr = edge_attr + self.edge_type_emb(edge_type)
         weight = edge_attr.new_zeros(edge_attr.size(0), 1)
@@ -76,7 +77,8 @@ class HydroConv(MessagePassing):
                 continue
             w_t = mlp(edge_attr.index_select(0, idx)).to(weight.dtype)
             weight.index_copy_(0, idx, w_t)
-        return weight * (x_j - x_i)
+        sign = direction * 2.0 - 1.0
+        return weight * sign * (x_j - x_i)
 
 
 class EnhancedGNNEncoder(nn.Module):

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -912,8 +912,12 @@ def build_edge_index(
         length = getattr(link, "length", 0.0) or 0.0
         diam = getattr(link, "diameter", 0.0) or 0.0
         rough = getattr(link, "roughness", 0.0) or 0.0
-        attrs.append([length, diam, rough])
-        attrs.append([length, diam, rough])
+        if link_name in wn.pump_name_list:
+            attrs.append([length, diam, rough, 1.0])
+            attrs.append([length, diam, rough, 0.0])
+        else:
+            attrs.append([length, diam, rough, 1.0])
+            attrs.append([length, diam, rough, 1.0])
         if link_name in wn.pipe_name_list:
             t = 0
             a = b = c = 0.0

--- a/scripts/feature_utils.py
+++ b/scripts/feature_utils.py
@@ -269,8 +269,8 @@ def apply_sequence_normalization(
 
 def build_edge_attr(
     wn: wntr.network.WaterNetworkModel, edge_index: np.ndarray
-) -> np.ndarray:
-    """Return edge attribute matrix [E,3] for given edge index."""
+    ) -> np.ndarray:
+    """Return edge attribute matrix ``[E,4]`` for given edge index."""
     node_map = {n: i for i, n in enumerate(wn.node_name_list)}
     attr_dict: Dict[Tuple[int, int], List[float]] = {}
     for link_name in wn.link_name_list:
@@ -280,9 +280,13 @@ def build_edge_attr(
         length = getattr(link, "length", 0.0) or 0.0
         diam = getattr(link, "diameter", 0.0) or 0.0
         rough = getattr(link, "roughness", 0.0) or 0.0
-        attr = [float(length), float(diam), float(rough)]
-        attr_dict[(i, j)] = attr
-        attr_dict[(j, i)] = attr
+        attr_fwd = [float(length), float(diam), float(rough), 1.0]
+        if link_name in wn.pump_name_list:
+            attr_rev = [float(length), float(diam), float(rough), 0.0]
+        else:
+            attr_rev = attr_fwd
+        attr_dict[(i, j)] = attr_fwd
+        attr_dict[(j, i)] = attr_rev
     return np.array([
         attr_dict[(int(s), int(t))] for s, t in edge_index.T
     ], dtype=np.float32)

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -263,16 +263,19 @@ def load_network(
         length = getattr(link, "length", 0.0) or 0.0
         diam = getattr(link, "diameter", 0.0) or 0.0
         rough = getattr(link, "roughness", 0.0) or 0.0
-        attrs.append([length, diam, rough])
-        attrs.append([length, diam, rough])
-        if link_name in wn.pipe_name_list:
-            t = 0
-        elif link_name in wn.pump_name_list:
+        if link_name in wn.pump_name_list:
+            attrs.append([length, diam, rough, 1.0])
+            attrs.append([length, diam, rough, 0.0])
             t = 1
-        elif link_name in wn.valve_name_list:
-            t = 2
         else:
-            t = 0
+            attrs.append([length, diam, rough, 1.0])
+            attrs.append([length, diam, rough, 1.0])
+            if link_name in wn.pipe_name_list:
+                t = 0
+            elif link_name in wn.valve_name_list:
+                t = 2
+            else:
+                t = 0
         etypes.extend([t, t])
     edge_index = torch.tensor(edges, dtype=torch.long).t().contiguous()
     node_types = build_node_type(wn)

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -29,7 +29,7 @@ def test_amp_evaluate_sequence_runs():
         return
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_attr = torch.tensor(
-        [[1.0, 0.5, 100.0], [1.0, 0.5, 100.0]], dtype=torch.float32
+        [[1.0, 0.5, 100.0, 1.0], [1.0, 0.5, 100.0, 1.0]], dtype=torch.float32
     )
     T = 2
     N = 2
@@ -49,7 +49,7 @@ def test_amp_evaluate_sequence_runs():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=8,
-        edge_dim=3,
+        edge_dim=4,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=2,

--- a/tests/test_barrier_and_clipping.py
+++ b/tests/test_barrier_and_clipping.py
@@ -13,7 +13,7 @@ def _setup():
     wn = wntr.network.WaterNetworkModel('CTown.inp')
     speeds = torch.tensor([[2.0]], requires_grad=True)
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.zeros((1, 3))
+    edge_attr = torch.zeros((1, 4))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))

--- a/tests/test_energy_clamp.py
+++ b/tests/test_energy_clamp.py
@@ -9,7 +9,7 @@ def test_negative_flow_headloss_clamped():
     wn = wntr.network.WaterNetworkModel('CTown.inp')
     speeds = torch.zeros((1, 1))
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.zeros((1, 3))
+    edge_attr = torch.zeros((1, 4))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))

--- a/tests/test_evaluate_sequence_mask.py
+++ b/tests/test_evaluate_sequence_mask.py
@@ -36,7 +36,7 @@ def test_evaluate_sequence_applies_node_mask_to_stats():
         }
     ], dtype=object)
     edge_index = np.array([[0], [1]])
-    edge_attr = np.zeros((1, 3), dtype=np.float32)
+    edge_attr = np.zeros((1, 4), dtype=np.float32)
     dataset = SequenceDataset(X, Y, edge_index=edge_index, edge_attr=edge_attr)
     loader = DataLoader(dataset, batch_size=1)
 

--- a/tests/test_flow_denorm.py
+++ b/tests/test_flow_denorm.py
@@ -25,7 +25,7 @@ class DummyModel(torch.nn.Module):
 
 def test_mass_balance_denorm_per_edge():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 3), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 4), dtype=torch.float32)
     T = 1
     N = 2
     E = 2

--- a/tests/test_headloss_loss.py
+++ b/tests/test_headloss_loss.py
@@ -3,7 +3,7 @@ from models.loss_utils import pressure_headloss_consistency_loss
 
 def test_headloss_consistency_zero():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.tensor([[1000.0, 0.5, 100.0]], dtype=torch.float32)
+    edge_attr = torch.tensor([[1000.0, 0.5, 100.0, 1.0]], dtype=torch.float32)
     flow = torch.tensor([0.1], dtype=torch.float32)
     const = 10.67
     q_m3 = flow * 0.001

--- a/tests/test_hydroconv.py
+++ b/tests/test_hydroconv.py
@@ -3,8 +3,8 @@ from scripts.train_gnn import HydroConv
 
 def test_mass_conservation():
     edge_index = torch.tensor([[0,1],[1,0]], dtype=torch.long)
-    edge_attr = torch.ones(2,3)
-    conv = HydroConv(1,1,edge_dim=3, num_node_types=1, num_edge_types=1)
+    edge_attr = torch.ones(2,4)
+    conv = HydroConv(1,1,edge_dim=4, num_node_types=1, num_edge_types=1)
     with torch.no_grad():
         conv.lin[0].weight.fill_(1.0)
         conv.lin[0].bias.zero_()

--- a/tests/test_interrupt_dataloader.py
+++ b/tests/test_interrupt_dataloader.py
@@ -12,7 +12,7 @@ from scripts.train_gnn import SequenceDataset, MultiTaskGNNSurrogate, train_sequ
 
 def test_train_sequence_dataloader_interrupt():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.tensor([[1.0, 0.5, 100.0], [1.0, 0.5, 100.0]], dtype=torch.float32)
+    edge_attr = torch.tensor([[1.0, 0.5, 100.0, 1.0], [1.0, 0.5, 100.0, 1.0]], dtype=torch.float32)
     T, N, E = 1, 2, 2
     X = np.ones((1, T, N, 4), dtype=np.float32)
     Y = np.array([
@@ -37,7 +37,7 @@ def test_train_sequence_dataloader_interrupt():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=4,
-        edge_dim=3,
+        edge_dim=4,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_max_pump_speed.py
+++ b/tests/test_max_pump_speed.py
@@ -12,7 +12,7 @@ from scripts.mpc_control import MAX_PUMP_SPEED, run_mpc_step
 def _setup():
     wn = wntr.network.WaterNetworkModel("CTown.inp")
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.zeros((1, 3))
+    edge_attr = torch.zeros((1, 4))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))

--- a/tests/test_output_clamp.py
+++ b/tests/test_output_clamp.py
@@ -4,11 +4,11 @@ from scripts.train_gnn import RecurrentGNNSurrogate, MultiTaskGNNSurrogate
 
 def test_recurrent_output_clamp():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.ones(1, 3)
+    edge_attr = torch.ones(1, 4)
     model = RecurrentGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=3,
+        edge_dim=4,
         output_dim=2,
         num_layers=1,
         use_attention=False,
@@ -26,11 +26,11 @@ def test_recurrent_output_clamp():
 
 def test_multitask_output_clamp_and_tank_level():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.ones(1, 3)
+    edge_attr = torch.ones(1, 4)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=3,
+        edge_dim=4,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,
@@ -56,11 +56,11 @@ def test_multitask_output_clamp_and_tank_level():
 
 def test_output_clamp_with_per_node_norm():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.ones(1, 3)
+    edge_attr = torch.ones(1, 4)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=3,
+        edge_dim=4,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_per_node_pressure_denorm.py
+++ b/tests/test_per_node_pressure_denorm.py
@@ -36,7 +36,7 @@ def test_evaluate_sequence_per_node_pressure_denorm():
         }
     ], dtype=object)
     edge_index = np.array([[0, 1], [1, 0]])
-    edge_attr = np.zeros((2, 3), dtype=np.float32)
+    edge_attr = np.zeros((2, 4), dtype=np.float32)
     dataset = SequenceDataset(X, Y, edge_index=edge_index, edge_attr=edge_attr)
     loader = DataLoader(dataset, batch_size=1)
 

--- a/tests/test_physics_training.py
+++ b/tests/test_physics_training.py
@@ -15,7 +15,7 @@ from scripts.train_gnn import (
 def test_train_sequence_with_physics_losses():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_attr = torch.tensor(
-        [[1.0, 0.5, 100.0], [1.0, 0.5, 100.0]], dtype=torch.float32
+        [[1.0, 0.5, 100.0, 1.0], [1.0, 0.5, 100.0, 1.0]], dtype=torch.float32
     )
     T = 2
     N = 2
@@ -36,7 +36,7 @@ def test_train_sequence_with_physics_losses():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=8,
-        edge_dim=3,
+        edge_dim=4,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=2,

--- a/tests/test_recurrent_forward.py
+++ b/tests/test_recurrent_forward.py
@@ -3,12 +3,12 @@ from scripts.train_gnn import RecurrentGNNSurrogate, MultiTaskGNNSurrogate
 
 def test_recurrent_gnn_forward_shape_with_pump_edges():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.ones(2, 3)
+    edge_attr = torch.tensor([[1.0,1.0,1.0,1.0],[1.0,1.0,1.0,0.0]])
     edge_type = torch.tensor([1, 1], dtype=torch.long)  # pump edges
     model = RecurrentGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=3,
+        edge_dim=4,
         output_dim=1,
         num_layers=2,
         use_attention=False,
@@ -25,12 +25,12 @@ def test_recurrent_gnn_forward_shape_with_pump_edges():
 
 def test_multitask_gnn_forward_shapes_with_pump_edges():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.ones(2, 3)
+    edge_attr = torch.tensor([[1.0,1.0,1.0,1.0],[1.0,1.0,1.0,0.0]])
     edge_type = torch.tensor([1, 1], dtype=torch.long)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=3,
+        edge_dim=4,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=2,

--- a/tests/test_reservoir_mask.py
+++ b/tests/test_reservoir_mask.py
@@ -17,7 +17,7 @@ import wntr
 
 def test_reservoir_node_excluded_from_loss():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.tensor([[1.0, 0.5, 100.0], [1.0, 0.5, 100.0]], dtype=torch.float32)
+    edge_attr = torch.tensor([[1.0, 0.5, 100.0, 1.0], [1.0, 0.5, 100.0, 1.0]], dtype=torch.float32)
     T = 1
     N = 2
     X = np.ones((1, T, N, 4), dtype=np.float32)
@@ -32,7 +32,7 @@ def test_reservoir_node_excluded_from_loss():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=4,
-        edge_dim=3,
+        edge_dim=4,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_sequence_nan_check.py
+++ b/tests/test_sequence_nan_check.py
@@ -24,7 +24,7 @@ class DummyModel(torch.nn.Module):
 
 def test_train_sequence_nan_detection():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 3), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 4), dtype=torch.float32)
     T, N, E = 1, 2, 2
     X = np.ones((1, T, N, 4), dtype=np.float32)
     X[0, 0, 0, 0] = np.nan

--- a/tests/test_tank_dynamics.py
+++ b/tests/test_tank_dynamics.py
@@ -3,11 +3,11 @@ from scripts.train_gnn import MultiTaskGNNSurrogate
 
 def test_tank_pressure_update():
     edge_index = torch.tensor([[0],[1]], dtype=torch.long)
-    edge_attr = torch.ones(1,3)
+    edge_attr = torch.ones(1,4)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=3,
+        edge_dim=4,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -96,7 +96,7 @@ def test_plot_error_histograms(tmp_path: Path):
 
 def test_plot_sequence_prediction(tmp_path: Path):
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 3), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 4), dtype=torch.float32)
     X = np.zeros((1, 2, 2, 4), dtype=np.float32)
     Y = np.array(
         [
@@ -128,7 +128,7 @@ def test_plot_sequence_prediction(tmp_path: Path):
 
 def test_plot_sequence_prediction_single_step(tmp_path: Path):
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 3), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 4), dtype=torch.float32)
     X = np.zeros((1, 1, 2, 4), dtype=np.float32)
     Y = np.array(
         [


### PR DESCRIPTION
## Summary
- encode pump direction in edge attributes during dataset generation and network loading
- propagate direction through HydroConv so reverse pump edges invert message sign
- update tests for new 4D edge attributes

## Testing
- `python scripts/data_generation.py --num-scenarios 1 --output-dir data/ --seed 0`
- `pytest` *(failed: tests/test_cli_args.py::test_cli_no_pressure_loss, tests/test_cli_args.py::test_cli_loss_weights, tests/test_cli_args.py::test_cli_loss_scales, tests/test_cli_args.py::test_cli_anneal)*

------
https://chatgpt.com/codex/tasks/task_e_68c7372c79308324a4648b16c7e4562b