### PR TITLE
Guard symmetry loss scaling and test gradient stability

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1759,16 +1759,24 @@ def train_sequence(
                     head_loss.detach().item(),
                     pump_loss_val.detach().item(),
                 )
-                mass_loss, head_loss, pump_loss_val = scale_physics_losses(
+                (
+                    mass_loss,
+                    head_loss,
+                    pump_loss_val,
+                    mass_denom,
+                    _,
+                    _,
+                ) = scale_physics_losses(
                     mass_loss,
                     head_loss,
                     pump_loss_val,
                     mass_scale=mass_scale,
                     head_scale=head_scale,
                     pump_scale=pump_scale,
+                    return_denominators=True,
                 )
                 if mass_scale > 0:
-                    sym_loss = sym_loss / mass_scale
+                    sym_loss = sym_loss / mass_denom
                 if physics_loss:
                     loss = loss + w_mass * (mass_loss + sym_loss)
                 if pressure_loss:
@@ -2251,16 +2259,24 @@ def evaluate_sequence(
                         head_loss.detach().item(),
                         pump_loss_val.detach().item(),
                     )
-                    mass_loss, head_loss, pump_loss_val = scale_physics_losses(
+                    (
+                        mass_loss,
+                        head_loss,
+                        pump_loss_val,
+                        mass_denom,
+                        _,
+                        _,
+                    ) = scale_physics_losses(
                         mass_loss,
                         head_loss,
                         pump_loss_val,
                         mass_scale=mass_scale,
                         head_scale=head_scale,
                         pump_scale=pump_scale,
+                        return_denominators=True,
                     )
                     if mass_scale > 0:
-                        sym_loss = sym_loss / mass_scale
+                        sym_loss = sym_loss / mass_denom
                     if physics_loss:
                         loss = loss + w_mass * (mass_loss + sym_loss)
                     if pressure_loss:


### PR DESCRIPTION
## Summary
- extend `scale_physics_losses` so callers can reuse the safeguarded denominators
- apply the safeguarded mass denominator when scaling the symmetry loss in training and evaluation
- add a regression test that runs `train_sequence` with a very small `mass_scale` and checks the gradient norm stays finite

## Testing
- pytest tests/test_physics_training.py

------
https://chatgpt.com/codex/tasks/task_e_68cb4158900083248bc361357d2aa18e