### PR TITLE
Add valve metadata to edge features

### DIFF
--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -252,7 +252,6 @@ def load_network(
 
     node_to_index = {n: i for i, n in enumerate(wn.node_name_list)}
     edges = []
-    attrs = []
     etypes = []
     for link_name in wn.link_name_list:
         link = wn.get_link(link_name)
@@ -260,16 +259,9 @@ def load_network(
         j = node_to_index[link.end_node.name]
         edges.append([i, j])
         edges.append([j, i])
-        length = getattr(link, "length", 0.0) or 0.0
-        diam = getattr(link, "diameter", 0.0) or 0.0
-        rough = getattr(link, "roughness", 0.0) or 0.0
         if link_name in wn.pump_name_list:
-            attrs.append([length, diam, rough, 1.0])
-            attrs.append([length, diam, rough, 0.0])
             t = 1
         else:
-            attrs.append([length, diam, rough, 1.0])
-            attrs.append([length, diam, rough, 1.0])
             if link_name in wn.pipe_name_list:
                 t = 0
             elif link_name in wn.valve_name_list:

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -29,7 +29,11 @@ def test_amp_evaluate_sequence_runs():
         return
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_attr = torch.tensor(
-        [[1.0, 0.5, 100.0, 1.0, 0.0], [1.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32
+        [
+            [1.0, 0.5, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [1.0, 0.5, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        ],
+        dtype=torch.float32,
     )
     T = 2
     N = 2
@@ -49,7 +53,7 @@ def test_amp_evaluate_sequence_runs():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=8,
-        edge_dim=5,
+        edge_dim=10,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=2,

--- a/tests/test_barrier_and_clipping.py
+++ b/tests/test_barrier_and_clipping.py
@@ -14,7 +14,7 @@ def _setup():
     wn = wntr.network.WaterNetworkModel('CTown.inp')
     speeds = torch.tensor([[2.0]], requires_grad=True)
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.zeros((1, 5))
+    edge_attr = torch.zeros((1, 10))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))

--- a/tests/test_energy_clamp.py
+++ b/tests/test_energy_clamp.py
@@ -9,7 +9,7 @@ def test_negative_flow_headloss_clamped():
     wn = wntr.network.WaterNetworkModel('CTown.inp')
     speeds = torch.zeros((1, 1))
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.zeros((1, 5))
+    edge_attr = torch.zeros((1, 10))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))

--- a/tests/test_evaluate_sequence_mask.py
+++ b/tests/test_evaluate_sequence_mask.py
@@ -36,7 +36,7 @@ def test_evaluate_sequence_applies_node_mask_to_stats():
         }
     ], dtype=object)
     edge_index = np.array([[0], [1]])
-    edge_attr = np.zeros((1, 5), dtype=np.float32)
+    edge_attr = np.zeros((1, 10), dtype=np.float32)
     dataset = SequenceDataset(X, Y, edge_index=edge_index, edge_attr=edge_attr)
     loader = DataLoader(dataset, batch_size=1)
 

--- a/tests/test_flow_denorm.py
+++ b/tests/test_flow_denorm.py
@@ -25,7 +25,7 @@ class DummyModel(torch.nn.Module):
 
 def test_mass_balance_denorm_per_edge():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 5), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 10), dtype=torch.float32)
     T = 1
     N = 2
     E = 2

