### PR TITLE
Fix numpy dtype annotation for Python 3.9

### DIFF
--- a/scripts/feature_utils.py
+++ b/scripts/feature_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import torch
-from typing import Dict, List, Tuple, Optional, Sequence
+from typing import Dict, List, Tuple, Optional, Sequence, Union
 import wntr
 from wntr.network.base import LinkStatus
 
@@ -488,7 +488,7 @@ def build_node_type(wn: wntr.network.WaterNetworkModel) -> np.ndarray:
 
 def build_pump_node_matrix(
     wn: wntr.network.WaterNetworkModel,
-    dtype: np.dtype | type = np.float32,
+    dtype: Union[np.dtype, type] = np.float32,
 ) -> np.ndarray:
     """Return a ``(num_nodes, num_pumps)`` matrix encoding pump incidence."""
 


### PR DESCRIPTION
## Summary
- replace the PEP 604 dtype annotation in `build_pump_node_matrix` with a `typing.Union` to ensure Python 3.9 compatibility
- import `Union` from `typing` to support the updated annotation

## Testing
- `python scripts/data_generation.py --help`
- `pytest tests/test_cli_args.py`


------
https://chatgpt.com/codex/tasks/task_e_68cf20e2e0ac8324971d1b73f08bf8fd