### PR TITLE
Improve EPANET result truncation detection

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -28,6 +28,11 @@ try:
 except ImportError:  # pragma: no cover
     from feature_utils import build_edge_attr
 
+try:
+    from .wntr_compat import make_simulator
+except ImportError:  # pragma: no cover
+    from wntr_compat import make_simulator
+
 logger = logging.getLogger(__name__)
 
 # Minimum allowed pressure [m].  Values below this threshold are clipped
@@ -91,7 +96,7 @@ def _create_epanet_simulator(
 ) -> wntr.sim.EpanetSimulator:
     """Create the platform-appropriate EPANET simulator instance."""
 
-    return wntr.sim.EpanetSimulator(wn)
+    return make_simulator(wn)
 
 
 def log_array_stats(name: str, arr: np.ndarray) -> None:


### PR DESCRIPTION
## Summary
- detect truncated EPANET result frames and trigger the float32 fallback before returning truncated data
- restore the data generation simulator helper to use the double-precision aware reader

## Testing
- pytest tests/test_dataset_distributions.py

------
https://chatgpt.com/codex/tasks/task_e_68cdfd4205b88324a11903dc89a2dc64