### PR TITLE
Support pump speed edge features in sequence training

### DIFF
--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -29,7 +29,7 @@ def test_amp_evaluate_sequence_runs():
         return
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_attr = torch.tensor(
-        [[1.0, 0.5, 100.0, 1.0], [1.0, 0.5, 100.0, 1.0]], dtype=torch.float32
+        [[1.0, 0.5, 100.0, 1.0, 0.0], [1.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32
     )
     T = 2
     N = 2
@@ -49,7 +49,7 @@ def test_amp_evaluate_sequence_runs():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=8,
-        edge_dim=4,
+        edge_dim=5,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=2,

--- a/tests/test_barrier_and_clipping.py
+++ b/tests/test_barrier_and_clipping.py
@@ -1,6 +1,7 @@
 import torch
 import wntr
 import torch
+import torch
 import wntr
 import sys
 from pathlib import Path
@@ -13,7 +14,7 @@ def _setup():
     wn = wntr.network.WaterNetworkModel('CTown.inp')
     speeds = torch.tensor([[2.0]], requires_grad=True)
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.zeros((1, 4))
+    edge_attr = torch.zeros((1, 5))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))

--- a/tests/test_energy_clamp.py
+++ b/tests/test_energy_clamp.py
@@ -9,7 +9,7 @@ def test_negative_flow_headloss_clamped():
     wn = wntr.network.WaterNetworkModel('CTown.inp')
     speeds = torch.zeros((1, 1))
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.zeros((1, 4))
+    edge_attr = torch.zeros((1, 5))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))

--- a/tests/test_evaluate_sequence_mask.py
+++ b/tests/test_evaluate_sequence_mask.py
@@ -36,7 +36,7 @@ def test_evaluate_sequence_applies_node_mask_to_stats():
         }
     ], dtype=object)
     edge_index = np.array([[0], [1]])
-    edge_attr = np.zeros((1, 4), dtype=np.float32)
+    edge_attr = np.zeros((1, 5), dtype=np.float32)
     dataset = SequenceDataset(X, Y, edge_index=edge_index, edge_attr=edge_attr)
     loader = DataLoader(dataset, batch_size=1)
 

--- a/tests/test_flow_denorm.py
+++ b/tests/test_flow_denorm.py
@@ -25,7 +25,7 @@ class DummyModel(torch.nn.Module):
 
 def test_mass_balance_denorm_per_edge():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 4), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 5), dtype=torch.float32)
     T = 1
     N = 2
     E = 2

--- a/tests/test_headloss_loss.py
+++ b/tests/test_headloss_loss.py
@@ -7,7 +7,7 @@ from models.loss_utils import pressure_headloss_consistency_loss
 
 def test_headloss_consistency_zero():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.tensor([[1000.0, 0.5, 100.0, 1.0]], dtype=torch.float32)
