### PR TITLE
Fix per-node normalization to retain elevation context

### DIFF
--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -2597,6 +2597,9 @@ def main(args: argparse.Namespace):
     norm_md5 = None
     if args.normalize:
         static_cols = None
+        if args.per_node_norm:
+            elev_idx = 3 if has_chlorine else 2
+            static_cols = [elev_idx]
         norm_mask = loss_mask.cpu()
         if seq_mode:
             x_mean, x_std, y_mean, y_std = compute_sequence_norm_stats(


### PR DESCRIPTION
## Summary
- treat the elevation feature as a static column when per-node normalization is enabled so tanks and pumped zones retain their height information

## Testing
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --edge-attr-path data/edge_attr.npy --pump-coeffs-path data/pump_coeffs.npy --x-val-path data/X_val.npy --y-val-path data/Y_val.npy --x-test-path data/X_test.npy --y-test-path data/Y_test.npy --edge-attr-train-seq-path data/edge_attr_train_seq.npy --edge-attr-val-seq-path data/edge_attr_val_seq.npy --edge-attr-test-seq-path data/edge_attr_test_seq.npy --epochs 5 --batch-size 8 --workers 0 --eval-sample 5000 --hidden-dim 128 --gat-heads 4 --dropout 0.1 --num-layers 6 --activation relu --residual --rnn-hidden-dim 64 --per-node-norm --output-dim 1 --lr 5e-4 --weight-decay 1e-5 --loss-fn mae --log-every 1 --early-stop-patience 10 --normalize --physics_loss --pressure_loss --w_mass 1.0 --w_head 1.0 --w-press 6.0 --w-flow 2.0 --w-cl 0.0 --seed 42 --run-name debug_fix_long --no-amp --progress`


------
https://chatgpt.com/codex/tasks/task_e_68cf96f4efa48324a07a68f0ccdbf285