### PR TITLE
Handle Windows EPANET simulator differences

### DIFF
--- a/scripts/data_generation.py
+++ b/scripts/data_generation.py
@@ -96,6 +96,12 @@ def _create_epanet_simulator(
 ) -> wntr.sim.EpanetSimulator:
     """Create the platform-appropriate EPANET simulator instance."""
 
+    # The ``make_simulator`` helper wraps :class:`~wntr.sim.EpanetSimulator`
+    # with a double-precision hydraulics binary reader.  Windows EPANET
+    # toolkits only emit single-precision binaries which causes the double
+    # reader to fail, so bypass it on ``os.name == "nt"``.
+    if os.name == "nt":
+        return wntr.sim.EpanetSimulator(wn)
     return make_simulator(wn)
 
 


### PR DESCRIPTION
## Summary
- guard the double-precision EPANET simulator wrapper so it is only used on non-Windows platforms
- instantiate wntr.sim.EpanetSimulator directly on Windows to avoid single-precision binary issues

## Testing
- python scripts/data_generation.py --num-scenarios 3 --seed 1 --output-dir data/test_run6


------
https://chatgpt.com/codex/tasks/task_e_68ce00fd9b2883249ee674ca58e3f6c7