+    edge_attr = torch.tensor([[1000.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32)
     flow = torch.tensor([0.1], dtype=torch.float32)
     const = 10.67
     q_m3 = flow * 0.001
@@ -30,7 +30,7 @@ def test_headloss_consistency_zero():
 
 def test_headloss_uses_head():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.tensor([[1000.0, 0.5, 100.0, 1.0]], dtype=torch.float32)
+    edge_attr = torch.tensor([[1000.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32)
     flow = torch.tensor([0.1], dtype=torch.float32)
     pressures = torch.tensor([50.0, 49.0], dtype=torch.float32)
     elev_equal = torch.tensor([10.0, 10.0], dtype=torch.float32)

--- a/tests/test_hydroconv.py
+++ b/tests/test_hydroconv.py
@@ -2,9 +2,9 @@ import torch
 from scripts.train_gnn import HydroConv
 
 def test_mass_conservation():
-    edge_index = torch.tensor([[0,1],[1,0]], dtype=torch.long)
-    edge_attr = torch.ones(2,4)
-    conv = HydroConv(1,1,edge_dim=4, num_node_types=1, num_edge_types=1)
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    edge_attr = torch.tensor([[1.0, 1.0, 1.0, 1.0, 0.0], [1.0, 1.0, 1.0, 1.0, 0.0]])
+    conv = HydroConv(1, 1, edge_dim=5, num_node_types=1, num_edge_types=1)
     with torch.no_grad():
         conv.lin[0].weight.fill_(1.0)
         conv.lin[0].bias.zero_()
@@ -13,3 +13,25 @@ def test_mass_conservation():
     x = torch.tensor([[1.0],[2.0]])
     out = conv(x, edge_index, edge_attr)
     assert torch.allclose(out.sum(), torch.tensor(0.0), atol=1e-6)
+
+
+def test_pump_speed_scales_messages():
+    edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    edge_type = torch.tensor([1, 1], dtype=torch.long)
+    base_attr = torch.tensor(
+        [[0.0, 0.0, 0.0, 1.0, 0.5], [0.0, 0.0, 0.0, 0.0, 0.5]], dtype=torch.float32
+    )
+    edge_attr_low = base_attr.clone()
+    edge_attr_high = base_attr.clone()
+    edge_attr_high[:, -1] = 1.5
+    conv = HydroConv(1, 1, edge_dim=5, num_node_types=1, num_edge_types=2)
+    with torch.no_grad():
+        conv.lin[0].weight.fill_(1.0)
+        conv.lin[0].bias.zero_()
+        conv.edge_mlps[1][0].weight.zero_()
+        conv.edge_mlps[1][0].bias.zero_()
+    x = torch.tensor([[1.0], [3.0]])
+    out_low = conv(x, edge_index, edge_attr_low, edge_type=edge_type)
+    out_high = conv(x, edge_index, edge_attr_high, edge_type=edge_type)
+    assert not torch.allclose(out_low, out_high)
+    assert torch.allclose(out_high.abs(), out_low.abs() * 1.5 / 0.5, atol=1e-5)

--- a/tests/test_interrupt_dataloader.py
+++ b/tests/test_interrupt_dataloader.py
@@ -12,7 +12,9 @@ from scripts.train_gnn import SequenceDataset, MultiTaskGNNSurrogate, train_sequ
 
 def test_train_sequence_dataloader_interrupt():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.tensor([[1.0, 0.5, 100.0, 1.0], [1.0, 0.5, 100.0, 1.0]], dtype=torch.float32)
+    edge_attr = torch.tensor(
+        [[1.0, 0.5, 100.0, 1.0, 0.0], [1.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32
+    )
     T, N, E = 1, 2, 2
     X = np.ones((1, T, N, 4), dtype=np.float32)
     Y = np.array([
@@ -37,7 +39,7 @@ def test_train_sequence_dataloader_interrupt():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=4,
-        edge_dim=4,
+        edge_dim=5,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_max_pump_speed.py
+++ b/tests/test_max_pump_speed.py
@@ -12,7 +12,7 @@ from scripts.mpc_control import MAX_PUMP_SPEED, run_mpc_step
 def _setup():
     wn = wntr.network.WaterNetworkModel("CTown.inp")
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.zeros((1, 4))
+    edge_attr = torch.zeros((1, 5))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))

--- a/tests/test_output_clamp.py
+++ b/tests/test_output_clamp.py
@@ -4,11 +4,11 @@ from scripts.train_gnn import RecurrentGNNSurrogate, MultiTaskGNNSurrogate
 
 def test_recurrent_output_clamp():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.ones(1, 4)
+    edge_attr = torch.ones(1, 5)
     model = RecurrentGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=4,
+        edge_dim=5,
         output_dim=2,
         num_layers=1,
         use_attention=False,
@@ -26,11 +26,11 @@ def test_recurrent_output_clamp():
 
 def test_multitask_output_clamp_and_tank_level():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.ones(1, 4)
+    edge_attr = torch.ones(1, 5)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=4,
+        edge_dim=5,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,
@@ -56,11 +56,11 @@ def test_multitask_output_clamp_and_tank_level():
 
 def test_output_clamp_with_per_node_norm():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.ones(1, 4)
+    edge_attr = torch.ones(1, 5)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=4,
+        edge_dim=5,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_per_node_demand_denorm.py
+++ b/tests/test_per_node_demand_denorm.py
@@ -33,7 +33,7 @@ def test_evaluate_sequence_per_node_denorm():
         }
     ], dtype=object)
     edge_index = np.array([[0, 1], [1, 0]])
-    edge_attr = np.zeros((2, 1), dtype=np.float32)
+    edge_attr = np.zeros((2, 5), dtype=np.float32)
     dataset = SequenceDataset(X, Y, edge_index=edge_index, edge_attr=edge_attr)
     loader = DataLoader(dataset, batch_size=1)
 

--- a/tests/test_per_node_pressure_denorm.py
+++ b/tests/test_per_node_pressure_denorm.py
@@ -36,7 +36,7 @@ def test_evaluate_sequence_per_node_pressure_denorm():
         }
     ], dtype=object)
     edge_index = np.array([[0, 1], [1, 0]])
-    edge_attr = np.zeros((2, 4), dtype=np.float32)
+    edge_attr = np.zeros((2, 5), dtype=np.float32)
     dataset = SequenceDataset(X, Y, edge_index=edge_index, edge_attr=edge_attr)
     loader = DataLoader(dataset, batch_size=1)
 

