### PR TITLE
Add double-precision EPANET reader compatibility helper

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -28,6 +28,11 @@ try:
 except ImportError:  # pragma: no cover
     from feature_utils import build_edge_attr
 
+try:
+    from .wntr_compat import make_simulator
+except ImportError:  # pragma: no cover
+    from wntr_compat import make_simulator
+
 logger = logging.getLogger(__name__)
 
 # Minimum allowed pressure [m].  Values below this threshold are clipped
@@ -566,7 +571,7 @@ def _run_single_scenario(
         prefix = TEMP_DIR / f"temp_{os.getpid()}_{idx}_{attempt}"
         try:
             with temp_simulation_files(prefix) as pf:
-                sim = wntr.sim.EpanetSimulator(wn)
+                sim = make_simulator(wn)
                 sim_results = sim.run_sim(file_prefix=str(pf))
                 sim_results.scenario_type = scenario_label
                 link_outputs = getattr(sim_results, "link", None)

--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -45,6 +45,11 @@ try:
 except ImportError:  # pragma: no cover
     from feature_utils import build_static_node_features, prepare_node_features
 
+try:
+    from .wntr_compat import make_simulator
+except ImportError:  # pragma: no cover
+    from wntr_compat import make_simulator
+
 # Compute absolute path to the repository's data directory so that results are
 # always written inside the project regardless of the current working
 # directory.
@@ -739,7 +744,7 @@ def run_all_pumps_on(
         wn.options.time.start_clocktime = hour * 3600
         wn.options.time.duration = 3600
         wn.options.time.report_timestep = 3600
-        sim = wntr.sim.EpanetSimulator(wn)
+        sim = make_simulator(wn)
         results = sim.run_sim(str(TEMP_DIR / "temp"))
         pressures = results.node["pressure"].iloc[-1].to_dict()
         chlorine = results.node["quality"].iloc[-1].to_dict()
@@ -780,7 +785,7 @@ def run_heuristic_baseline(
     wn.options.time.start_clocktime = 0
     wn.options.time.duration = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     results = sim.run_sim(str(TEMP_DIR / "temp"))
     pressures = results.node["pressure"].iloc[-1].to_dict()
     chlorine = results.node["quality"].iloc[-1].to_dict()
@@ -803,7 +808,7 @@ def run_heuristic_baseline(
         wn.options.time.start_clocktime = (hour + 1) * 3600
         wn.options.time.duration = 3600
         wn.options.time.report_timestep = 3600
-        sim = wntr.sim.EpanetSimulator(wn)
+        sim = make_simulator(wn)
         results = sim.run_sim(str(TEMP_DIR / "temp"))
         pressures = results.node["pressure"].iloc[-1].to_dict()
         chlorine = results.node["quality"].iloc[-1].to_dict()

--- a/scripts/mpc_control.py
+++ b/scripts/mpc_control.py
@@ -54,6 +54,11 @@ except ImportError:  # pragma: no cover - executed when run as a script
         build_static_node_features,
         prepare_node_features,
     )
+
+try:
+    from .wntr_compat import make_simulator
+except ImportError:  # pragma: no cover
+    from wntr_compat import make_simulator
 import wntr
 from wntr.metrics.economic import pump_energy
 
@@ -1589,7 +1594,7 @@ def simulate_closed_loop(
     # obtain hydraulic state at time zero
     wn.options.time.duration = 0
     wn.options.time.report_timestep = 0
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     results = sim.run_sim(str(TEMP_DIR / "temp"))
     p_arr = results.node["pressure"].iloc[0].to_numpy(dtype=np.float32)
     c_arr = results.node["quality"].iloc[0].to_numpy(dtype=np.float32)
@@ -1705,7 +1710,7 @@ def simulate_closed_loop(
             wn.options.time.start_clocktime = t
             wn.options.time.duration = 3600
             wn.options.time.report_timestep = 3600
-            sim = wntr.sim.EpanetSimulator(wn)
+            sim = make_simulator(wn)
             results = sim.run_sim(str(TEMP_DIR / "temp"))
             p_arr = results.node["pressure"].iloc[-1].to_numpy(dtype=np.float32)
             c_arr = results.node["quality"].iloc[-1].to_numpy(dtype=np.float32)

--- a/scripts/wntr_compat.py
+++ b/scripts/wntr_compat.py
@@ -1,0 +1,195 @@
+"""Compatibility helpers for WNTR simulators.
+
+This module wraps :class:`wntr.epanet.io.BinFile` to prefer double-precision
+hydraulics binaries when available. Some EPANET toolkits (notably the 2.2
+release distributed with WNTR) emit 64-bit floating point values in the
+``.bin`` hydraulics output. Older readers that assume 32-bit values silently
+corrupt the results. The :func:`make_simulator` helper defined here creates an
+:class:`wntr.sim.EpanetSimulator` that first attempts to parse binaries with
+64-bit floats and falls back to the legacy float32 reader when necessary.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Optional
+
+import wntr
+import numpy as np
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DoublePrecisionBinFile(wntr.epanet.io.BinFile):
+    """Binary reader that prefers double-precision hydraulics outputs."""
+
+    def __init__(
+        self,
+        result_types: Optional[Iterable[wntr.epanet.io.ResultType]] = None,
+        network: bool = False,
+        energy: bool = False,
+        statistics: bool = False,
+        convert_status: bool = True,
+    ) -> None:
+        self._result_types_arg = None if result_types is None else list(result_types)
+        super().__init__(
+            result_types=result_types,
+            network=network,
+            energy=energy,
+            statistics=statistics,
+            convert_status=convert_status,
+        )
+        self.ftype = "=f8"
+        self._last_good_read: Optional[bool] = None
+        self._fallback_reader: Optional[wntr.epanet.io.BinFile] = None
+        self._fallback_exception: Optional[BaseException] = None
+        self._fallback_used = False
+
+    def finalize_save(self, good_read, sim_warnings) -> None:  # type: ignore[override]
+        if isinstance(good_read, np.ndarray):
+            good = bool(good_read.all())
+        else:
+            good = bool(good_read)
+        self._last_good_read = good
+        super().finalize_save(good_read, sim_warnings)
+
+    def read(self, filename, convergence_error=False, darcy_weisbach=False, convert=True):  # type: ignore[override]
+        self._last_good_read = None
+        self._fallback_exception = None
+        self._fallback_used = False
+        try:
+            results = super().read(
+                filename,
+                convergence_error=convergence_error,
+                darcy_weisbach=darcy_weisbach,
+                convert=convert,
+            )
+        except Exception as exc:  # pragma: no cover - defensive guard
+            self._fallback_exception = exc
+            self._last_good_read = False
+            _LOGGER.debug("Double precision read failed with exception", exc_info=exc)
+            results = None
+        if not self._last_good_read or results is None or self._values_look_corrupt():
+            results = self._read_with_fallback(
+                filename,
+                convergence_error=convergence_error,
+                darcy_weisbach=darcy_weisbach,
+                convert=convert,
+            )
+        return results
+
+    def _read_with_fallback(self, filename, convergence_error=False, darcy_weisbach=False, convert=True):
+        if self._fallback_reader is None:
+            result_types = None if self._result_types_arg is None else list(self._result_types_arg)
+            self._fallback_reader = wntr.epanet.io.BinFile(
+                result_types=result_types,
+                network=self.create_network,
+                energy=self.keep_energy,
+                statistics=self.keep_statistics,
+                convert_status=self.convert_status,
+            )
+        if self._fallback_exception is not None or self._last_good_read is False:
+            _LOGGER.debug("Falling back to float32 EPANET binary reader")
+        results = self._fallback_reader.read(
+            filename,
+            convergence_error=convergence_error,
+            darcy_weisbach=darcy_weisbach,
+            convert=convert,
+        )
+        self._copy_state_from(self._fallback_reader)
+        self._fallback_used = True
+        self._last_good_read = True
+        return results
+
+    def _copy_state_from(self, other: wntr.epanet.io.BinFile) -> None:
+        for attr in (
+            "flow_units",
+            "pres_units",
+            "quality_type",
+            "mass_units",
+            "num_nodes",
+            "num_tanks",
+            "num_links",
+            "num_pumps",
+            "num_valves",
+            "report_start",
+            "report_step",
+            "duration",
+            "chemical",
+            "chem_units",
+            "inp_file",
+            "report_file",
+            "node_names",
+            "link_names",
+            "report_times",
+            "num_periods",
+            "averages",
+            "peak_energy",
+        ):
+            if hasattr(other, attr):
+                setattr(self, attr, getattr(other, attr))
+        self.results = other.results
+
+    @property
+    def used_fallback(self) -> bool:
+        """Return ``True`` if the float32 reader handled the most recent run."""
+
+        return self._fallback_used
+
+    def _values_look_corrupt(self) -> bool:
+        if self.results is None:
+            return False
+
+        def _max_abs(df) -> float:
+            if df is None:
+                return 0.0
+            values = getattr(df, "values", None)
+            if values is None or values.size == 0:
+                return 0.0
+            finite = np.isfinite(values)
+            if not finite.any():
+                return 0.0
+            return float(np.nanmax(np.abs(values[finite])))
+
+        limit = 1e9
+        node_frames = [
+            self.results.node.get("pressure"),
+            self.results.node.get("head"),
+        ]
+        link_frames = [
+            self.results.link.get("flowrate"),
+            self.results.link.get("velocity"),
+            self.results.link.get("headloss"),
+            self.results.link.get("setting"),
+            self.results.link.get("reaction_rate"),
+            self.results.link.get("friction_factor"),
+        ]
+        for df in node_frames + link_frames:
+            if _max_abs(df) > limit:
+                _LOGGER.debug("Detected implausible values while using double precision reader; triggering fallback")
+                return True
+        return False
+
+
+def make_simulator(
+    wn: wntr.network.WaterNetworkModel,
+    *,
+    result_types: Optional[Iterable[wntr.epanet.io.ResultType]] = None,
+    network: bool = False,
+    energy: bool = False,
+    statistics: bool = False,
+    convert_status: bool = True,
+) -> wntr.sim.EpanetSimulator:
+    """Create an :class:`~wntr.sim.EpanetSimulator` with a double-precision reader."""
+
+    reader = DoublePrecisionBinFile(
+        result_types=result_types,
+        network=network,
+        energy=energy,
+        statistics=statistics,
+        convert_status=convert_status,
+    )
+    return wntr.sim.EpanetSimulator(wn, reader=reader, result_types=result_types)
+
+
+__all__ = ["DoublePrecisionBinFile", "make_simulator"]

--- a/tests/test_dataset_distributions.py
+++ b/tests/test_dataset_distributions.py
@@ -1,9 +1,105 @@
 from pathlib import Path
+import struct
 import sys
+
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from scripts.data_generation import plot_dataset_distributions
+from scripts.wntr_compat import DoublePrecisionBinFile
+import wntr
+from wntr.epanet.util import FlowUnits, PressureUnits, QualType, StatisticsType
 
 
 def test_plot_dataset_distributions(tmp_path: Path):
     plot_dataset_distributions([0.8, 1.0, 1.2], [0.0, 0.5, 1.0], "unit", plots_dir=tmp_path)
     assert (tmp_path / "dataset_distributions_unit.png").exists()
+
+
+def _pad_bytes(text: str, length: int) -> bytes:
+    data = text.encode("ascii")
+    if len(data) > length:
+        raise ValueError("text too long")
+    return data + b"\0" * (length - len(data))
+
+
+def test_double_precision_reader_parses_fake_binary(tmp_path: Path) -> None:
+    """Ensure the compatibility reader correctly handles 64-bit hydraulics files."""
+
+    bin_path = tmp_path / "fake_double.bin"
+    magic = 516114521
+    version = 20012
+    nnodes = 1
+    ntanks = 0
+    nlinks = 1
+    npumps = 0
+    nvalve = 0
+    prolog = struct.pack(
+        "<15i",
+        magic,
+        version,
+        nnodes,
+        ntanks,
+        nlinks,
+        npumps,
+        nvalve,
+        QualType.none.value,
+        0,
+        int(FlowUnits.SI),
+        PressureUnits.Meters.value,
+        StatisticsType.none.value,
+        0,
+        3600,
+        0,
+    )
+
+    with bin_path.open("wb") as fh:
+        fh.write(prolog)
+        fh.write(b"\0" * 240)  # title records
+        fh.write(_pad_bytes("fake.inp", 260))
+        fh.write(_pad_bytes("fake.rpt", 260))
+        fh.write(_pad_bytes("", 32))  # chemical name
+        fh.write(_pad_bytes("mg/L", 32))
+        fh.write(_pad_bytes("NODE1", 32))
+        fh.write(_pad_bytes("LINK1", 32))
+        fh.write(struct.pack("<i", 1))  # link start node index
+        fh.write(struct.pack("<i", 1))  # link end node index
+        fh.write(struct.pack("<i", 0))  # link type (pipe)
+        fh.write(struct.pack("<d", 10.0))  # node elevation
+        fh.write(struct.pack("<d", 100.0))  # link length
+        fh.write(struct.pack("<d", 0.5))  # link diameter
+        fh.write(struct.pack("<d", 0.0))  # peak energy placeholder
+        # Hydraulic results for one report period (4 node + 8 link values)
+        values = (
+            1.5,
+            101.25,
+            50.125,
+            0.5,
+            2.25,
+            0.5,
+            1.75,
+            0.25,
+            1.0,
+            1.2,
+            0.05,
+            0.02,
+        )
+        fh.write(struct.pack("<12d", *values))
+        fh.write(struct.pack("<4d", 0.0, 0.0, 0.0, 0.0))
+        fh.write(struct.pack("<i", 0))  # number of periods
+        fh.write(struct.pack("<i", 0))  # warning flag
+        fh.write(struct.pack("<i", magic))
+
+    reader = DoublePrecisionBinFile()
+    results = reader.read(str(bin_path))
+    pressure_df = results.node["pressure"]
+    flow_df = results.link["flowrate"]
+    assert pressure_df.iloc[0, 0] == pytest.approx(50.125)
+    assert flow_df.iloc[0, 0] == pytest.approx(2.25)
+    assert not reader.used_fallback
+
+    legacy_reader = wntr.epanet.io.BinFile()
+    legacy_results = legacy_reader.read(str(bin_path))
+    legacy_pressure = legacy_results.node["pressure"].iloc[0, 0]
+    # Float32 interpretation truncates the pressure to zero once the file is misaligned
+    assert legacy_pressure == pytest.approx(0.0)

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,11 +1,15 @@
 import os
+import sys
 from pathlib import Path
 import wntr
 from wntr.metrics.economic import pump_energy
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(REPO_ROOT))
+sys.path.append(str(REPO_ROOT / "scripts"))
 TEMP_DIR = REPO_ROOT / "data" / "temp"
 os.makedirs(TEMP_DIR, exist_ok=True)
+from scripts.wntr_compat import make_simulator
 
 
 def test_pump_energy_not_nan():
@@ -13,7 +17,7 @@ def test_pump_energy_not_nan():
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.duration = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     results = sim.run_sim(str(TEMP_DIR / "temp"))
     energy_df = pump_energy(results.link['flowrate'][wn.pump_name_list], results.node['head'], wn)
     assert not energy_df[wn.pump_name_list].isna().any().any(), 'energy contains NaN'
@@ -28,7 +32,7 @@ def _simulate_speed(speed: float):
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.duration = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     results = sim.run_sim(str(TEMP_DIR / f"temp_{speed}"))
     flows = results.link['flowrate'][wn.pump_name_list].iloc[-1].abs().sum()
     energy_df = pump_energy(results.link['flowrate'][wn.pump_name_list], results.node['head'], wn)

--- a/tests/test_rollout_eval.py
+++ b/tests/test_rollout_eval.py
@@ -11,6 +11,7 @@ sys.path.append(str(REPO_ROOT))
 sys.path.append(str(REPO_ROOT / "scripts"))
 TEMP_DIR = REPO_ROOT / "data" / "temp"
 os.makedirs(TEMP_DIR, exist_ok=True)
+from scripts.wntr_compat import make_simulator
 from scripts.mpc_control import load_network
 from scripts.experiments_validation import rollout_surrogate
 
@@ -51,7 +52,7 @@ def test_rollout_rmse_decreases_with_perfect_model():
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     res = sim.run_sim(str(TEMP_DIR / 'rollout'))
 
     p_df = res.node['pressure'].clip(lower=5.0)

--- a/tests/test_rollout_extra_outputs.py
+++ b/tests/test_rollout_extra_outputs.py
@@ -10,6 +10,7 @@ sys.path.append(str(REPO_ROOT))
 sys.path.append(str(REPO_ROOT / "scripts"))
 TEMP_DIR = REPO_ROOT / "data" / "temp"
 os.makedirs(TEMP_DIR, exist_ok=True)
+from scripts.wntr_compat import make_simulator
 from scripts.mpc_control import load_network
 from scripts.experiments_validation import rollout_surrogate
 
@@ -37,7 +38,7 @@ def test_rollout_surrogate_ignores_excess_outputs():
     wn.options.time.duration = 3 * 3600
     wn.options.time.hydraulic_timestep = wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     res = sim.run_sim(str(TEMP_DIR / "extra_outputs"))
 
     p_df = res.node["pressure"].clip(lower=5.0)

--- a/tests/test_tempfile_cleanup.py
+++ b/tests/test_tempfile_cleanup.py
@@ -17,7 +17,10 @@ def test_temp_files_cleanup_on_failure(tmp_path, monkeypatch):
             Path(f"{file_prefix}.rpt").touch()
             raise dg.wntr.epanet.exceptions.EpanetException("fail")
 
-    monkeypatch.setattr(dg.wntr.sim, "EpanetSimulator", FailingSim)
+    def fake_make_simulator(wn, **_):
+        return FailingSim(wn)
+
+    monkeypatch.setattr(dg, "make_simulator", fake_make_simulator)
 
     res = dg._run_single_scenario((0, str(dg.REPO_ROOT / "CTown.inp"), 42))
     assert res is None

--- a/tests/test_validate_surrogate.py
+++ b/tests/test_validate_surrogate.py
@@ -11,6 +11,7 @@ sys.path.append(str(REPO_ROOT))
 sys.path.append(str(REPO_ROOT / "scripts"))
 TEMP_DIR = REPO_ROOT / "data" / "temp"
 os.makedirs(TEMP_DIR, exist_ok=True)
+from scripts.wntr_compat import make_simulator
 from scripts.mpc_control import load_network
 from scripts.experiments_validation import validate_surrogate
 
@@ -34,7 +35,7 @@ def test_validate_surrogate_accepts_tuple():
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     res = sim.run_sim(str(TEMP_DIR / "temp"))
     model = DummyModel().to(device)
     metrics, arr, times = validate_surrogate(
@@ -59,7 +60,7 @@ def test_validate_surrogate_clips_low_pressure():
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     res = sim.run_sim(str(TEMP_DIR / "temp_clip"))
     # create an unrealistic negative pressure for the next timestep
     res.node["pressure"].iloc[1] = -1.0
@@ -88,7 +89,7 @@ def test_validate_surrogate_respects_node_mask():
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     res = sim.run_sim(str(TEMP_DIR / "temp_mask"))
     model = DummyModel().to(device)
     custom_types = [0] + [1] * (len(node_types) - 1)
@@ -136,7 +137,7 @@ def test_validate_surrogate_pressure_only():
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     res = sim.run_sim(str(TEMP_DIR / "temp_pressure_only"))
     model = DummyModel(out_dim=1).to(device)
     metrics, arr, times = validate_surrogate(
@@ -161,7 +162,7 @@ def test_validate_surrogate_dict_stats():
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     res = sim.run_sim(str(TEMP_DIR / "temp_dict"))
     model = DummyModel().to(device)
     model.y_mean = {"node_outputs": torch.tensor([1.0, 0.1])}
@@ -200,7 +201,7 @@ def test_validate_surrogate_handles_extra_output_dim():
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     res = sim.run_sim(str(TEMP_DIR / "temp_extra"))
     model = DummyModel(out_dim=4).to(device)
     model.y_mean = torch.zeros(2)
@@ -235,7 +236,7 @@ def test_validate_surrogate_edge_dim_check():
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     res = sim.run_sim(str(TEMP_DIR / 'temp_edge'))
 
     class EdgeModel(DummyModel):
@@ -273,7 +274,7 @@ def test_validate_surrogate_normalizes_edge_attr():
     wn.options.time.hydraulic_timestep = 3600
     wn.options.time.quality_timestep = 3600
     wn.options.time.report_timestep = 3600
-    sim = wntr.sim.EpanetSimulator(wn)
+    sim = make_simulator(wn)
     res = sim.run_sim(str(TEMP_DIR / 'temp_edge_norm'))
 
     class EdgeNormModel(DummyModel):


### PR DESCRIPTION
## Summary
- add scripts/wntr_compat.py with a DoublePrecisionBinFile that prefers float64 output and falls back to float32 when values look corrupt
- update data generation, MPC, validation scripts and supporting tests to rely on the shared make_simulator helper
- add a regression test that fabricates a 64-bit hydraulics binary to verify the new reader and show the legacy reader fails

## Testing
- pytest tests/test_dataset_distributions.py
- pytest tests/test_extreme_events.py
- pytest tests/test_pump_controls.py

------
https://chatgpt.com/codex/tasks/task_e_68cd945bb7dc8324815f444d001ca3a3