--- a/tests/test_headloss_loss.py
+++ b/tests/test_headloss_loss.py
@@ -7,7 +7,10 @@ from models.loss_utils import pressure_headloss_consistency_loss
 
 def test_headloss_consistency_zero():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.tensor([[1000.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32)
+    edge_attr = torch.tensor(
+        [[1000.0, 0.5, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]],
+        dtype=torch.float32,
+    )
     flow = torch.tensor([0.1], dtype=torch.float32)
     const = 10.67
     q_m3 = flow * 0.001
@@ -30,7 +33,10 @@ def test_headloss_consistency_zero():
 
 def test_headloss_uses_head():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.tensor([[1000.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32)
+    edge_attr = torch.tensor(
+        [[1000.0, 0.5, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]],
+        dtype=torch.float32,
+    )
     flow = torch.tensor([0.1], dtype=torch.float32)
     pressures = torch.tensor([50.0, 49.0], dtype=torch.float32)
     elev_equal = torch.tensor([10.0, 10.0], dtype=torch.float32)

--- a/tests/test_hydroconv.py
+++ b/tests/test_hydroconv.py
@@ -3,8 +3,14 @@ from scripts.train_gnn import HydroConv
 
 def test_mass_conservation():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.tensor([[1.0, 1.0, 1.0, 1.0, 0.0], [1.0, 1.0, 1.0, 1.0, 0.0]])
-    conv = HydroConv(1, 1, edge_dim=5, num_node_types=1, num_edge_types=1)
+    edge_attr = torch.tensor(
+        [
+            [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    conv = HydroConv(1, 1, edge_dim=10, num_node_types=1, num_edge_types=1)
     with torch.no_grad():
         conv.lin[0].weight.fill_(1.0)
         conv.lin[0].bias.zero_()
@@ -19,12 +25,16 @@ def test_pump_speed_scales_messages():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_type = torch.tensor([1, 1], dtype=torch.long)
     base_attr = torch.tensor(
-        [[0.0, 0.0, 0.0, 1.0, 0.5], [0.0, 0.0, 0.0, 0.0, 0.5]], dtype=torch.float32
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.5],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5],
+        ],
+        dtype=torch.float32,
     )
     edge_attr_low = base_attr.clone()
     edge_attr_high = base_attr.clone()
     edge_attr_high[:, -1] = 1.5
-    conv = HydroConv(1, 1, edge_dim=5, num_node_types=1, num_edge_types=2)
+    conv = HydroConv(1, 1, edge_dim=10, num_node_types=1, num_edge_types=2)
     with torch.no_grad():
         conv.lin[0].weight.fill_(1.0)
         conv.lin[0].bias.zero_()

--- a/tests/test_interrupt_dataloader.py
+++ b/tests/test_interrupt_dataloader.py
@@ -13,7 +13,11 @@ from scripts.train_gnn import SequenceDataset, MultiTaskGNNSurrogate, train_sequ
 def test_train_sequence_dataloader_interrupt():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_attr = torch.tensor(
-        [[1.0, 0.5, 100.0, 1.0, 0.0], [1.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32
+        [
+            [1.0, 0.5, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [1.0, 0.5, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        ],
+        dtype=torch.float32,
     )
     T, N, E = 1, 2, 2
     X = np.ones((1, T, N, 4), dtype=np.float32)
@@ -39,7 +43,7 @@ def test_train_sequence_dataloader_interrupt():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=4,
-        edge_dim=5,
+        edge_dim=10,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_max_pump_speed.py
+++ b/tests/test_max_pump_speed.py
@@ -12,7 +12,7 @@ from scripts.mpc_control import MAX_PUMP_SPEED, run_mpc_step
 def _setup():
     wn = wntr.network.WaterNetworkModel("CTown.inp")
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.zeros((1, 5))
+    edge_attr = torch.zeros((1, 10))
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))

--- a/tests/test_output_clamp.py
+++ b/tests/test_output_clamp.py
@@ -4,11 +4,11 @@ from scripts.train_gnn import RecurrentGNNSurrogate, MultiTaskGNNSurrogate
 
 def test_recurrent_output_clamp():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.ones(1, 5)
+    edge_attr = torch.ones(1, 10)
     model = RecurrentGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=5,
+        edge_dim=10,
         output_dim=2,
         num_layers=1,
         use_attention=False,
@@ -26,11 +26,11 @@ def test_recurrent_output_clamp():
 
 def test_multitask_output_clamp_and_tank_level():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.ones(1, 5)
+    edge_attr = torch.ones(1, 10)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=5,
+        edge_dim=10,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,
@@ -56,11 +56,11 @@ def test_multitask_output_clamp_and_tank_level():
 
 def test_output_clamp_with_per_node_norm():
     edge_index = torch.tensor([[0], [1]], dtype=torch.long)
-    edge_attr = torch.ones(1, 5)
+    edge_attr = torch.ones(1, 10)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=5,
+        edge_dim=10,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_per_node_demand_denorm.py
+++ b/tests/test_per_node_demand_denorm.py
@@ -33,7 +33,7 @@ def test_evaluate_sequence_per_node_denorm():
         }
     ], dtype=object)
     edge_index = np.array([[0, 1], [1, 0]])
-    edge_attr = np.zeros((2, 5), dtype=np.float32)
+    edge_attr = np.zeros((2, 10), dtype=np.float32)
     dataset = SequenceDataset(X, Y, edge_index=edge_index, edge_attr=edge_attr)
     loader = DataLoader(dataset, batch_size=1)
 

--- a/tests/test_per_node_pressure_denorm.py
+++ b/tests/test_per_node_pressure_denorm.py
@@ -36,7 +36,7 @@ def test_evaluate_sequence_per_node_pressure_denorm():
         }
     ], dtype=object)
     edge_index = np.array([[0, 1], [1, 0]])