--- a/tests/test_physics_training.py
+++ b/tests/test_physics_training.py
@@ -15,7 +15,7 @@ from scripts.train_gnn import (
 def test_train_sequence_with_physics_losses():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_attr = torch.tensor(
-        [[1.0, 0.5, 100.0, 1.0], [1.0, 0.5, 100.0, 1.0]], dtype=torch.float32
+        [[1.0, 0.5, 100.0, 1.0, 0.0], [1.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32
     )
     T = 2
     N = 2
@@ -36,7 +36,7 @@ def test_train_sequence_with_physics_losses():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=8,
-        edge_dim=4,
+        edge_dim=5,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=2,

--- a/tests/test_recurrent_forward.py
+++ b/tests/test_recurrent_forward.py
@@ -3,12 +3,14 @@ from scripts.train_gnn import RecurrentGNNSurrogate, MultiTaskGNNSurrogate
 
 def test_recurrent_gnn_forward_shape_with_pump_edges():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.tensor([[1.0,1.0,1.0,1.0],[1.0,1.0,1.0,0.0]])
+    edge_attr = torch.tensor(
+        [[1.0, 1.0, 1.0, 1.0, 0.0], [1.0, 1.0, 1.0, 0.0, 0.0]], dtype=torch.float32
+    )
     edge_type = torch.tensor([1, 1], dtype=torch.long)  # pump edges
     model = RecurrentGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=4,
+        edge_dim=5,
         output_dim=1,
         num_layers=2,
         use_attention=False,
@@ -25,12 +27,14 @@ def test_recurrent_gnn_forward_shape_with_pump_edges():
 
 def test_multitask_gnn_forward_shapes_with_pump_edges():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.tensor([[1.0,1.0,1.0,1.0],[1.0,1.0,1.0,0.0]])
+    edge_attr = torch.tensor(
+        [[1.0, 1.0, 1.0, 1.0, 0.0], [1.0, 1.0, 1.0, 0.0, 0.0]], dtype=torch.float32
+    )
     edge_type = torch.tensor([1, 1], dtype=torch.long)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=4,
+        edge_dim=5,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=2,

--- a/tests/test_reservoir_mask.py
+++ b/tests/test_reservoir_mask.py
@@ -17,7 +17,9 @@ import wntr
 
 def test_reservoir_node_excluded_from_loss():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.tensor([[1.0, 0.5, 100.0, 1.0], [1.0, 0.5, 100.0, 1.0]], dtype=torch.float32)
+    edge_attr = torch.tensor(
+        [[1.0, 0.5, 100.0, 1.0, 0.0], [1.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32
+    )
     T = 1
     N = 2
     X = np.ones((1, T, N, 4), dtype=np.float32)
@@ -32,7 +34,7 @@ def test_reservoir_node_excluded_from_loss():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=4,
-        edge_dim=4,
+        edge_dim=5,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_sequence_nan_check.py
+++ b/tests/test_sequence_nan_check.py
@@ -24,7 +24,7 @@ class DummyModel(torch.nn.Module):
 
 def test_train_sequence_nan_detection():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 4), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 5), dtype=torch.float32)
     T, N, E = 1, 2, 2
     X = np.ones((1, T, N, 4), dtype=np.float32)
     X[0, 0, 0, 0] = np.nan

--- a/tests/test_tank_dynamics.py
+++ b/tests/test_tank_dynamics.py
@@ -3,11 +3,11 @@ from scripts.train_gnn import MultiTaskGNNSurrogate
 
 def test_tank_pressure_update():
     edge_index = torch.tensor([[0],[1]], dtype=torch.long)
-    edge_attr = torch.ones(1,4)
+    edge_attr = torch.ones(1,5)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=4,
+        edge_dim=5,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -96,7 +96,7 @@ def test_plot_error_histograms(tmp_path: Path):
 
 def test_plot_sequence_prediction(tmp_path: Path):
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 4), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 5), dtype=torch.float32)
     X = np.zeros((1, 2, 2, 4), dtype=np.float32)
     Y = np.array(
         [
@@ -128,7 +128,7 @@ def test_plot_sequence_prediction(tmp_path: Path):
 
 def test_plot_sequence_prediction_single_step(tmp_path: Path):
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 4), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 5), dtype=torch.float32)
     X = np.zeros((1, 1, 2, 4), dtype=np.float32)
     Y = np.array(
         [


### PR DESCRIPTION
## Summary
- include pump speed metadata when building edge attributes and emit per-timestep edge_attr_seq arrays during data generation
- extend SequenceDataset, training, and the HydroConv-based models to consume time-varying edge attributes with pump speed scaling
- refresh the unit tests to exercise the new edge feature dimension and pump speed behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c99988ea608324bd2e436dbe63cfa2