### PR TITLE
Refine per-node pump features and update normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ The repository provides a simple training script `scripts/train_gnn.py` which
 expects feature and label data saved in the `data/` directory as NumPy arrays.
 Each node feature vector has the layout
 ``[base_demand, pressure, chlorine, elevation, pump_1, ..., pump_N]`` where each
-``pump_i`` denotes the fractional pump speed in ``[0, 1]`` rather than a binary
-on/off flag. Reservoir nodes use their constant hydraulic head in the
+``pump_i`` stores the signed contribution of pump ``i`` for that node: discharge
+nodes receive ``+speed`` and suction nodes ``-speed`` while unrelated nodes
+store ``0``. Reservoir nodes use their constant hydraulic head in the
 ``pressure`` slot so the model is given the correct supply level. The helper
 script `scripts/data_generation.py`
 generates these arrays as well as the graph ``edge_index``.  Two dataset formats
@@ -297,7 +298,8 @@ relative speeds and the maximum hourly change (defaults 0.6, 1.2 and
 0.05).
 Use ``--no-include-chlorine`` to omit chlorine concentration from the
 generated node features and targets. The resulting node features become
-``[d_t, p_t, elev, pump_speeds...]`` and the targets only contain next-step
+``[d_t, p_t, elev, pump_contribs...]`` where the pump slots retain the signed
+contribution convention described above, and the targets only contain next-step
 pressure. The training script automatically detects this layout and adjusts
 its output dimension accordingly.
 The script logs to stdout and ``logs/data_generation.log`` by default. Use

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2550,11 +2550,9 @@ def main(args: argparse.Namespace):
             f"Dataset provides {sample_dim} features per node but the network has {pump_count} pumps."
         )
     args.output_dim = 2 if has_chlorine else 1
-    pump_cols = list(range(base_dim, base_dim + pump_count))
-
     norm_md5 = None
     if args.normalize:
-        static_cols = pump_cols if args.per_node_norm else None
+        static_cols = None
         norm_mask = loss_mask.cpu()
         if seq_mode:
             x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(

--- a/tests/test_barrier_and_clipping.py
+++ b/tests/test_barrier_and_clipping.py
@@ -18,6 +18,7 @@ def _setup():
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))
+    feature_template[:, 4] = torch.tensor([-1.0, 1.0])
     pressures = torch.zeros(2)
     chlorine = torch.zeros(2)
 

--- a/tests/test_energy_clamp.py
+++ b/tests/test_energy_clamp.py
@@ -14,6 +14,7 @@ def test_negative_flow_headloss_clamped():
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))
     feature_template[:, 3] = torch.tensor([10.0, 0.0])
+    feature_template[:, 4] = torch.tensor([-1.0, 1.0])
     pressures = torch.zeros(2)
     chlorine = torch.zeros(2)
 

--- a/tests/test_max_pump_speed.py
+++ b/tests/test_max_pump_speed.py
@@ -16,6 +16,7 @@ def _setup():
     node_types = torch.zeros(2, dtype=torch.long)
     edge_types = torch.zeros(1, dtype=torch.long)
     feature_template = torch.zeros((2, 5))
+    feature_template[:, 4] = torch.tensor([-1.0, 1.0])
     pressures = torch.zeros(2)
     chlorine = torch.zeros(2)
 

--- a/tests/test_mpc_cost_extra_outputs.py
+++ b/tests/test_mpc_cost_extra_outputs.py
@@ -40,11 +40,13 @@ def test_compute_mpc_cost_handles_extra_outputs():
     pump_speeds = torch.zeros(1, 1, dtype=torch.float32)
     edge_index = torch.zeros((2, 0), dtype=torch.long)
     edge_attr = torch.zeros((0, 0))
-    node_types = torch.zeros(1, dtype=torch.long)
+    num_nodes = 2
+    node_types = torch.zeros(num_nodes, dtype=torch.long)
     edge_types = torch.zeros(0, dtype=torch.long)
-    template = torch.zeros(1, 5)
-    pressures = torch.tensor([10.0])
-    chlorine = torch.tensor([0.0])
+    template = torch.zeros(num_nodes, 5)
+    template[:, 4] = torch.tensor([-1.0, 1.0])
+    pressures = torch.tensor([10.0, 10.0])
+    chlorine = torch.tensor([0.0, 0.0])
 
     cost, _ = compute_mpc_cost(
         pump_speeds,

--- a/tests/test_mpc_cost_per_node_norm.py
+++ b/tests/test_mpc_cost_per_node_norm.py
@@ -38,6 +38,7 @@ def test_compute_mpc_cost_handles_per_node_norm():
     node_types = torch.zeros(num_nodes, dtype=torch.long)
     edge_types = torch.zeros(0, dtype=torch.long)
     template = torch.zeros(num_nodes, 4 + num_pumps)
+    template[:, 4] = torch.tensor([-1.0, 1.0, 0.0])
     pressures = torch.full((num_nodes,), 50.0)
     chlorine = torch.zeros(num_nodes)
 


### PR DESCRIPTION
## Summary
- encode pump speed inputs per node using the pump-node incidence matrix during data generation and feature assembly
- update runtime feature preparation and normalization logic to consume signed pump contributions instead of broadcasting speeds
- align tests and documentation with the new per-node pump semantics

## Testing
- pytest
- python scripts/train_gnn.py --x-path data/test_run/X_train.npy --y-path data/test_run/Y_train.npy --edge-index-path data/test_run/edge_index.npy --edge-attr-path data/test_run/edge_attr.npy --pump-coeffs-path data/test_run/pump_coeffs.npy --epochs 3 --batch-size 16 --workers 0 --run-name test_run_signed --normalize --inp-path CTown.inp --no-amp --no-progress

------
https://chatgpt.com/codex/tasks/task_e_68cf1692c2a88324a8c9e76e35ae0bfb