### PR TITLE
Remove legacy controls before random pump scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ Each node feature vector has the layout
 on/off flag. Reservoir nodes use their constant hydraulic head in the
 ``pressure`` slot so the model is given the correct supply level. The helper
 script `scripts/data_generation.py`
-generates these arrays as well as the graph ``edge_index``.  Two dataset formats
+generates these arrays as well as the graph ``edge_index``. Beginning with this
+update the generator strips all legacy controls embedded in the INP file before
+assigning random-walk pump speeds so CTown's level rules no longer override the
+sampled commands. Because the resulting pump schedules differ from previously
+generated datasets, regenerate any training data created with older versions of
+the repository to take advantage of the expanded speed range. Two dataset formats
 are
 supported:
 

--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -349,6 +349,9 @@ def _build_randomized_network(
     """
 
     wn = wntr.network.WaterNetworkModel(inp_file)
+    # Remove existing EPANET controls so random walk speeds are not overridden
+    for control_name in list(wn.control_name_list):
+        wn.remove_control(control_name)
     wn.options.time.duration = 24 * 3600
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600


### PR DESCRIPTION
## Summary
- remove all controls from the EPANET model before applying randomized pump speed patterns so CTown's level triggers no longer override them
- document in the README that data generation strips legacy controls and that datasets created previously should be regenerated

## Testing
- python scripts/data_generation.py --num-scenarios 5 --output-dir data/control_strip_test --num-workers 1 --log-level INFO
- pytest tests/test_pump_controls.py


------
https://chatgpt.com/codex/tasks/task_e_68cce0a474688324a0b7286a058bf5a1