### PR TITLE
Add hydraulic head feature and dataset manifest support

### DIFF
--- a/scripts/experiments_validation.py
+++ b/scripts/experiments_validation.py
@@ -41,9 +41,13 @@ if str(REPO_ROOT) not in sys.path:
 
 from models.loss_utils import compute_mass_balance_loss
 try:
-    from .feature_utils import build_static_node_features, prepare_node_features
+    from .feature_utils import (
+        build_static_node_features,
+        prepare_node_features,
+        build_node_type,
+    )
 except ImportError:  # pragma: no cover
-    from feature_utils import build_static_node_features, prepare_node_features
+    from feature_utils import build_static_node_features, prepare_node_features, build_node_type
 
 # Compute absolute path to the repository's data directory so that results are
 # always written inside the project regardless of the current working
@@ -249,6 +253,13 @@ def _prepare_features(
             wn, num_pumps, include_chlorine=include_chlorine
         )
         _prepare_features.include_chlorine = include_chlorine
+        _prepare_features.node_types = torch.tensor(
+            build_node_type(wn), dtype=torch.long
+        )
+    elif not hasattr(_prepare_features, "node_types"):
+        _prepare_features.node_types = torch.tensor(
+            build_node_type(wn), dtype=torch.long
+        )
     template = _prepare_features.template
 
     pressures_t = torch.tensor(
@@ -275,7 +286,8 @@ def _prepare_features(
         chlorine_t,
         pump_t,
         model,
-        demands_t,
+        demands=demands_t,
+        node_type=_prepare_features.node_types,
         skip_normalization=skip_normalization,
         include_chlorine=include_chlorine,
     )

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -30,7 +30,7 @@ def test_cli_no_pressure_loss(tmp_path):
     np.save(tmp_path / "edge_index.npy", edge_index)
     np.save(tmp_path / "edge_attr.npy", edge_attr)
 
-    F = 4 + len(wn.pump_name_list)
+    F = 5 + len(wn.pump_name_list)
     N = len(wn.node_name_list)
     X = np.ones((1, N, F), dtype=np.float32)
     Y = np.zeros((1, N, 2), dtype=np.float32)
@@ -89,7 +89,7 @@ def test_cli_loss_weights(tmp_path):
     np.save(tmp_path / "edge_index.npy", edge_index)
     np.save(tmp_path / "edge_attr.npy", edge_attr)
 
-    F = 4 + len(wn.pump_name_list)
+    F = 5 + len(wn.pump_name_list)
     N = len(wn.node_name_list)
     X = np.ones((1, N, F), dtype=np.float32)
     Y = np.zeros((1, N, 2), dtype=np.float32)
@@ -155,7 +155,7 @@ def test_cli_loss_scales(tmp_path):
     np.save(tmp_path / "edge_index.npy", edge_index)
     np.save(tmp_path / "edge_attr.npy", edge_attr)
 
-    F = 4 + len(wn.pump_name_list)
+    F = 5 + len(wn.pump_name_list)
     N = len(wn.node_name_list)
     X = np.ones((1, N, F), dtype=np.float32)
     Y = np.zeros((1, N, 2), dtype=np.float32)
@@ -221,7 +221,7 @@ def test_cli_anneal(tmp_path):
     np.save(tmp_path / "edge_index.npy", edge_index)
     np.save(tmp_path / "edge_attr.npy", edge_attr)
 
-    F = 4 + len(wn.pump_name_list)
+    F = 5 + len(wn.pump_name_list)
     N = len(wn.node_name_list)
     X = np.ones((1, N, F), dtype=np.float32)
     Y = np.zeros((1, N, 2), dtype=np.float32)
@@ -287,7 +287,7 @@ def test_cli_hidden_dim_num_layers(tmp_path):
     np.save(tmp_path / "edge_index.npy", edge_index)
     np.save(tmp_path / "edge_attr.npy", edge_attr)
 
-    F = 4 + len(wn.pump_name_list)
+    F = 5 + len(wn.pump_name_list)
     N = len(wn.node_name_list)
     X = np.ones((1, N, F), dtype=np.float32)
     Y = np.zeros((1, N, 2), dtype=np.float32)

--- a/tests/test_mpc_input_check.py
+++ b/tests/test_mpc_input_check.py
@@ -70,7 +70,7 @@ def test_simulate_closed_loop_checks_edge_dim():
     class EdgeModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.layers = torch.nn.ModuleList([DummyConv(4 + len(pump_names))])
+            self.layers = torch.nn.ModuleList([DummyConv(template.size(1))])
             self.edge_dim = 2  # expect fewer edge attributes than provided
 
         def forward(self, x, edge_index, edge_attr=None, node_types=None, edge_types=None):

--- a/tests/test_val_loader_no_neighbor_sampling.py
+++ b/tests/test_val_loader_no_neighbor_sampling.py
@@ -31,7 +31,7 @@ def test_train_with_val_without_neighbor_sampling(tmp_path):
     np.save(tmp_path / "edge_index.npy", edge_index)
     np.save(tmp_path / "edge_attr.npy", edge_attr)
 
-    F = 4 + len(wn.pump_name_list)
+    F = 5 + len(wn.pump_name_list)
     N = len(wn.node_name_list)
     X = np.ones((1, N, F), dtype=np.float32)
     Y = np.zeros((1, N, 2), dtype=np.float32)


### PR DESCRIPTION
## Summary
- include hydraulic head in generated node features and record the layout/head flag in `manifest.json`
- update feature assembly, normalization, and runtime callers to treat head/elevation as static columns and pass node types through MPC/validation helpers
- adjust CLI smoke tests for the new feature width and make the trainer skip incompatible default sequence splits when running with static toy data

## Testing
- `pytest tests/test_mpc_normalization.py tests/test_cli_args.py tests/test_val_loader_no_neighbor_sampling.py`
- `python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --edge-index-path data/edge_index.npy --edge-attr-path data/edge_attr.npy --pump-coeffs-path data/pump_coeffs.npy --x-val-path data/X_val.npy --y-val-path data/Y_val.npy --x-test-path data/X_test.npy --y-test-path data/Y_test.npy --edge-attr-train-seq-path data/edge_attr_train_seq.npy --edge-attr-val-seq-path data/edge_attr_val_seq.npy --edge-attr-test-seq-path data/edge_attr_test_seq.npy --epochs 2 --batch-size 8 --workers 0 --eval-sample 5000 --hidden-dim 256 --gat-heads 4 --dropout 0.1 --num-layers 6 --activation relu --residual --rnn-hidden-dim 64 --per-node-norm --output-dim 1 --lr 5e-4 --weight-decay 1e-5 --loss-fn mae --log-every 1 --early-stop-patience 80 --normalize --physics_loss --pressure_loss --w_mass 1.0 --w_head 1.0 --w-press 6.0 --w-flow 2.0 --w-cl 0.0 --seed 42 --run-name debug_head_fix --no-amp --progress`


------
https://chatgpt.com/codex/tasks/task_e_68cf96f4efa48324a07a68f0ccdbf285