### PR TITLE
Incorporate pump speed scaling into pump curve loss

### DIFF
--- a/models/loss_utils.py
+++ b/models/loss_utils.py
@@ -10,6 +10,7 @@ def pump_curve_loss(
     pump_coeffs: torch.Tensor,
     edge_index: torch.Tensor,
     edge_type: Optional[torch.Tensor] = None,
+    pump_speeds: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Return penalty for flows violating pump head--flow curves."""
     if edge_type is None:
@@ -22,6 +23,24 @@ def pump_curve_loss(
 
     coeff = pump_coeffs[mask].to(pred_flows.device)
     q = flows[:, mask]
+    pump_count = int(mask.sum().item())
+
+    speeds = None
+    if pump_speeds is not None:
+        speeds = pump_speeds.to(pred_flows.device)
+        if speeds.ndim == 0:
+            speeds = speeds.view(1, 1)
+        elif speeds.ndim == 1:
+            speeds = speeds.view(1, -1)
+        else:
+            speeds = speeds.reshape(-1, speeds.shape[-1])
+        if speeds.shape[-1] == flows.shape[-1]:
+            speeds = speeds[:, mask]
+        elif speeds.shape[-1] != pump_count:
+            raise ValueError(
+                "pump_speeds must align with the pump edge mask"
+            )
+
     a = coeff[:, 0]
     b = coeff[:, 1]
     c = coeff[:, 2]
@@ -30,6 +49,12 @@ def pump_curve_loss(
     # values.
     q_max = (a / b).pow(1.0 / c) * 1.2  # 20% above zero-head flow
     q = torch.clamp(q, -q_max, q_max)
-    head = a - b * q.abs().pow(c)
+    if speeds is not None:
+        eps = torch.finfo(q.dtype).eps
+        s = speeds
+        s_safe = torch.clamp_min(s, eps)
+        head = s.pow(2) * (a - b * (q.abs() / s_safe).pow(c))
+    else:
+        head = a - b * q.abs().pow(c)
     violation = torch.clamp(-head, min=0.0)
     return F.smooth_l1_loss(violation, torch.zeros_like(violation))


### PR DESCRIPTION
## Summary
- add optional pump speed input to `pump_curve_loss` and apply EPANET speed scaling
- propagate pump speed tensors through training, evaluation, and physics scale estimation
- extend pump curve loss tests to cover the speed-aware behaviour

## Testing
- PYTHONPATH=. pytest tests/test_pump_curve_loss.py

------
https://chatgpt.com/codex/tasks/task_e_68cf408476a88324990229099758bdc7