### PR TITLE
Sanitize pump controls to prevent NaNs during training

### DIFF
--- a/scripts/feature_utils.py
+++ b/scripts/feature_utils.py
@@ -187,13 +187,16 @@ class SequenceDataset(torch.utils.data.Dataset):
         edge_attr_seq: Optional[np.ndarray] = None,
     ):
         self.X = torch.tensor(X, dtype=torch.float32)
+        torch.nan_to_num_(self.X, nan=0.0, posinf=0.0, neginf=0.0)
         self.edge_index = torch.tensor(edge_index, dtype=torch.long)
         self.edge_attr = None
         if edge_attr is not None:
             self.edge_attr = torch.tensor(edge_attr, dtype=torch.float32)
+            torch.nan_to_num_(self.edge_attr, nan=0.0, posinf=0.0, neginf=0.0)
         self.edge_attr_seq = None
         if edge_attr_seq is not None:
             self.edge_attr_seq = torch.tensor(edge_attr_seq, dtype=torch.float32)
+            torch.nan_to_num_(self.edge_attr_seq, nan=0.0, posinf=0.0, neginf=0.0)
         self.node_type = None
         if node_type is not None:
             self.node_type = torch.tensor(node_type, dtype=torch.long)
@@ -209,25 +212,41 @@ class SequenceDataset(torch.utils.data.Dataset):
                 self.Y["node_outputs"] = torch.stack(
                     [torch.tensor(y["node_outputs"], dtype=torch.float32) for y in Y]
                 )
+                torch.nan_to_num_(
+                    self.Y["node_outputs"], nan=0.0, posinf=0.0, neginf=0.0
+                )
             if "edge_outputs" in first:
                 self.Y["edge_outputs"] = torch.stack(
                     [torch.tensor(y["edge_outputs"], dtype=torch.float32) for y in Y]
+                )
+                torch.nan_to_num_(
+                    self.Y["edge_outputs"], nan=0.0, posinf=0.0, neginf=0.0
                 )
             if "pump_energy" in first:
                 self.Y["pump_energy"] = torch.stack(
                     [torch.tensor(y["pump_energy"], dtype=torch.float32) for y in Y]
                 )
+                torch.nan_to_num_(
+                    self.Y["pump_energy"], nan=0.0, posinf=0.0, neginf=0.0
+                )
             if "demand" in first:
                 self.Y["demand"] = torch.stack(
                     [torch.tensor(y["demand"], dtype=torch.float32) for y in Y]
+                )
+                torch.nan_to_num_(
+                    self.Y["demand"], nan=0.0, posinf=0.0, neginf=0.0
                 )
             if self.edge_attr_seq is None and isinstance(first, dict) and "edge_attr_seq" in first:
                 self.edge_attr_seq = torch.stack(
                     [torch.tensor(y["edge_attr_seq"], dtype=torch.float32) for y in Y]
                 )
+                torch.nan_to_num_(
+                    self.edge_attr_seq, nan=0.0, posinf=0.0, neginf=0.0
+                )
         else:
             self.multi = False
             self.Y = torch.tensor(Y, dtype=torch.float32)
+            torch.nan_to_num_(self.Y, nan=0.0, posinf=0.0, neginf=0.0)
 
         # Truncate to the shortest target length to avoid out-of-bounds access
         self.length = self.X.shape[0]

--- a/scripts/train_gnn.py
+++ b/scripts/train_gnn.py
@@ -1960,7 +1960,10 @@ def train_sequence(
     grad_count = 0
     edge_index = edge_index.to(device)
     edge_attr = edge_attr.to(device) if edge_attr is not None else None
+    if edge_attr is not None:
+        torch.nan_to_num_(edge_attr, nan=0.0, posinf=0.0, neginf=0.0)
     edge_attr_phys = edge_attr_phys.to(device)
+    torch.nan_to_num_(edge_attr_phys, nan=0.0, posinf=0.0, neginf=0.0)
     if node_type is not None:
         node_type = node_type.to(device)
     if edge_type is not None:
@@ -1985,6 +1988,8 @@ def train_sequence(
             edge_attr_batch = None
         X_seq = X_seq.to(device)
         attr_input = edge_attr_batch.to(device) if isinstance(edge_attr_batch, torch.Tensor) else edge_attr
+        if isinstance(attr_input, torch.Tensor):
+            attr_input = torch.nan_to_num(attr_input, nan=0.0, posinf=0.0, neginf=0.0)
         if isinstance(Y_seq, dict):
             Y_seq = {k: v.to(device) for k, v in Y_seq.items()}
         else:


### PR DESCRIPTION
## Summary
- clamp generated pump control sequences to finite values and replace any non-finite edge attributes when building sequence datasets
- zero out NaN or infinite entries when loading sequence data tensors so training inputs remain well-defined
- sanitize edge attribute tensors inside the training loop before computing losses to avoid NaN pressure loss failures

## Testing
- python scripts/train_gnn.py --x-path data/X_train.npy --y-path data/Y_train.npy --x-val-path data/X_val.npy --y-val-path data/Y_val.npy --x-test-path data/X_test.npy --y-test-path data/Y_test.npy --edge-index-path data/edge_index.npy --edge-attr-path data/edge_attr.npy --edge-attr-train-seq-path data/edge_attr_train_seq.npy --edge-attr-val-seq-path data/edge_attr_val_seq.npy --edge-attr-test-seq-path data/edge_attr_test_seq.npy --pump-coeffs-path data/pump_coeffs.npy --inp-path CTown.inp --epochs 1 --batch-size 2 --workers 0 --hidden-dim 128 --num-layers 4 --dropout 0.1 --residual --lstm-hidden 64 --weight-decay 1e-5 --w-press 5.0 --w-flow 3.0 --w-cl 0.0 --early-stop-patience 10 --progress

------
https://chatgpt.com/codex/tasks/task_e_68f98c02aee88324a809fd2811a2c517