-    edge_attr = np.zeros((2, 5), dtype=np.float32)
+    edge_attr = np.zeros((2, 10), dtype=np.float32)
     dataset = SequenceDataset(X, Y, edge_index=edge_index, edge_attr=edge_attr)
     loader = DataLoader(dataset, batch_size=1)
 

--- a/tests/test_physics_training.py
+++ b/tests/test_physics_training.py
@@ -15,7 +15,11 @@ from scripts.train_gnn import (
 def _build_sequence_training_components():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_attr = torch.tensor(
-        [[1.0, 0.5, 100.0, 1.0, 0.0], [1.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32
+        [
+            [1.0, 0.5, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [1.0, 0.5, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        ],
+        dtype=torch.float32,
     )
     T = 2
     N = 2
@@ -36,7 +40,7 @@ def _build_sequence_training_components():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=8,
-        edge_dim=5,
+        edge_dim=10,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=2,

--- a/tests/test_pump_controls.py
+++ b/tests/test_pump_controls.py
@@ -60,9 +60,13 @@ def test_closed_pumps_reflected_in_features(monkeypatch):
             self.base_head = base_head
 
     class DummyLink:
-        length = 100.0
-        diameter = 0.5
-        roughness = 100.0
+        def __init__(self):
+            self.length = 100.0
+            self.diameter = 0.5
+            self.roughness = 100.0
+            node_ref = SimpleNamespace(name="J1")
+            self.start_node = node_ref
+            self.end_node = node_ref
 
         def get_head_curve_coefficients(self):
             return (0.0, 0.0, 0.0)

--- a/tests/test_recurrent_forward.py
+++ b/tests/test_recurrent_forward.py
@@ -4,13 +4,17 @@ from scripts.train_gnn import RecurrentGNNSurrogate, MultiTaskGNNSurrogate
 def test_recurrent_gnn_forward_shape_with_pump_edges():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_attr = torch.tensor(
-        [[1.0, 1.0, 1.0, 1.0, 0.0], [1.0, 1.0, 1.0, 0.0, 0.0]], dtype=torch.float32
+        [
+            [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
     )
     edge_type = torch.tensor([1, 1], dtype=torch.long)  # pump edges
     model = RecurrentGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=5,
+        edge_dim=10,
         output_dim=1,
         num_layers=2,
         use_attention=False,
@@ -28,13 +32,17 @@ def test_recurrent_gnn_forward_shape_with_pump_edges():
 def test_multitask_gnn_forward_shapes_with_pump_edges():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_attr = torch.tensor(
-        [[1.0, 1.0, 1.0, 1.0, 0.0], [1.0, 1.0, 1.0, 0.0, 0.0]], dtype=torch.float32
+        [
+            [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
     )
     edge_type = torch.tensor([1, 1], dtype=torch.long)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=5,
+        edge_dim=10,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=2,

--- a/tests/test_reservoir_mask.py
+++ b/tests/test_reservoir_mask.py
@@ -18,7 +18,11 @@ import wntr
 def test_reservoir_node_excluded_from_loss():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
     edge_attr = torch.tensor(
-        [[1.0, 0.5, 100.0, 1.0, 0.0], [1.0, 0.5, 100.0, 1.0, 0.0]], dtype=torch.float32
+        [
+            [1.0, 0.5, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [1.0, 0.5, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        ],
+        dtype=torch.float32,
     )
     T = 1
     N = 2
@@ -34,7 +38,7 @@ def test_reservoir_node_excluded_from_loss():
     model = MultiTaskGNNSurrogate(
         in_channels=4,
         hidden_channels=4,
-        edge_dim=5,
+        edge_dim=10,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_sequence_nan_check.py
+++ b/tests/test_sequence_nan_check.py
@@ -24,7 +24,7 @@ class DummyModel(torch.nn.Module):
 
 def test_train_sequence_nan_detection():
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 5), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 10), dtype=torch.float32)
     T, N, E = 1, 2, 2
     X = np.ones((1, T, N, 4), dtype=np.float32)
     X[0, 0, 0, 0] = np.nan

--- a/tests/test_tank_dynamics.py
+++ b/tests/test_tank_dynamics.py
@@ -3,11 +3,11 @@ from scripts.train_gnn import MultiTaskGNNSurrogate
 
 def test_tank_pressure_update():
     edge_index = torch.tensor([[0],[1]], dtype=torch.long)
-    edge_attr = torch.ones(1,5)
+    edge_attr = torch.ones(1,10)
     model = MultiTaskGNNSurrogate(
         in_channels=2,
         hidden_channels=4,
-        edge_dim=5,
+        edge_dim=10,
         node_output_dim=2,
         edge_output_dim=1,
         num_layers=1,

--- a/tests/test_valve_metadata.py
+++ b/tests/test_valve_metadata.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import wntr
+from wntr.network.base import LinkStatus
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.feature_utils import build_edge_attr  # noqa: E402
+from scripts.data_generation import build_edge_index  # noqa: E402
+
+
+def test_valve_edges_expose_setpoint_and_status():
+    wn = wntr.network.WaterNetworkModel('CTown.inp')
+    edge_index, _, _, _ = build_edge_index(wn)
+    edge_attr = build_edge_attr(wn, edge_index)
+
+    node_map = {name: idx for idx, name in enumerate(wn.node_name_list)}
+    valve = wn.get_link('v1')
+    start = node_map[valve.start_node.name]
+    end = node_map[valve.end_node.name]
+
+    forward_idx = np.where((edge_index[0] == start) & (edge_index[1] == end))[0]
+    assert forward_idx.size == 1
+    forward_attr = edge_attr[forward_idx[0]]
+
+    assert forward_attr[3] == pytest.approx(float(valve.initial_setting or 0.0))
+    expected_flags = np.array([
+        1.0 if valve.status == LinkStatus.Open else 0.0,
+        1.0 if valve.status == LinkStatus.Closed else 0.0,
+        1.0 if valve.status == LinkStatus.Active else 0.0,
+    ], dtype=np.float32)
+    assert np.allclose(forward_attr[4:7], expected_flags)
+    assert forward_attr[7] == pytest.approx(float(valve.minor_loss or 0.0))
+
+    reverse_idx = np.where((edge_index[0] == end) & (edge_index[1] == start))[0]
+    assert reverse_idx.size == 1
+    reverse_attr = edge_attr[reverse_idx[0]]
+    assert np.allclose(reverse_attr[3:8], forward_attr[3:8])

--- a/tests/test_visualizations.py
+++ b/tests/test_visualizations.py
@@ -96,7 +96,7 @@ def test_plot_error_histograms(tmp_path: Path):
 
 def test_plot_sequence_prediction(tmp_path: Path):
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 5), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 10), dtype=torch.float32)
     X = np.zeros((1, 2, 2, 4), dtype=np.float32)
     Y = np.array(
         [
@@ -128,7 +128,7 @@ def test_plot_sequence_prediction(tmp_path: Path):
 
 def test_plot_sequence_prediction_single_step(tmp_path: Path):
     edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
-    edge_attr = torch.zeros((2, 5), dtype=torch.float32)
+    edge_attr = torch.zeros((2, 10), dtype=torch.float32)
     X = np.zeros((1, 1, 2, 4), dtype=np.float32)
     Y = np.array(
         [


### PR DESCRIPTION
## Summary
- extend the shared edge feature builder so valve links emit their initial setpoint, status flags, and minor loss values alongside direction/pump columns
- reuse the helper in data generation/MPC routines so edge_attr.npy and sequence datasets persist the expanded feature layout
- refresh unit tests for the 10-D edge attributes and add a valve metadata regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb85c039248324b89a4d1f6a9ef095