### PR TITLE
Use hydraulic head for pipe head-loss consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,12 @@ file by default via ``--edge-attr-path``. Pump curve coefficients are saved as
 (``--pump-loss``) with weight ``--w_pump``.
 Optional physics losses in ``models/loss_utils.py`` further regularise
 training. ``compute_mass_balance_loss`` penalises node flow imbalance,
-``pressure_headloss_consistency_loss`` enforces Hazen–Williams head losses and
-``pump_curve_loss`` discourages infeasible pump operating points. Combine these
-terms with data losses to keep predictions physically plausible.
+``pressure_headloss_consistency_loss`` enforces Hazen–Williams head losses using
+hydraulic head (pressure plus elevation) and ignores edges connected to tanks or
+reservoirs, while ``pump_curve_loss`` discourages infeasible pump operating
+points. Combine these terms with data losses to keep predictions physically
+plausible. The head-based behaviour can be disabled for ablation studies via
+``--no-physics-loss-use-head`` when running ``scripts/train_gnn.py``.
 
 Training performs node-wise regression and by default optimizes the mean
 absolute error (MAE).  Specify ``--loss-fn`` to switch between MAE (``mae``),

--- a/tests/test_headloss_loss.py
+++ b/tests/test_headloss_loss.py
@@ -1,4 +1,8 @@
 import torch
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from models.loss_utils import pressure_headloss_consistency_loss
 
 def test_headloss_consistency_zero():
@@ -11,6 +15,46 @@ def test_headloss_consistency_zero():
         edge_attr[0,2].pow(1.852) * edge_attr[0,1].pow(4.87)
     )
     pressures = torch.tensor([50.0 + hl.item(), 50.0], dtype=torch.float32)
-    loss = pressure_headloss_consistency_loss(pressures, flow, edge_index, edge_attr)
+    elevation = torch.zeros(2, dtype=torch.float32)
+    node_type = torch.zeros(2, dtype=torch.long)
+    loss = pressure_headloss_consistency_loss(
+        pressures,
+        flow,
+        edge_index,
+        edge_attr,
+        elevation=elevation,
+        node_type=node_type,
+    )
     assert torch.allclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+def test_headloss_uses_head():
+    edge_index = torch.tensor([[0], [1]], dtype=torch.long)
+    edge_attr = torch.tensor([[1000.0, 0.5, 100.0, 1.0]], dtype=torch.float32)
+    flow = torch.tensor([0.1], dtype=torch.float32)
+    pressures = torch.tensor([50.0, 49.0], dtype=torch.float32)
+    elev_equal = torch.tensor([10.0, 10.0], dtype=torch.float32)
+    elev_diff = torch.tensor([10.0, 20.0], dtype=torch.float32)
+    node_type = torch.zeros(2, dtype=torch.long)
+    loss_pressure = pressure_headloss_consistency_loss(
+        pressures, flow, edge_index, edge_attr, use_head=False
+    )
+    loss_equal = pressure_headloss_consistency_loss(
+        pressures,
+        flow,
+        edge_index,
+        edge_attr,
+        elevation=elev_equal,
+        node_type=node_type,
+    )
+    loss_diff = pressure_headloss_consistency_loss(
+        pressures,
+        flow,
+        edge_index,
+        edge_attr,
+        elevation=elev_diff,
+        node_type=node_type,
+    )
+    assert torch.allclose(loss_equal, loss_pressure, atol=1e-6)
+    assert not torch.allclose(loss_diff, loss_pressure, atol=1e-6)
 


### PR DESCRIPTION
## Summary
- compute head-loss physics on hydraulic head (pressure + elevation) and mask tank/reservoir edges
- expose `--physics-loss-use-head` flag in `train_gnn.py`
- add tests for head-based loss behaviour and update documentation

## Testing
- `pytest -q`
- `python scripts/train_gnn.py --x-path tmp_X.npy --y-path tmp_Y.npy --edge-index-path tmp_edge_index.npy --edge-attr-path tmp_edge_attr.npy --epochs 1 --batch-size 1 --run-name unit_no_cl --output tmp/tmp_model.pth --no-physics-loss --no-pump-loss --inp-path CTown.inp`


------
https://chatgpt.com/codex/tasks/task_e_68c75c4bb86c832499fc459a8600d2b0