### PR TITLE
Use stock EPANET simulator in data generation

### DIFF
--- a/tests/test_pump_controls.py
+++ b/tests/test_pump_controls.py
@@ -140,10 +140,12 @@ def test_closed_pumps_reflected_in_features(monkeypatch):
     monkeypatch.setattr(data_generation, "_build_randomized_network", fake_build)
     monkeypatch.setattr(data_generation, "pump_energy", fake_pump_energy)
 
-    def fake_make_simulator(wn, **_):
+    def fake_create_simulator(wn, **_):
         return DummySim(wn)
 
-    monkeypatch.setattr(data_generation, "make_simulator", fake_make_simulator)
+    monkeypatch.setattr(
+        data_generation, "_create_epanet_simulator", fake_create_simulator
+    )
 
     result = data_generation._run_single_scenario((0, "fake.inp", None))
     assert result is not None

--- a/tests/test_tempfile_cleanup.py
+++ b/tests/test_tempfile_cleanup.py
@@ -17,10 +17,10 @@ def test_temp_files_cleanup_on_failure(tmp_path, monkeypatch):
             Path(f"{file_prefix}.rpt").touch()
             raise dg.wntr.epanet.exceptions.EpanetException("fail")
 
-    def fake_make_simulator(wn, **_):
+    def fake_create_simulator(wn, **_):
         return FailingSim(wn)
 
-    monkeypatch.setattr(dg, "make_simulator", fake_make_simulator)
+    monkeypatch.setattr(dg, "_create_epanet_simulator", fake_create_simulator)
 
     res = dg._run_single_scenario((0, str(dg.REPO_ROOT / "CTown.inp"), 42))
     assert res is None


### PR DESCRIPTION
## Summary
- create a helper in `scripts/data_generation.py` that instantiates `wntr.sim.EpanetSimulator`
- switch `_run_single_scenario` to use the stock EPANET simulator instead of the `make_simulator` wrapper
- update tests to monkeypatch the new `_create_epanet_simulator` helper in place of `make_simulator`

## Testing
- `python scripts/data_generation.py --num-scenarios 5 --show-progress --seed 123`
- `pytest tests/test_tempfile_cleanup.py tests/test_pump_controls.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68cddf33bd6883249b9a67a1feb42e1b